### PR TITLE
fix: cut iCloud sync's battery cost on large graphs

### DIFF
--- a/apps/desktop/src-tauri/src/icloud/storage.rs
+++ b/apps/desktop/src-tauri/src/icloud/storage.rs
@@ -248,11 +248,12 @@ pub async fn icloud_request_downloads(
     .map_err(|err| AppError::io(err.to_string()))?
 }
 
-/// The app container's `Documents/` directory, if resolvable — shared with
-/// the watch's query-coverage check ([`super::watch`]). Can block on first
-/// use (the OS may initialize the container); call off the main thread.
-pub(crate) fn ubiquity_documents_dir() -> Option<PathBuf> {
-    platform::ubiquity_documents_dir()
+/// The app container's `Documents/` directory as a pure lookup — nothing is
+/// created — shared with the watch's query-coverage check
+/// ([`super::watch`]). Can block on first use (the OS may initialize the
+/// container); call off the main thread.
+pub(crate) fn ubiquity_documents_path() -> Option<PathBuf> {
+    platform::ubiquity_documents_path()
 }
 
 #[cfg(any(target_os = "ios", target_os = "macos"))]
@@ -264,15 +265,24 @@ mod platform {
     /// The container's `Documents/` directory, created if missing. `None`
     /// when iCloud Drive is unavailable (signed out, entitlement missing).
     pub fn ubiquity_documents_dir() -> Option<PathBuf> {
-        let manager = NSFileManager::defaultManager();
-        let container = manager.URLForUbiquityContainerIdentifier(None)?;
-        let path = container.path()?.to_string();
-        let documents = PathBuf::from(path).join("Documents");
+        let documents = ubiquity_documents_path()?;
         if let Err(err) = std::fs::create_dir_all(&documents) {
             tracing::warn!(%err, "failed to create iCloud Documents directory");
             return None;
         }
         Some(documents)
+    }
+
+    /// The same path **without creating anything** — for pure lookups like
+    /// the watch's coverage check. Creating the container's `Documents/` as
+    /// a side effect there would plant an empty, user-visible "Reflect"
+    /// folder in iCloud Drive just because the user opened a graph kept
+    /// elsewhere; only adoption and mobile storage may create it.
+    pub fn ubiquity_documents_path() -> Option<PathBuf> {
+        let manager = NSFileManager::defaultManager();
+        let container = manager.URLForUbiquityContainerIdentifier(None)?;
+        let path = container.path()?.to_string();
+        Some(PathBuf::from(path).join("Documents"))
     }
 
     /// Walk `root` counting evicted files — legacy `.icloud` stubs (spotted
@@ -366,6 +376,11 @@ mod platform {
     /// No iCloud Drive container off Apple platforms (Android, and
     /// Windows/Linux desktop builds).
     pub fn ubiquity_documents_dir() -> Option<PathBuf> {
+        None
+    }
+
+    /// See above — no container to look up either.
+    pub fn ubiquity_documents_path() -> Option<PathBuf> {
         None
     }
 

--- a/apps/desktop/src-tauri/src/icloud/storage.rs
+++ b/apps/desktop/src-tauri/src/icloud/storage.rs
@@ -274,6 +274,13 @@ mod platform {
     /// the count and the requests to markdown under the note directories
     /// ([`super::placeholder_in_note_scope`]). Individual failures are logged
     /// and skipped — one undownloadable file must not stop the rest.
+    ///
+    /// The walk runs on every foreground resume and then once per poll tick
+    /// while downloads drain, so its per-entry cost matters: the type check
+    /// rides the `readdir` record (never a second stat), and sync-excluded
+    /// directories ([`super::local_only_name`] — notably a backup repo's
+    /// `.git/`, thousands of loose objects) are never entered, since iCloud
+    /// can hold no placeholder under them.
     pub fn pending_walk(root: &Path, nudge: bool, notes_only: bool) -> u32 {
         let manager = NSFileManager::defaultManager();
         let mut pending = 0;
@@ -283,22 +290,22 @@ mod platform {
                 continue;
             };
             for entry in entries.flatten() {
-                let path = entry.path();
                 // Never follow links (they can loop, or point out of the
                 // graph) — same rule as the adopt-copy walks below.
-                if entry
-                    .file_type()
-                    .map(|kind| kind.is_symlink())
-                    .unwrap_or(true)
-                {
+                let Ok(kind) = entry.file_type() else {
                     continue;
-                }
-                if path.is_dir() {
-                    stack.push(path);
+                };
+                if kind.is_symlink() {
                     continue;
                 }
                 let name = entry.file_name();
                 let name = name.to_string_lossy();
+                if kind.is_dir() {
+                    if !super::local_only_name(&name) {
+                        stack.push(entry.path());
+                    }
+                    continue;
+                }
                 let target = match crate::fs::icloud_placeholder_target(&name) {
                     Some(target) => target.to_string(),
                     None => {
@@ -322,7 +329,7 @@ mod platform {
                     }
                 }
                 pending += 1;
-                if nudge && !start_download(&manager, &path) {
+                if nudge && !start_download(&manager, &entry.path()) {
                     // Some iOS releases want the logical URL, not the stub
                     // (a no-op retry for the dataless form, where the two
                     // paths coincide).
@@ -475,9 +482,13 @@ fn copy_and_verify(root: &Path, target: &Path) -> AppResult<()> {
     Ok(())
 }
 
-/// What stays behind on a move-in: the rebuildable local state, the backup
-/// repo, and OS litter.
-fn adopt_skips(name: &str) -> bool {
+/// Names that never ride a file-sync provider: the rebuildable local state,
+/// the backup repo, and OS litter. A move-in leaves them behind
+/// ([`copy_graph_tree`]), and the pending-download walk never descends into
+/// them — `.reflect/` and `.git/` are marked sync-excluded at bootstrap
+/// (`fs::io::mark_dir_local_only`), so iCloud can never hold a placeholder
+/// under either.
+fn local_only_name(name: &str) -> bool {
     matches!(name, ".reflect" | ".git" | ".DS_Store")
 }
 
@@ -491,7 +502,7 @@ fn copy_graph_tree(source: &Path, target: &Path) -> AppResult<(u64, u64)> {
         for entry in std::fs::read_dir(&from_dir)? {
             let entry = entry?;
             let name = entry.file_name();
-            if adopt_skips(&name.to_string_lossy()) {
+            if local_only_name(&name.to_string_lossy()) {
                 continue;
             }
             let file_type = entry.file_type()?;
@@ -520,7 +531,7 @@ fn count_graph_tree(root: &Path) -> AppResult<(u64, u64)> {
     while let Some(dir) = stack.pop() {
         for entry in std::fs::read_dir(&dir)? {
             let entry = entry?;
-            if adopt_skips(&entry.file_name().to_string_lossy()) {
+            if local_only_name(&entry.file_name().to_string_lossy()) {
                 continue;
             }
             let file_type = entry.file_type()?;
@@ -598,6 +609,27 @@ mod tests {
         assert!(!target.join(".reflect").exists());
         assert!(!target.join(".git").exists());
         assert!(!target.join(".DS_Store").exists());
+    }
+
+    /// The pending walk must count placeholders anywhere in the graph but
+    /// never descend into the sync-excluded directories: `.git/` and
+    /// `.reflect/` are marked local-only at bootstrap, so a placeholder can
+    /// never exist under them, and a backup repo's object store would
+    /// otherwise dominate the walk's stat count on every poll tick.
+    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    #[test]
+    fn pending_walk_skips_sync_excluded_directories() {
+        let root = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(root.path().join("notes")).expect("mkdir");
+        std::fs::create_dir_all(root.path().join(".git/objects")).expect("mkdir");
+        std::fs::create_dir_all(root.path().join(".reflect/tmp")).expect("mkdir");
+        std::fs::write(root.path().join("notes/.a.md.icloud"), b"stub").expect("write");
+        std::fs::write(root.path().join("notes/b.md"), b"# B").expect("write");
+        // Placeholder-shaped names under excluded dirs must not be reached.
+        std::fs::write(root.path().join(".git/objects/.x.md.icloud"), b"stub").expect("write");
+        std::fs::write(root.path().join(".reflect/tmp/.y.md.icloud"), b"stub").expect("write");
+
+        assert_eq!(platform::pending_walk(root.path(), false, false), 1);
     }
 
     #[cfg(unix)]

--- a/apps/desktop/src-tauri/src/icloud/storage.rs
+++ b/apps/desktop/src-tauri/src/icloud/storage.rs
@@ -248,6 +248,13 @@ pub async fn icloud_request_downloads(
     .map_err(|err| AppError::io(err.to_string()))?
 }
 
+/// The app container's `Documents/` directory, if resolvable — shared with
+/// the watch's query-coverage check ([`super::watch`]). Can block on first
+/// use (the OS may initialize the container); call off the main thread.
+pub(crate) fn ubiquity_documents_dir() -> Option<PathBuf> {
+    platform::ubiquity_documents_dir()
+}
+
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 mod platform {
     use std::path::{Path, PathBuf};

--- a/apps/desktop/src-tauri/src/icloud/sweep.rs
+++ b/apps/desktop/src-tauri/src/icloud/sweep.rs
@@ -16,11 +16,11 @@
 //! and `record_baseline` snapshots a graph on iCloud adoption — never on
 //! local saves (see [`crate::conflict::shadow`]).
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 use std::fs;
 use std::path::Path;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::conflict::ladder::{self, ConflictInput};
@@ -67,26 +67,55 @@ pub struct SweepOutcome {
     pub auto_resolved: u32,
 }
 
+/// How much of the graph a sweep checks for unresolved versions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SweepScope {
+    /// Check every note, and run the store-housekeeping passes. The backstop
+    /// — resume, adoption baseline, and any sweep without a live watch.
+    Full,
+    /// Restrict the per-note `NSFileVersion` checks to the paths the live
+    /// metadata query flags as conflicted
+    /// ([`crate::icloud::watch::conflicted_paths`]) — each check is a
+    /// synchronous file-coordination round-trip to `fileproviderd`, and a
+    /// bulk-sync arrival sweep over a large graph paid one per note for a
+    /// listing the query already has. Degrades to `Full` whenever the watch
+    /// cannot answer completely (not installed, or pre-gather).
+    Candidates,
+}
+
 /// Command: run a conflict sweep over the generation-pinned graph.
 ///
 /// `skip_paths` — notes with dirty open sessions (the session's own conflict
 /// parking covers them until flushed). `ingested_paths` — external changes
 /// the frontend just applied cleanly; their content becomes the new shadow
 /// base. `record_baseline` — snapshot every conflict-free note as its own
-/// base (iCloud adoption).
+/// base (iCloud adoption). `scope` — how much of the graph the version
+/// checks cover ([`SweepScope`]).
 #[tauri::command]
 pub async fn icloud_conflicts_scan(
     generation: u64,
     skip_paths: Vec<String>,
     ingested_paths: Vec<String>,
     record_baseline: bool,
+    scope: SweepScope,
     state: State<'_, GraphState>,
 ) -> AppResult<SweepOutcome> {
     let started = std::time::Instant::now();
     let root = crate::fs::root_for_generation(&state, generation)?;
     let sweep_root = root.clone();
     let outcome = crate::blocking::run_blocking(move || {
-        run_sweep(&sweep_root, &skip_paths, &ingested_paths, record_baseline)
+        let candidates = match scope {
+            SweepScope::Full => None,
+            SweepScope::Candidates => crate::icloud::watch::conflicted_paths(),
+        };
+        run_sweep(
+            &sweep_root,
+            &skip_paths,
+            &ingested_paths,
+            record_baseline,
+            candidates,
+        )
     })
     .await;
     if let Ok(outcome) = &outcome {
@@ -108,11 +137,20 @@ pub async fn icloud_conflicts_scan(
 
 /// The sweep body (blocking). Pure fs + ladder logic apart from the
 /// `NSFileVersion` calls, which no-op off Apple platforms.
+///
+/// `conflict_candidates` — when `Some`, the per-note version checks cover
+/// only these paths (the metadata query's conflicted set); `None` checks
+/// everything. **Only** the version checks scope down: ingest base advances,
+/// collision folding, and the baseline all still see the full listing — and
+/// the store-housekeeping passes (orphan pruning, archive pruning) run only
+/// on unscoped sweeps, because pruning against anything less than the full
+/// live set would drop bases for merely-unlisted notes.
 fn run_sweep(
     root: &Path,
     skip_paths: &[String],
     ingested_paths: &[String],
     record_baseline: bool,
+    conflict_candidates: Option<HashSet<String>>,
 ) -> AppResult<SweepOutcome> {
     let shadow = ShadowStore::new(root);
     let skip: BTreeSet<&str> = skip_paths.iter().map(String::as_str).collect();
@@ -152,6 +190,11 @@ fn run_sweep(
     for file in &files {
         if file.placeholder {
             continue;
+        }
+        if let Some(candidates) = &conflict_candidates {
+            if !candidates.contains(&file.path) {
+                continue; // the provider says no conflict lives here
+            }
         }
         let abs = root.join(&file.path);
         let scan = unresolved_versions(&abs);
@@ -211,9 +254,15 @@ fn run_sweep(
             live.remove(change.path.as_str());
         }
     }
-    shadow.prune_orphans(&live);
-
-    archive::prune(root);
+    // Housekeeping only on unscoped sweeps: `live` is correct either way
+    // (built from the full listing above), but pruning is pure maintenance
+    // — external deletions' orphaned bases and aged archive entries can
+    // wait for the next resume's full sweep instead of running on every
+    // 30-second arrival sweep of a bulk sync.
+    if conflict_candidates.is_none() {
+        shadow.prune_orphans(&live);
+        archive::prune(root);
+    }
     Ok(outcome)
 }
 
@@ -757,7 +806,7 @@ mod tests {
             .record("daily/2026-07-04 2.md", "# Day\n\n- from phone\n")
             .unwrap();
 
-        let outcome = run_sweep(root.path(), &[], &[], false).unwrap();
+        let outcome = run_sweep(root.path(), &[], &[], false, None).unwrap();
 
         assert_eq!(outcome.auto_resolved, 1);
         assert!(outcome.needs_review.is_empty());
@@ -803,7 +852,7 @@ mod tests {
             .record("daily/2026-07-04.md", "- old lineage\n")
             .unwrap();
 
-        let outcome = run_sweep(root.path(), &[], &[], false).unwrap();
+        let outcome = run_sweep(root.path(), &[], &[], false, None).unwrap();
 
         assert!(root.path().join("daily/2026-07-04.md").exists());
         assert!(!root.path().join("daily/2026-07-04 2.md").exists());
@@ -825,7 +874,7 @@ mod tests {
         write(root.path(), "daily/.2026-07-04.md.icloud", "stub");
         write(root.path(), "daily/2026-07-04 2.md", "- phone only\n");
 
-        let outcome = run_sweep(root.path(), &[], &[], false).unwrap();
+        let outcome = run_sweep(root.path(), &[], &[], false, None).unwrap();
 
         assert!(!root.path().join("daily/2026-07-04.md").exists());
         assert!(root.path().join("daily/2026-07-04 2.md").exists());
@@ -850,7 +899,7 @@ mod tests {
             "- shared\n- phone wording\n- common tail\n",
         );
 
-        let outcome = run_sweep(root.path(), &[], &[], false).unwrap();
+        let outcome = run_sweep(root.path(), &[], &[], false, None).unwrap();
 
         assert_eq!(
             outcome.needs_review,
@@ -869,7 +918,7 @@ mod tests {
         write(root.path(), "notes/chapter.md", "# Chapter\n");
         write(root.path(), "notes/chapter 2.md", "# Chapter 2\n");
 
-        let outcome = run_sweep(root.path(), &[], &[], false).unwrap();
+        let outcome = run_sweep(root.path(), &[], &[], false, None).unwrap();
 
         assert!(outcome.changed.is_empty());
         assert_eq!(
@@ -889,11 +938,45 @@ mod tests {
             &["daily/2026-07-04.md".to_string()],
             &[],
             false,
+            None,
         )
         .unwrap();
 
         assert_eq!(outcome.deferred, vec!["daily/2026-07-04 2.md".to_string()]);
         assert!(root.path().join("daily/2026-07-04 2.md").exists());
+    }
+
+    #[test]
+    fn scoped_sweeps_defer_housekeeping_to_the_next_full_sweep() {
+        let root = graph();
+        write(root.path(), "notes/a.md", "# a\n");
+        // Record a base, then delete the note externally — an orphaned base.
+        run_sweep(root.path(), &[], &["notes/a.md".to_string()], false, None).unwrap();
+        assert!(ShadowStore::new(root.path()).base("notes/a.md").is_some());
+        fs::remove_file(root.path().join("notes/a.md")).unwrap();
+
+        // A candidate-scoped sweep leaves the orphan alone (pruning against
+        // its narrower view would be wrong; deferring it is safe)…
+        run_sweep(root.path(), &[], &[], false, Some(HashSet::new())).unwrap();
+        assert!(ShadowStore::new(root.path()).base("notes/a.md").is_some());
+
+        // …and the next full sweep prunes it.
+        run_sweep(root.path(), &[], &[], false, None).unwrap();
+        assert!(ShadowStore::new(root.path()).base("notes/a.md").is_none());
+    }
+
+    #[test]
+    fn scoped_sweeps_still_fold_collision_duplicates() {
+        // The scope narrows only the NSFileVersion checks — collision
+        // folding works from the listing and must not be skipped, or a
+        // bulk-sync's "2026-07-04 2.md" would sit unfolded until resume.
+        let root = graph();
+        write(root.path(), "daily/2026-07-04.md", "- a\n");
+        write(root.path(), "daily/2026-07-04 2.md", "- b\n");
+
+        run_sweep(root.path(), &[], &[], false, Some(HashSet::new())).unwrap();
+
+        assert!(!root.path().join("daily/2026-07-04 2.md").exists());
     }
 
     #[test]
@@ -909,6 +992,7 @@ mod tests {
             &["notes/open.md".to_string()],
             &["notes/open.md".to_string()],
             true, // even an adoption baseline must respect the dirty skip
+            None,
         )
         .unwrap();
 
@@ -927,6 +1011,7 @@ mod tests {
             &[],
             &["../evil.md".to_string(), "/etc/hosts".to_string()],
             false,
+            None,
         )
         .unwrap();
 
@@ -946,7 +1031,7 @@ mod tests {
             "<<<<<<< Mac\nmine\n=======\ntheirs\n>>>>>>> iPhone\n",
         );
 
-        run_sweep(root.path(), &[], &["notes/a.md".to_string()], true).unwrap();
+        run_sweep(root.path(), &[], &["notes/a.md".to_string()], true, None).unwrap();
 
         assert_eq!(ShadowStore::new(root.path()).base("notes/a.md"), None);
     }
@@ -957,12 +1042,12 @@ mod tests {
         write(root.path(), "notes/a.md", "# A\n");
         write(root.path(), "notes/b.md", "# B\n");
 
-        run_sweep(root.path(), &[], &[], true).unwrap();
+        run_sweep(root.path(), &[], &[], true, None).unwrap();
         let shadow = ShadowStore::new(root.path());
         assert_eq!(shadow.base("notes/a.md"), Some("# A\n".to_string()));
 
         write(root.path(), "notes/b.md", "# B updated externally\n");
-        run_sweep(root.path(), &[], &["notes/b.md".to_string()], false).unwrap();
+        run_sweep(root.path(), &[], &["notes/b.md".to_string()], false, None).unwrap();
         assert_eq!(
             shadow.base("notes/b.md"),
             Some("# B updated externally\n".to_string())

--- a/apps/desktop/src-tauri/src/icloud/sweep.rs
+++ b/apps/desktop/src-tauri/src/icloud/sweep.rs
@@ -125,6 +125,7 @@ pub async fn icloud_conflicts_scan(
             deferred = outcome.deferred.len(),
             auto_resolved = outcome.auto_resolved,
             record_baseline,
+            scope = ?scope,
             elapsed_ms = started.elapsed().as_millis() as u64,
             "icloud_conflicts_scan"
         );

--- a/apps/desktop/src-tauri/src/icloud/watch.rs
+++ b/apps/desktop/src-tauri/src/icloud/watch.rs
@@ -51,6 +51,19 @@ pub fn icloud_watch_stop(app: tauri::AppHandle) -> AppResult<()> {
     platform::stop(app)
 }
 
+/// The paths the live metadata query currently flags as carrying unresolved
+/// conflict versions — the scoped conflict sweep's candidate set. `None`
+/// whenever the query cannot answer completely (no watch installed, or the
+/// gather round hasn't seeded the view yet); callers must treat `None` as
+/// "check everything". The set may run momentarily stale in the harmless
+/// direction only: a just-resolved path lingers until its update round lands
+/// (an extra no-op check), while a new conflict is always in the set before
+/// the `icloud:conflicts` signal that triggers a sweep, because both come
+/// from the same notification round.
+pub(crate) fn conflicted_paths() -> Option<std::collections::HashSet<String>> {
+    platform::conflicted_paths()
+}
+
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod platform {
     use std::collections::{HashMap, HashSet};
@@ -117,6 +130,20 @@ mod platform {
     static SNAPSHOT: LazyLock<Mutex<HashMap<String, TrackedState>>> =
         LazyLock::new(|| Mutex::new(HashMap::new()));
 
+    /// Paths the provider currently flags as carrying unresolved conflict
+    /// versions — maintained by the same rounds that emit `icloud:conflicts`,
+    /// and consumed by the scoped conflict sweep so it checks `NSFileVersion`
+    /// only where the provider says a conflict exists instead of once per
+    /// note. Valid only once [`GATHERED`] is set: before the gather round the
+    /// set is empty for the wrong reason.
+    static CONFLICTED: LazyLock<Mutex<HashSet<String>>> =
+        LazyLock::new(|| Mutex::new(HashSet::new()));
+
+    /// True once the current watch's gather round has seeded a complete
+    /// view. Cleared on install and teardown — a stopped or restarted watch
+    /// must answer "unknown", never "no conflicts".
+    static GATHERED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
     /// Content-change date last download-requested, per graph-relative path.
     /// The OS treats repeat requests as no-ops, but *issuing* them is not
     /// free: during an initial sync every update round used to re-request
@@ -172,6 +199,9 @@ mod platform {
     /// caller is a main-thread closure, which is what serializes teardown
     /// against installs.
     fn teardown_active(mtm: MainThreadMarker) {
+        // A stopped watch must answer "unknown", never "no conflicts".
+        GATHERED.store(false, std::sync::atomic::Ordering::SeqCst);
+        CONFLICTED.lock().expect("conflict lock").clear();
         let Some(bound) = ACTIVE.lock().expect("watch lock").take() else {
             return;
         };
@@ -217,6 +247,8 @@ mod platform {
         }
         SNAPSHOT.lock().expect("snapshot lock").clear();
         NUDGED.lock().expect("nudge lock").clear();
+        CONFLICTED.lock().expect("conflict lock").clear();
+        GATHERED.store(false, Ordering::SeqCst);
         let query = NSMetadataQuery::new();
         query.setNotificationBatchingInterval(UPDATE_BATCHING_INTERVAL_S);
 
@@ -441,6 +473,35 @@ mod platform {
             .collect()
     }
 
+    /// Fold one round's items into the conflicted-path set: a reported item
+    /// enters or leaves by its flag, a removed item leaves. Pure, so the set
+    /// semantics are unit-testable next to [`apply_update_delta`]'s.
+    fn apply_conflict_delta(
+        conflicted: &mut HashSet<String>,
+        upserted: &[ItemState],
+        removed: &[String],
+    ) {
+        for item in upserted {
+            if item.conflict {
+                conflicted.insert(item.rel.clone());
+            } else {
+                conflicted.remove(&item.rel);
+            }
+        }
+        for rel in removed {
+            conflicted.remove(rel);
+        }
+    }
+
+    /// The scoped sweep's candidate set — see the outer
+    /// [`super::conflicted_paths`] for the contract.
+    pub(crate) fn conflicted_paths() -> Option<HashSet<String>> {
+        if !GATHERED.load(std::sync::atomic::Ordering::SeqCst) {
+            return None;
+        }
+        Some(CONFLICTED.lock().expect("conflict lock").clone())
+    }
+
     /// One gathering/update round. Updates apply the notification's own
     /// added/changed/removed delta — O(changed items); a full results
     /// enumeration here would be O(all items) per round, O(n²) across an
@@ -526,6 +587,10 @@ mod platform {
                 nudged.remove(rel);
             }
         }
+        {
+            let mut conflicted = CONFLICTED.lock().expect("conflict lock");
+            apply_conflict_delta(&mut conflicted, upserted, removed);
+        }
         Round {
             changes,
             conflicts: conflicted_rels(upserted),
@@ -572,6 +637,14 @@ mod platform {
                 .collect();
             apply_update_delta(&mut snapshot, &items, &removed)
         };
+        {
+            // A full listing is authoritative — rebuild the set wholesale,
+            // and only a full listing may declare the view complete.
+            let mut conflicted = CONFLICTED.lock().expect("conflict lock");
+            conflicted.clear();
+            apply_conflict_delta(&mut conflicted, &items, &[]);
+        }
+        GATHERED.store(true, std::sync::atomic::Ordering::SeqCst);
         Round {
             changes,
             conflicts: conflicted_rels(&items),
@@ -701,10 +774,10 @@ mod platform {
     #[cfg(test)]
     mod tests {
         use super::{
-            apply_update_delta, plan_nudges, root_variants, tracked_note_relpath, ItemState,
-            TrackedState,
+            apply_conflict_delta, apply_update_delta, plan_nudges, root_variants,
+            tracked_note_relpath, ItemState, TrackedState,
         };
-        use std::collections::HashMap;
+        use std::collections::{HashMap, HashSet};
 
         fn state(entries: &[(&str, TrackedState)]) -> HashMap<String, TrackedState> {
             entries
@@ -738,6 +811,32 @@ mod platform {
                 .collect();
             shapes.sort();
             shapes
+        }
+
+        #[test]
+        fn conflict_set_tracks_flags_across_rounds() {
+            let mut conflicted: HashSet<String> = HashSet::new();
+            let mut flagged = item("notes/a.md", true, Some(1));
+            flagged.conflict = true;
+
+            // A flagged report enters the set and stays across later rounds
+            // that don't mention the path.
+            apply_conflict_delta(&mut conflicted, std::slice::from_ref(&flagged), &[]);
+            apply_conflict_delta(
+                &mut conflicted,
+                &[item("notes/other.md", true, Some(2))],
+                &[],
+            );
+            assert!(conflicted.contains("notes/a.md"));
+
+            // Resolution (the flag dropping) leaves the set…
+            apply_conflict_delta(&mut conflicted, &[item("notes/a.md", true, Some(3))], &[]);
+            assert!(!conflicted.contains("notes/a.md"));
+
+            // …and so does the file disappearing from the listing.
+            apply_conflict_delta(&mut conflicted, std::slice::from_ref(&flagged), &[]);
+            apply_conflict_delta(&mut conflicted, &[], &["notes/a.md".to_string()]);
+            assert!(conflicted.is_empty());
         }
 
         #[test]
@@ -963,5 +1062,10 @@ mod platform {
 
     pub fn stop(_app: tauri::AppHandle) -> AppResult<()> {
         Ok(())
+    }
+
+    /// No query, no view — "unknown", so scoped sweeps fall back to full.
+    pub(crate) fn conflicted_paths() -> Option<std::collections::HashSet<String>> {
+        None
     }
 }

--- a/apps/desktop/src-tauri/src/icloud/watch.rs
+++ b/apps/desktop/src-tauri/src/icloud/watch.rs
@@ -37,12 +37,34 @@ use crate::error::AppResult;
 /// reports file events; double delivery is harmless but wasteful). Conflict
 /// paths always emit as `icloud:conflicts`.
 #[tauri::command]
-pub fn icloud_watch_start(
+pub async fn icloud_watch_start(
     root: String,
     emit_file_changes: bool,
     app: tauri::AppHandle,
 ) -> AppResult<()> {
-    platform::start(app, root, emit_file_changes)
+    // Whether the query's scope actually covers this root — it lists the
+    // app's own ubiquity container only, so for any other iCloud path (a
+    // desktop graph in the user's general iCloud Drive) the gather produces
+    // an empty view that must read as "unknown", never "no conflicts".
+    // Resolved off the main thread: the container API can block on first use.
+    let authoritative = {
+        let root = root.clone();
+        crate::blocking::run_blocking(move || Ok(query_covers_root(&root))).await?
+    };
+    platform::start(app, root, emit_file_changes, authoritative)
+}
+
+/// See [`icloud_watch_start`]: `root` lives inside the app's own ubiquity
+/// container. Both sides canonicalized — iOS containers sit behind the
+/// `/var` → `/private/var` symlink, and a lexical compare would miss.
+fn query_covers_root(root: &str) -> bool {
+    let Some(documents) = super::storage::ubiquity_documents_dir() else {
+        return false;
+    };
+    fn canonical(path: &std::path::Path) -> std::path::PathBuf {
+        std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    }
+    canonical(std::path::Path::new(root)).starts_with(canonical(&documents))
 }
 
 /// Command: stop the active watch (graph switch or shutdown). Idempotent.
@@ -130,19 +152,35 @@ mod platform {
     static SNAPSHOT: LazyLock<Mutex<HashMap<String, TrackedState>>> =
         LazyLock::new(|| Mutex::new(HashMap::new()));
 
-    /// Paths the provider currently flags as carrying unresolved conflict
-    /// versions — maintained by the same rounds that emit `icloud:conflicts`,
-    /// and consumed by the scoped conflict sweep so it checks `NSFileVersion`
-    /// only where the provider says a conflict exists instead of once per
-    /// note. Valid only once [`GATHERED`] is set: before the gather round the
-    /// set is empty for the wrong reason.
-    static CONFLICTED: LazyLock<Mutex<HashSet<String>>> =
-        LazyLock::new(|| Mutex::new(HashSet::new()));
+    /// The scoped sweep's candidate view: the paths the provider currently
+    /// flags as carrying unresolved conflict versions, maintained by the
+    /// same rounds that emit `icloud:conflicts`. Everything that decides
+    /// whether the view may be *trusted* lives in the same struct, under one
+    /// lock, so a reader can never observe a torn combination (readiness
+    /// from one watch, paths from another):
+    ///
+    /// - `epoch` pins the view to one install; rounds carry the epoch their
+    ///   watch was installed with, and a stale round — an old query's
+    ///   in-flight gather completing after teardown or after a newer graph's
+    ///   install — folds into nothing.
+    /// - `authoritative` records whether the query's scope actually covers
+    ///   the watched root (the app's own ubiquity container). For any other
+    ///   iCloud path the query gathers an *empty* view that must read as
+    ///   "unknown", never "no conflicts".
+    /// - `gathered` flips only when a full listing of this epoch lands;
+    ///   before that the set is empty for the wrong reason.
+    #[derive(Default)]
+    struct ConflictView {
+        epoch: u64,
+        authoritative: bool,
+        gathered: bool,
+        paths: HashSet<String>,
+    }
 
-    /// True once the current watch's gather round has seeded a complete
-    /// view. Cleared on install and teardown — a stopped or restarted watch
-    /// must answer "unknown", never "no conflicts".
-    static GATHERED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    /// The live [`ConflictView`]. Install epochs start at 1, so the default
+    /// view (epoch 0) can never accept a round.
+    static CONFLICT_VIEW: LazyLock<Mutex<ConflictView>> =
+        LazyLock::new(|| Mutex::new(ConflictView::default()));
 
     /// Content-change date last download-requested, per graph-relative path.
     /// The OS treats repeat requests as no-ops, but *issuing* them is not
@@ -174,12 +212,19 @@ mod platform {
     /// (dropping observer tokens does not deregister them).
     static EPOCH: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-    pub fn start(app: tauri::AppHandle, root: String, emit_file_changes: bool) -> AppResult<()> {
+    pub fn start(
+        app: tauri::AppHandle,
+        root: String,
+        emit_file_changes: bool,
+        authoritative: bool,
+    ) -> AppResult<()> {
         use std::sync::atomic::Ordering;
         let epoch = EPOCH.fetch_add(1, Ordering::SeqCst) + 1;
         let handle = app.clone();
-        app.run_on_main_thread(move || install(handle, root, emit_file_changes, epoch))
-            .map_err(|err| AppError::io(format!("failed to reach the main thread: {err}")))
+        app.run_on_main_thread(move || {
+            install(handle, root, emit_file_changes, authoritative, epoch)
+        })
+        .map_err(|err| AppError::io(format!("failed to reach the main thread: {err}")))
     }
 
     pub fn stop(app: tauri::AppHandle) -> AppResult<()> {
@@ -200,8 +245,7 @@ mod platform {
     /// against installs.
     fn teardown_active(mtm: MainThreadMarker) {
         // A stopped watch must answer "unknown", never "no conflicts".
-        GATHERED.store(false, std::sync::atomic::Ordering::SeqCst);
-        CONFLICTED.lock().expect("conflict lock").clear();
+        *CONFLICT_VIEW.lock().expect("conflict view lock") = ConflictView::default();
         let Some(bound) = ACTIVE.lock().expect("watch lock").take() else {
             return;
         };
@@ -238,7 +282,13 @@ mod platform {
     /// aborts when a later `start`/`stop` has superseded this one's epoch —
     /// so rapid graph switches can never leave two queries running or
     /// install a watch after its graph closed.
-    fn install(app: tauri::AppHandle, root: String, emit_file_changes: bool, epoch: u64) {
+    fn install(
+        app: tauri::AppHandle,
+        root: String,
+        emit_file_changes: bool,
+        authoritative: bool,
+        epoch: u64,
+    ) {
         use std::sync::atomic::Ordering;
         let mtm = MainThreadMarker::new().expect("run_on_main_thread is the main thread");
         teardown_active(mtm);
@@ -247,8 +297,12 @@ mod platform {
         }
         SNAPSHOT.lock().expect("snapshot lock").clear();
         NUDGED.lock().expect("nudge lock").clear();
-        CONFLICTED.lock().expect("conflict lock").clear();
-        GATHERED.store(false, Ordering::SeqCst);
+        *CONFLICT_VIEW.lock().expect("conflict view lock") = ConflictView {
+            epoch,
+            authoritative,
+            gathered: false,
+            paths: HashSet::new(),
+        };
         let query = NSMetadataQuery::new();
         query.setNotificationBatchingInterval(UPDATE_BATCHING_INTERVAL_S);
 
@@ -297,7 +351,7 @@ mod platform {
         let handler_roots = roots.clone();
         let emit_app = app.clone();
         let block = RcBlock::new(move |notification: NonNull<NSNotification>| {
-            handle_notification(&app, &handler_roots, emit_file_changes, notification);
+            handle_notification(&app, &handler_roots, emit_file_changes, epoch, notification);
         });
         let center = NSNotificationCenter::defaultCenter();
         let query_object: &AnyObject = &query;
@@ -494,12 +548,40 @@ mod platform {
     }
 
     /// The scoped sweep's candidate set — see the outer
-    /// [`super::conflicted_paths`] for the contract.
+    /// [`super::conflicted_paths`] for the contract. One lock read: the
+    /// trust conditions and the paths come from the same view, and the
+    /// epoch check also covers "the watch was stopped but its main-thread
+    /// teardown hasn't run yet" (stop bumps [`EPOCH`] synchronously).
     pub(crate) fn conflicted_paths() -> Option<HashSet<String>> {
-        if !GATHERED.load(std::sync::atomic::Ordering::SeqCst) {
-            return None;
+        use std::sync::atomic::Ordering;
+        let view = CONFLICT_VIEW.lock().expect("conflict view lock");
+        (view.authoritative && view.gathered && view.epoch == EPOCH.load(Ordering::SeqCst))
+            .then(|| view.paths.clone())
+    }
+
+    /// Fold one round's conflict information into the live view, iff the
+    /// round belongs to the view's install epoch — a stale round from a
+    /// torn-down watch (an old query's gather completing late) must never
+    /// seed or poison a newer watch's view. A full listing (`rebuild`)
+    /// replaces the set wholesale and is the only round shape that may
+    /// declare the view gathered.
+    fn fold_conflicts_into_view(
+        view: &mut ConflictView,
+        epoch: u64,
+        upserted: &[ItemState],
+        removed: &[String],
+        rebuild: bool,
+    ) {
+        if view.epoch != epoch {
+            return;
         }
-        Some(CONFLICTED.lock().expect("conflict lock").clone())
+        if rebuild {
+            view.paths.clear();
+        }
+        apply_conflict_delta(&mut view.paths, upserted, removed);
+        if rebuild {
+            view.gathered = true;
+        }
     }
 
     /// One gathering/update round. Updates apply the notification's own
@@ -511,6 +593,7 @@ mod platform {
         app: &tauri::AppHandle,
         roots: &[String],
         emit_file_changes: bool,
+        epoch: u64,
         notification: NonNull<NSNotification>,
     ) {
         let notification = unsafe { notification.as_ref() };
@@ -524,8 +607,8 @@ mod platform {
         let is_update = &*notification.name() == unsafe { NSMetadataQueryDidUpdateNotification };
         let round = if is_update {
             match update_delta(notification, roots) {
-                Some((upserted, removed)) => update_round(&upserted, &removed),
-                None => full_round(&query, roots, true),
+                Some((upserted, removed)) => update_round(&upserted, &removed, epoch),
+                None => full_round(&query, roots, true, epoch),
             }
         } else {
             // The gather round: this watch just started, with an empty
@@ -534,7 +617,7 @@ mod platform {
             // every app open, an unpaced download storm that pinned
             // fileproviderd. The reconcile's targeted downloads own
             // open-path catch-up; this round only seeds the snapshot.
-            full_round(&query, roots, false)
+            full_round(&query, roots, false, epoch)
         };
 
         if !round.changes.is_empty() {
@@ -575,7 +658,7 @@ mod platform {
     /// Apply one update notification's delta: nudge placeholders whose
     /// content this device lacks, fold the delta into the snapshot, and drop
     /// nudge marks for removed items.
-    fn update_round(upserted: &[ItemState], removed: &[String]) -> Round {
+    fn update_round(upserted: &[ItemState], removed: &[String], epoch: u64) -> Round {
         nudge_pending(upserted);
         let changes = {
             let mut snapshot = SNAPSHOT.lock().expect("snapshot lock");
@@ -588,8 +671,8 @@ mod platform {
             }
         }
         {
-            let mut conflicted = CONFLICTED.lock().expect("conflict lock");
-            apply_conflict_delta(&mut conflicted, upserted, removed);
+            let mut view = CONFLICT_VIEW.lock().expect("conflict view lock");
+            fold_conflicts_into_view(&mut view, epoch, upserted, removed, false);
         }
         Round {
             changes,
@@ -604,7 +687,7 @@ mod platform {
     /// [`apply_update_delta`] (every listed item as an upsert, every
     /// snapshot row missing from the listing as a remove) so the full and
     /// incremental paths share one set of diff rules and can never drift.
-    fn full_round(query: &NSMetadataQuery, roots: &[String], nudge: bool) -> Round {
+    fn full_round(query: &NSMetadataQuery, roots: &[String], nudge: bool, epoch: u64) -> Round {
         query.disableUpdates();
         let results = query.results();
         let mut items: Vec<ItemState> = Vec::new();
@@ -638,13 +721,12 @@ mod platform {
             apply_update_delta(&mut snapshot, &items, &removed)
         };
         {
-            // A full listing is authoritative — rebuild the set wholesale,
-            // and only a full listing may declare the view complete.
-            let mut conflicted = CONFLICTED.lock().expect("conflict lock");
-            conflicted.clear();
-            apply_conflict_delta(&mut conflicted, &items, &[]);
+            // A full listing is authoritative — rebuild the set wholesale;
+            // only a full listing may declare the view complete, and only
+            // for the epoch it belongs to.
+            let mut view = CONFLICT_VIEW.lock().expect("conflict view lock");
+            fold_conflicts_into_view(&mut view, epoch, &items, &[], true);
         }
-        GATHERED.store(true, std::sync::atomic::Ordering::SeqCst);
         Round {
             changes,
             conflicts: conflicted_rels(&items),
@@ -774,8 +856,8 @@ mod platform {
     #[cfg(test)]
     mod tests {
         use super::{
-            apply_conflict_delta, apply_update_delta, plan_nudges, root_variants,
-            tracked_note_relpath, ItemState, TrackedState,
+            apply_conflict_delta, apply_update_delta, fold_conflicts_into_view, plan_nudges,
+            root_variants, tracked_note_relpath, ConflictView, ItemState, TrackedState,
         };
         use std::collections::{HashMap, HashSet};
 
@@ -811,6 +893,55 @@ mod platform {
                 .collect();
             shapes.sort();
             shapes
+        }
+
+        fn conflicted_item(rel: &str) -> ItemState {
+            ItemState {
+                conflict: true,
+                ..item(rel, true, Some(1))
+            }
+        }
+
+        #[test]
+        fn a_stale_rounds_conflicts_never_reach_a_newer_view() {
+            // The race: an old query's in-flight round completes after
+            // teardown (epoch 0) or after a newer install (epoch 2). Either
+            // way it must fold into nothing — a candidate sweep trusting a
+            // poisoned or resurrected view would skip real conflicts.
+            let mut view = ConflictView {
+                epoch: 2,
+                authoritative: true,
+                gathered: false,
+                paths: HashSet::new(),
+            };
+            fold_conflicts_into_view(&mut view, 1, &[conflicted_item("notes/a.md")], &[], true);
+            assert!(!view.gathered, "a stale gather must not declare readiness");
+            assert!(view.paths.is_empty());
+        }
+
+        #[test]
+        fn a_current_rounds_rebuild_replaces_and_seeds_the_view() {
+            let mut view = ConflictView {
+                epoch: 3,
+                authoritative: true,
+                gathered: false,
+                paths: HashSet::from(["notes/stale.md".to_string()]),
+            };
+            fold_conflicts_into_view(&mut view, 3, &[conflicted_item("notes/a.md")], &[], true);
+            assert!(view.gathered);
+            assert_eq!(view.paths, HashSet::from(["notes/a.md".to_string()]));
+
+            // A later delta of the same epoch edits in place without
+            // touching readiness.
+            fold_conflicts_into_view(
+                &mut view,
+                3,
+                &[item("notes/a.md", true, Some(2))],
+                &["notes/b.md".to_string()],
+                false,
+            );
+            assert!(view.gathered);
+            assert!(view.paths.is_empty());
         }
 
         #[test]
@@ -1056,7 +1187,12 @@ mod platform {
 
     /// No iCloud metadata queries off Apple platforms — honest no-ops so the
     /// command surface never branches.
-    pub fn start(_app: tauri::AppHandle, _root: String, _emit_file_changes: bool) -> AppResult<()> {
+    pub fn start(
+        _app: tauri::AppHandle,
+        _root: String,
+        _emit_file_changes: bool,
+        _authoritative: bool,
+    ) -> AppResult<()> {
         Ok(())
     }
 

--- a/apps/desktop/src-tauri/src/icloud/watch.rs
+++ b/apps/desktop/src-tauri/src/icloud/watch.rs
@@ -46,25 +46,63 @@ pub async fn icloud_watch_start(
     // app's own ubiquity container only, so for any other iCloud path (a
     // desktop graph in the user's general iCloud Drive) the gather produces
     // an empty view that must read as "unknown", never "no conflicts".
-    // Resolved off the main thread: the container API can block on first use.
+    // Resolved off the main thread: the container API can block on first
+    // use. Best-effort — a failed probe degrades to "not authoritative"
+    // (sweeps go full, the safe direction) rather than failing the start:
+    // on mobile this watch is the sole external-change source, and losing
+    // it over a coverage probe would be the far worse trade.
     let authoritative = {
         let root = root.clone();
-        crate::blocking::run_blocking(move || Ok(query_covers_root(&root))).await?
+        crate::blocking::run_blocking(move || Ok(query_covers_root(&root)))
+            .await
+            .unwrap_or(false)
     };
     platform::start(app, root, emit_file_changes, authoritative)
 }
 
 /// See [`icloud_watch_start`]: `root` lives inside the app's own ubiquity
-/// container. Both sides canonicalized — iOS containers sit behind the
-/// `/var` → `/private/var` symlink, and a lexical compare would miss.
+/// container. The lookup is a pure path resolve — watching a graph kept
+/// elsewhere in iCloud Drive must not create the container as a side effect.
 fn query_covers_root(root: &str) -> bool {
-    let Some(documents) = super::storage::ubiquity_documents_dir() else {
-        return false;
-    };
+    match super::storage::ubiquity_documents_path() {
+        Some(documents) => root_within(std::path::Path::new(root), &documents),
+        None => false,
+    }
+}
+
+/// Canonicalized prefix check — iOS containers sit behind the `/var` →
+/// `/private/var` symlink, and a lexical compare would miss. A path that
+/// fails to canonicalize (not on disk) compares as spelled.
+fn root_within(root: &std::path::Path, documents: &std::path::Path) -> bool {
     fn canonical(path: &std::path::Path) -> std::path::PathBuf {
         std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
     }
-    canonical(std::path::Path::new(root)).starts_with(canonical(&documents))
+    canonical(root).starts_with(canonical(documents))
+}
+
+#[cfg(test)]
+mod coverage_tests {
+    use super::root_within;
+
+    #[test]
+    fn resolves_symlinked_spellings_before_comparing() {
+        let dir = tempfile::tempdir().unwrap();
+        let documents = dir.path().join("container/Documents");
+        std::fs::create_dir_all(documents.join("Graph")).unwrap();
+        std::os::unix::fs::symlink(dir.path().join("container"), dir.path().join("alias")).unwrap();
+
+        assert!(root_within(&documents.join("Graph"), &documents));
+        // The same graph reached through a symlinked spelling still matches —
+        // the iOS `/var` → `/private/var` shape.
+        assert!(root_within(
+            &dir.path().join("alias/Documents/Graph"),
+            &documents
+        ));
+        // A sibling outside the container never does.
+        let elsewhere = dir.path().join("CloudDocs/Graph");
+        std::fs::create_dir_all(&elsewhere).unwrap();
+        assert!(!root_within(&elsewhere, &documents));
+    }
 }
 
 /// Command: stop the active watch (graph switch or shutdown). Idempotent.

--- a/apps/desktop/src/lib/icloud-controller.test.tsx
+++ b/apps/desktop/src/lib/icloud-controller.test.tsx
@@ -26,6 +26,7 @@ interface ScanCall {
   skipPaths: string[]
   ingestedPaths: string[]
   recordBaseline: boolean
+  scope: string
 }
 
 const GRAPH = {
@@ -63,6 +64,7 @@ beforeEach(() => {
             skipPaths: (args?.['skipPaths'] as string[] | undefined) ?? [],
             ingestedPaths: (args?.['ingestedPaths'] as string[] | undefined) ?? [],
             recordBaseline: args?.['recordBaseline'] === true,
+            scope: String(args?.['scope']),
           })
           const scripted = scanResults.shift()
           if (scripted instanceof Error) {
@@ -251,6 +253,41 @@ describe('createIcloudController', () => {
     } finally {
       visibility.mockRestore()
     }
+  })
+
+  it('scopes sweeps: full for baseline and resume, candidates for signals and ingests', async () => {
+    const icloud = controller()
+    await icloud.start()
+    await settleScan()
+    expect(scanCalls[0]?.scope).toBe('full') // the adoption baseline is the backstop
+
+    listeners.get('icloud:conflicts')?.(['notes/conflicted.md'])
+    await settleScan()
+    expect(scanCalls[1]?.scope).toBe('candidates') // signal and set share a round
+
+    emitFileChanges([{ path: 'notes/external.md', kind: 'upsert', modifiedMs: 2 }])
+    await settleScan(INGEST_SETTLE_MS)
+    expect(scanCalls[2]?.scope).toBe('candidates') // bulk-sync arrival sweeps stay cheap
+
+    window.dispatchEvent(new Event('focus'))
+    await settleScan()
+    expect(scanCalls[3]?.scope).toBe('full') // resume re-checks everything
+  })
+
+  it('a failed candidates sweep retries at full scope', async () => {
+    const icloud = controller()
+    await icloud.start()
+    await settleScan() // baseline (full) out of the way
+
+    scanResults.push(new Error('container hiccup'))
+    listeners.get('icloud:conflicts')?.(['notes/conflicted.md'])
+    await settleScan()
+    expect(scanCalls[1]?.scope).toBe('candidates')
+
+    listeners.get('icloud:conflicts')?.(['notes/conflicted.md'])
+    await settleScan()
+    // Whatever failed, the retry must be thorough.
+    expect(scanCalls[2]?.scope).toBe('full')
   })
 
   it('a failed sweep re-queues its ingests and the adoption baseline', async () => {

--- a/apps/desktop/src/lib/icloud-controller.test.tsx
+++ b/apps/desktop/src/lib/icloud-controller.test.tsx
@@ -343,10 +343,30 @@ describe('createIcloudController', () => {
     expect(scanCalls).toHaveLength(1)
 
     // The sweep ends → the queued conflict replays promptly (1s), never on
-    // the wide ingest window.
+    // the wide ingest window — and with its own candidates scope, not the
+    // default full: replaying the O(N) version pass on overlap would undo
+    // the scoping in exactly the case it exists for.
     releaseScan?.()
     await settleScan()
     expect(scanCalls).toHaveLength(2)
+    expect(scanCalls[1]?.scope).toBe('candidates')
+  })
+
+  it('a mid-sweep resume keeps its full scope through the replay', async () => {
+    scanResults.push('hang')
+    const icloud = controller()
+    await icloud.start()
+    await settleScan() // the baseline sweep starts — and hangs
+    expect(scanCalls).toHaveLength(1)
+
+    // A resume (full) and a conflict signal (candidates) both land mid-sweep:
+    // full is sticky through the merge, whatever the arrival order.
+    listeners.get('icloud:conflicts')?.(['notes/a.md'])
+    window.dispatchEvent(new Event('focus'))
+    releaseScan?.()
+    await settleScan()
+    expect(scanCalls).toHaveLength(2)
+    expect(scanCalls[1]?.scope).toBe('full')
   })
 
   it('an arrival caught mid-sweep replays on the ingest spacing', async () => {

--- a/apps/desktop/src/lib/icloud-controller.ts
+++ b/apps/desktop/src/lib/icloud-controller.ts
@@ -107,15 +107,19 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
   let scanTimerDue = 0
   let scanRunning = false
   /**
-   * The most urgent trigger class that arrived while a sweep was running,
-   * replayed on its own window once the sweep ends: `'prompt'` (conflict
-   * signal, resume) reschedules on {@link SCAN_DEBOUNCE_MS}; `'ingest'`
-   * (arrival batches) respects the full ingest spacing. Requests that land
-   * mid-sweep don't arm a timer — the class survives instead, so a long
-   * sweep neither chains straight into the next one (ingest) nor delays
-   * conflict handling by the wide window (prompt).
+   * The request that arrived while a sweep was running, replayed on its own
+   * window once the sweep ends: `'prompt'` urgency (conflict signal, resume)
+   * reschedules on {@link SCAN_DEBOUNCE_MS}; `'ingest'` (arrival batches)
+   * respects the full ingest spacing. Requests that land mid-sweep don't arm
+   * a timer — the request survives instead, so a long sweep neither chains
+   * straight into the next one (ingest) nor delays conflict handling by the
+   * wide window (prompt). The requested scope rides along and merges the
+   * same way scopes always merge (`'full'` is sticky): without it, a
+   * mid-sweep conflict signal would replay as a default-`'full'` sweep —
+   * another O(N) version pass, in exactly the overlap case the scoping
+   * exists for.
    */
-  let queuedScan: 'prompt' | 'ingest' | null = null
+  let queuedScan: { urgency: 'prompt' | 'ingest'; scope: IcloudSweepScope } | null = null
   let lastScanEndedAt = 0
   /**
    * Version-check coverage for the next sweep. `'full'` is sticky until a
@@ -142,8 +146,11 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
       nextScanScope = 'full' // sticky until a sweep consumes it
     }
     if (scanRunning) {
-      const requested = delayMs <= SCAN_DEBOUNCE_MS ? 'prompt' : 'ingest'
-      queuedScan = requested === 'prompt' ? 'prompt' : (queuedScan ?? 'ingest')
+      const urgency = delayMs <= SCAN_DEBOUNCE_MS ? 'prompt' : 'ingest'
+      queuedScan = {
+        urgency: urgency === 'prompt' || queuedScan?.urgency === 'prompt' ? 'prompt' : 'ingest',
+        scope: scope === 'full' || queuedScan?.scope === 'full' ? 'full' : 'candidates',
+      }
       return
     }
     const due = Date.now() + delayMs
@@ -165,11 +172,11 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
    * to the watch's conflict candidates — during a bulk sync these fire every
    * spacing window, and a full per-note version check each time was the
    * sweep's dominant cost on a large graph. */
-  function scheduleIngestScan(): void {
+  function scheduleIngestScan(scope: IcloudSweepScope = 'candidates'): void {
     const sinceLastScan = Date.now() - lastScanEndedAt
     scheduleScan(
       Math.max(INGEST_SCAN_DEBOUNCE_MS, INGEST_SCAN_MIN_SPACING_MS - sinceLastScan),
-      'candidates',
+      scope,
     )
   }
 
@@ -179,8 +186,8 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
     }
     if (scanRunning) {
       // Unreachable in the current shape (mid-run requests never arm a
-      // timer), kept as a safe fallback: replay promptly.
-      queuedScan = 'prompt'
+      // timer), kept as a safe fallback: replay promptly and thoroughly.
+      queuedScan = { urgency: 'prompt', scope: 'full' }
       return
     }
     scanRunning = true
@@ -217,10 +224,10 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
       if (queuedScan !== null) {
         const replay = queuedScan
         queuedScan = null
-        if (replay === 'prompt') {
-          scheduleScan()
+        if (replay.urgency === 'prompt') {
+          scheduleScan(SCAN_DEBOUNCE_MS, replay.scope)
         } else {
-          scheduleIngestScan()
+          scheduleIngestScan(replay.scope)
         }
       }
     }

--- a/apps/desktop/src/lib/icloud-controller.ts
+++ b/apps/desktop/src/lib/icloud-controller.ts
@@ -11,6 +11,7 @@ import {
   subscribeOwnWrites,
   type FileChange,
   type GraphInfo,
+  type IcloudSweepScope,
 } from '@reflect/core'
 import { dirtyOpenPaths } from '@/editor/open-documents'
 import { throttledInvalidateIndexQueries } from '@/lib/query-client'
@@ -116,14 +117,29 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
    */
   let queuedScan: 'prompt' | 'ingest' | null = null
   let lastScanEndedAt = 0
+  /**
+   * Version-check coverage for the next sweep. `'full'` is sticky until a
+   * sweep consumes it — a resume request must not be narrowed by a later
+   * conflict signal — and the initial baseline sweep starts full. After each
+   * sweep the scope relaxes to `'candidates'` (the watch's conflicted set;
+   * Rust degrades it to full whenever the watch can't answer), and a failed
+   * sweep re-arms `'full'` so the retry is thorough.
+   */
+  let nextScanScope: IcloudSweepScope = 'full'
 
   function scanSuspended(): boolean {
     return emitFileChangesFromWatch && document.visibilityState === 'hidden'
   }
 
-  function scheduleScan(delayMs: number = SCAN_DEBOUNCE_MS): void {
+  function scheduleScan(
+    delayMs: number = SCAN_DEBOUNCE_MS,
+    scope: IcloudSweepScope = 'full',
+  ): void {
     if (disposed || scanSuspended()) {
       return
+    }
+    if (scope === 'full') {
+      nextScanScope = 'full' // sticky until a sweep consumes it
     }
     if (scanRunning) {
       const requested = delayMs <= SCAN_DEBOUNCE_MS ? 'prompt' : 'ingest'
@@ -145,10 +161,16 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
   }
 
   /** Arrival-triggered sweeps: the wide debounce, stretched further to keep
-   * {@link INGEST_SCAN_MIN_SPACING_MS} from the previous sweep's end. */
+   * {@link INGEST_SCAN_MIN_SPACING_MS} from the previous sweep's end. Scoped
+   * to the watch's conflict candidates — during a bulk sync these fire every
+   * spacing window, and a full per-note version check each time was the
+   * sweep's dominant cost on a large graph. */
   function scheduleIngestScan(): void {
     const sinceLastScan = Date.now() - lastScanEndedAt
-    scheduleScan(Math.max(INGEST_SCAN_DEBOUNCE_MS, INGEST_SCAN_MIN_SPACING_MS - sinceLastScan))
+    scheduleScan(
+      Math.max(INGEST_SCAN_DEBOUNCE_MS, INGEST_SCAN_MIN_SPACING_MS - sinceLastScan),
+      'candidates',
+    )
   }
 
   async function runScan(): Promise<void> {
@@ -166,12 +188,15 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
     pendingIngest = new Set()
     const recordBaseline = baselinePending
     baselinePending = false
+    const scope = recordBaseline ? 'full' : nextScanScope
+    nextScanScope = 'candidates' // consumed; the next full trigger re-arms it
     try {
       const outcome = await icloudConflictsScan({
         generation: graph.generation,
         skipPaths: dirtyOpenPaths(),
         ingestedPaths: ingested,
         recordBaseline,
+        scope,
       })
       if (!disposed && outcome.changed.length > 0) {
         applySweepChanges(outcome.changed)
@@ -185,6 +210,7 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
       if (recordBaseline) {
         baselinePending = true // the adoption baseline must survive a failed first sweep
       }
+      nextScanScope = 'full' // whatever failed, retry thoroughly
     } finally {
       lastScanEndedAt = Date.now()
       scanRunning = false
@@ -294,7 +320,10 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
       disposers.push(
         await subscribeIcloudConflicts(() => {
           if (!disposed) {
-            scheduleScan()
+            // The signal and the candidate set come from the same
+            // notification round, so the flagged paths are already in the
+            // watch's view — the prompt sweep needn't re-check every note.
+            scheduleScan(SCAN_DEBOUNCE_MS, 'candidates')
           }
         }),
       )

--- a/apps/desktop/src/lib/icloud-controller.ts
+++ b/apps/desktop/src/lib/icloud-controller.ts
@@ -114,10 +114,12 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
    * a timer — the request survives instead, so a long sweep neither chains
    * straight into the next one (ingest) nor delays conflict handling by the
    * wide window (prompt). The requested scope rides along and merges the
-   * same way scopes always merge (`'full'` is sticky): without it, a
-   * mid-sweep conflict signal would replay as a default-`'full'` sweep —
-   * another O(N) version pass, in exactly the overlap case the scoping
-   * exists for.
+   * same way scopes always merge (`'full'` is sticky). Mechanically the
+   * sweep's coverage always comes from {@link nextScanScope}; what carrying
+   * the scope prevents is the replay's `scheduleScan` call passing the
+   * *default* `'full'` and re-arming the sticky flag — which turned every
+   * mid-sweep conflict signal into another O(N) version pass, in exactly
+   * the overlap case the scoping exists for.
    */
   let queuedScan: { urgency: 'prompt' | 'ingest'; scope: IcloudSweepScope } | null = null
   let lastScanEndedAt = 0

--- a/apps/desktop/src/mobile/use-icloud-refresh.test.tsx
+++ b/apps/desktop/src/mobile/use-icloud-refresh.test.tsx
@@ -218,6 +218,36 @@ describe('useICloudRefresh', () => {
     expect(countCalls).toHaveLength(1) // ...and the poll starts over
   })
 
+  it('a quick hide → show inside the dedupe window still restarts the drain', async () => {
+    pendingCount = 3
+    await renderHook(() => useICloudRefresh())
+    await flush()
+    expect(downloadCalls).toHaveLength(1)
+
+    // Hide and let the armed tick bail — the poll is now abandoned…
+    visibility = 'hidden'
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+    await flush()
+    expect(countCalls).toHaveLength(0)
+
+    // …and a return to visible only 200ms later (inside the 1.5s resume
+    // dedupe) must not be swallowed, or nothing would be scheduled at all.
+    visibility = 'visible'
+    await act(async () => {
+      vi.advanceTimersByTime(200)
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await flush()
+    expect(downloadCalls).toHaveLength(2)
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+    await flush()
+    expect(countCalls).toHaveLength(1)
+  })
+
   it('gives up polling at the limit with one final reconcile', async () => {
     pendingCount = 3
     await renderHook(() => useICloudRefresh())

--- a/apps/desktop/src/mobile/use-icloud-refresh.test.tsx
+++ b/apps/desktop/src/mobile/use-icloud-refresh.test.tsx
@@ -24,9 +24,16 @@ let allScopeDownloadCalls: string[]
 /** What the fake pending commands report — note placeholders remaining. */
 let pendingCount: number
 let refreshIndex: ReturnType<typeof vi.fn<() => void>>
+/** Simulated `document.visibilityState` (the use-wake-to-today pattern). */
+let visibility: DocumentVisibilityState = 'visible'
 
 beforeEach(() => {
   vi.useFakeTimers()
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => visibility,
+  })
+  visibility = 'visible'
   downloadCalls = []
   countCalls = []
   allScopeDownloadCalls = []
@@ -135,6 +142,80 @@ describe('useICloudRefresh', () => {
     })
     await flush()
     expect(countCalls).toHaveLength(2)
+  })
+
+  it('backs the poll off geometrically while notes stay pending', async () => {
+    pendingCount = 3
+    await renderHook(() => useICloudRefresh())
+    await flush()
+
+    // First wait: the 1s floor.
+    await act(async () => {
+      vi.advanceTimersByTime(999)
+    })
+    await flush()
+    expect(countCalls).toHaveLength(0)
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+    })
+    await flush()
+    expect(countCalls).toHaveLength(1)
+
+    // Second wait doubles to 2s...
+    await act(async () => {
+      vi.advanceTimersByTime(1999)
+    })
+    await flush()
+    expect(countCalls).toHaveLength(1)
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+    })
+    await flush()
+    expect(countCalls).toHaveLength(2)
+
+    // ...then 4s, the ceiling.
+    await act(async () => {
+      vi.advanceTimersByTime(3999)
+    })
+    await flush()
+    expect(countCalls).toHaveLength(2)
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+    })
+    await flush()
+    expect(countCalls).toHaveLength(3)
+  })
+
+  it('stops polling when the app hides, and the next foreground restarts the drain', async () => {
+    pendingCount = 3
+    await renderHook(() => useICloudRefresh())
+    await flush()
+    expect(downloadCalls).toHaveLength(1)
+
+    visibility = 'hidden'
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+    await flush()
+    expect(countCalls).toHaveLength(0) // the armed tick bailed hidden
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000)
+    })
+    await flush()
+    expect(countCalls).toHaveLength(0) // and nothing re-armed behind the webview
+
+    visibility = 'visible'
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await flush()
+    expect(downloadCalls).toHaveLength(2) // the resume renudges...
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+    await flush()
+    expect(countCalls).toHaveLength(1) // ...and the poll starts over
   })
 
   it('gives up polling at the limit with one final reconcile', async () => {

--- a/apps/desktop/src/mobile/use-icloud-refresh.ts
+++ b/apps/desktop/src/mobile/use-icloud-refresh.ts
@@ -10,11 +10,17 @@ import { useGraph } from '@/providers/graph-provider'
 const RESUME_REFRESH_DEDUPE_MS = 1500
 
 /**
- * While placeholders are still pending, poll the count at this interval and
- * reconcile the moment it reaches zero — note files are small, so downloads
- * usually land within a poll or two and the Mac edit appears in seconds.
+ * While placeholders are still pending, poll the count and reconcile the
+ * moment it reaches zero — note files are small, so downloads usually land
+ * within a poll or two and the Mac edit appears in seconds. Each poll is a
+ * full-graph walk in Rust, so the wait doubles from this floor up to
+ * {@link PENDING_POLL_MAX_MS}: the fast early ticks stay, and a slow link
+ * stops paying a walk every second for the whole drain.
  */
 const PENDING_POLL_MS = 1000
+
+/** The backoff ceiling between pending-count polls. */
+const PENDING_POLL_MAX_MS = 4000
 
 /** Give up polling after this long; the metadata watch and the next resume
  * still cover stragglers (a large asset on a slow link, say). */
@@ -69,13 +75,20 @@ export function useICloudRefresh(): void {
       })
     }
 
-    const pollPending = (startedAt: number): void => {
+    const pollPending = (startedAt: number, attempt: number): void => {
       if (retryTimer !== null) {
         return
       }
+      const delayMs = Math.min(PENDING_POLL_MS * 2 ** attempt, PENDING_POLL_MAX_MS)
       retryTimer = setTimeout(() => {
         retryTimer = null
         if (disposed) {
+          return
+        }
+        if (document.visibilityState === 'hidden') {
+          // Backgrounded mid-drain: stop rather than keep walking the graph
+          // behind a hidden webview (every sibling controller suspends on
+          // hidden). The next resume restarts the whole sequence.
           return
         }
         void icloudPendingCount(root, 'notes').then(
@@ -97,7 +110,7 @@ export function useICloudRefresh(): void {
               refreshIndex()
               return
             }
-            pollPending(startedAt)
+            pollPending(startedAt, attempt + 1)
           },
           (err) => {
             console.error('iCloud pending poll failed:', errorMessage(err))
@@ -106,7 +119,7 @@ export function useICloudRefresh(): void {
             }
           },
         )
-      }, PENDING_POLL_MS)
+      }, delayMs)
     }
 
     const refresh = async (options: { reconcile: boolean }): Promise<void> => {
@@ -126,7 +139,7 @@ export function useICloudRefresh(): void {
         refreshIndex()
       }
       if (pending > 0) {
-        pollPending(Date.now())
+        pollPending(Date.now(), 0)
       } else if (nudged) {
         // A confirmed-empty note count — never a failed nudge, which would
         // start the bulk while notes may still be pending. The next resume

--- a/apps/desktop/src/mobile/use-icloud-refresh.ts
+++ b/apps/desktop/src/mobile/use-icloud-refresh.ts
@@ -88,7 +88,10 @@ export function useICloudRefresh(): void {
         if (document.visibilityState === 'hidden') {
           // Backgrounded mid-drain: stop rather than keep walking the graph
           // behind a hidden webview (every sibling controller suspends on
-          // hidden). The next resume restarts the whole sequence.
+          // hidden). The next resume restarts the whole sequence — clear the
+          // dedupe stamp so even a resume inside the dedupe window counts
+          // (otherwise a quick hide → show would leave nothing scheduled).
+          lastRefreshAt = 0
           return
         }
         void icloudPendingCount(root, 'notes').then(

--- a/packages/core/src/exports/platform.ts
+++ b/packages/core/src/exports/platform.ts
@@ -17,6 +17,7 @@ export {
   type AppPlatform,
   type IcloudDownloadScope,
   type IcloudScanOptions,
+  type IcloudSweepScope,
   type IcloudStatus,
   type IcloudSweepOutcome,
   type MobileStorageInfo,

--- a/packages/core/src/ipc/commands.ts
+++ b/packages/core/src/ipc/commands.ts
@@ -181,6 +181,15 @@ const icloudSweepOutcomeSchema = z.object({
  */
 export type IcloudSweepOutcome = z.infer<typeof icloudSweepOutcomeSchema>
 
+/**
+ * How much of the graph a sweep checks for unresolved versions. `'full'`
+ * checks every note and runs store housekeeping — the backstop (resume,
+ * adoption baseline). `'candidates'` restricts the per-note version checks
+ * to the paths the live metadata watch flags as conflicted; Rust degrades it
+ * to a full check whenever the watch cannot answer completely.
+ */
+export type IcloudSweepScope = 'full' | 'candidates'
+
 /** Options for {@link icloudConflictsScan}. */
 export interface IcloudScanOptions {
   /** The open graph's generation — the scan is pinned to it. */
@@ -197,6 +206,8 @@ export interface IcloudScanOptions {
    * their current content. Safe to repeat — existing bases never move here.
    */
   recordBaseline?: boolean
+  /** Version-check coverage; defaults to `'full'` (the safe backstop). */
+  scope?: IcloudSweepScope
 }
 
 /** Run an iCloud conflict sweep over the open graph (Plan 21 Phase 2). */
@@ -208,6 +219,7 @@ export async function icloudConflictsScan(options: IcloudScanOptions): Promise<I
       skipPaths: options.skipPaths ?? [],
       ingestedPaths: options.ingestedPaths ?? [],
       recordBaseline: options.recordBaseline ?? false,
+      scope: options.scope ?? 'full',
     },
     icloudSweepOutcomeSchema,
   )


### PR DESCRIPTION
## Problem

The iOS battery audit found the two iCloud maintenance passes scale badly with graph size:

1. **`pending_walk` (the placeholder count/nudge) walked the entire graph with no exclusions.** It recursed into `.git/` and `.reflect/` — thousands of loose git objects on a backup-repo graph — paying two `stat`s per entry (`file_type` for the symlink check, then a discarded `path.is_dir()`), up to 20 times per foreground while downloads drained, on a flat 1 Hz poll with no visibility gate. Both directories are marked sync-excluded at bootstrap (`NSURLUbiquitousItemIsExcludedFromSyncKey`), so descending into them is provably zero-yield: iCloud can never hold a placeholder there.
2. **Every conflict sweep ran one `NSFileVersion` check per non-placeholder note** — each a synchronous file-coordination round-trip to `fileproviderd` — even though the `NSMetadataQuery` watch already reads `HasUnresolvedConflicts` per item and emits the exact conflicted paths. During a bulk sync that meant a full O(N)-XPC pass every 30-second arrival window.

## Changes

**Rust — `icloud/storage.rs`**
- `pending_walk` never enters sync-excluded directories (shared `local_only_name` predicate, renamed from `adopt_skips` — same set, same reason) and reuses the readdir-record `file_type` for the dir check, halving per-entry stats.

**Rust — `icloud/watch.rs`**
- New `CONFLICTED` set maintained by the same notification rounds that emit `icloud:conflicts` (pure `apply_conflict_delta`, unit-tested beside `apply_update_delta`), gated by a `GATHERED` flag so a not-yet-seeded or stopped watch answers "unknown", never "no conflicts". Exposed as `conflicted_paths()`.

**Rust — `icloud/sweep.rs`**
- `icloud_conflicts_scan` gains `scope: 'full' | 'candidates'`. `'candidates'` restricts **only** the per-note version checks to the watch's conflicted set — ingest base advances, collision folding, and the baseline still see the full listing — and degrades to full whenever the watch can't answer. Housekeeping (`prune_orphans` + `archive::prune`) runs only on full sweeps; pruning against a narrower view would drop bases for merely-unlisted notes, and deferring it to the next resume is safe.

**Frontend — `icloud-controller.ts`**
- Scope threads through `scheduleScan` with a sticky-`'full'` merge rule: resume, watch-failed, and the adoption baseline sweep stay full (the backstop); conflict-signal and arrival sweeps pass `'candidates'` (the signal and the set come from the same notification round). A failed sweep re-arms `'full'` so the retry is thorough.

**Frontend — `use-icloud-refresh.ts`**
- The pending poll backs off geometrically (1s → 2s → 4s cap; the fast early ticks stay since notes usually land within a poll or two), bails while `document.visibilityState === 'hidden'` (matching every sibling controller), and restarts cleanly on the next resume.

## Testing

- Rust: `cargo test -p reflect-open icloud::` — 37 pass, including new tests for the walk's exclusions, the conflict-set delta semantics, scoped-sweep housekeeping deferral, and scoped sweeps still folding collision duplicates. `cargo fmt --check` + clippy clean.
- TS: `icloud-controller.test.tsx` (14 pass) with new scope-per-trigger and failed-sweep-retries-full tests; `use-icloud-refresh.test.tsx` (9 pass) with new backoff-pacing and hidden-stop/resume-restart tests. `pnpm check` clean.
- Owed: a device pass on a real iCloud graph (large graph + a second device producing conflicts) before trusting the sweep scoping under real `fileproviderd` behavior.

## Risk

The sweep scoping is the sensitive piece. Safety rests on three invariants, each covered: `None`/not-gathered degrades to a full check (Rust-side), deferred dirty-session conflicts stay provider-flagged until actually resolved so they remain candidates, and resume/baseline sweeps are always full. The stale-direction asymmetry is deliberately harmless-only: a just-resolved path may get one extra no-op check; a new conflict cannot be missed because the triggering signal and the candidate set come from the same round. The walk exclusion is zero-risk (sync-excluded dirs cannot contain placeholders). The poll backoff trades up to ~3s of extra latency on a slow drain for ~3× fewer full-graph walks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update (2026-08-01): rebased + review round addressed

Rebased over the merged startup-perf stack (#1008–#1010): the sweep rides `blocking::run_blocking` and keeps the timing log (now with `scope`); the gather-round reconcile emit and `has_base` fill guard from #1010 coexist with the scoping unchanged.

Review fixes (eef8c622):

- **Epoch-scoped view** — readiness, authority, and paths now live in one `ConflictView` under one lock; rounds fold in only when their install epoch is current, and `conflicted_paths()` requires the epoch to still be live. A stop/restart can no longer hand a candidates sweep `Some(empty)` or let a stale gather re-seed a newer watch.
- **Query-coverage gate** — watch start records (off the main thread) whether the query's scope actually covers the root; a desktop graph outside the app container answers `None` and every candidates sweep degrades to full.
- **Queued scope** — mid-sweep requests keep their scope through the replay (full sticky), so an overlapping conflict signal no longer escalates to a full O(N) version pass. Tests: replay-scope assertions on both mid-sweep tests.

Verification re-run after rebase + fixes: `cargo test -p reflect-open` 355 pass, clippy/fmt clean, iOS target check clean; `icloud-controller.test.tsx` 15 pass, `use-icloud-refresh.test.tsx` 10 pass; `pnpm check` clean. The owed real-device pass (large graph + second device producing conflicts) still stands as the gate before trusting sweep scoping under real `fileproviderd` behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved iCloud conflict detection by prioritizing likely conflict locations while retaining full-scan coverage when needed.
  * Added smarter iCloud download polling with exponential backoff.
  * Paused pending-download polling while the app is hidden and resumed it when visible again.
  * Improved iCloud directory traversal to skip excluded folders and symbolic links.

* **Bug Fixes**
  * Ensured failed targeted conflict scans retry with full coverage.
  * Prevented housekeeping cleanup during limited-scope scans.
  * Ignored stale conflict notifications to keep results accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Scoped conflict sweeps are the main risk; safety relies on degrading to full when the watch is unknown or non-authoritative, epoch-gated conflict views, and resume/baseline always staying full—still warrants real-device validation under fileproviderd.
> 
> **Overview**
> Reduces **iCloud sync maintenance cost** on large graphs by making two hot paths cheaper and tightening when full work runs.
> 
> **Placeholder walks** (`pending_walk`) no longer recurse into sync-excluded trees (`.git/`, `.reflect/`, `.DS_Store` via shared `local_only_name`), and directory checks reuse the `readdir` `file_type` instead of an extra stat. A non-creating `ubiquity_documents_path()` supports the watch’s coverage probe without planting an empty Reflect folder in Drive.
> 
> **Conflict sweeps** gain `scope: full | candidates`. In **candidates** mode, per-note `NSFileVersion` checks run only on paths the live metadata watch flags (`ConflictView` with install epoch, gather readiness, and container-authority gating); ingest advances, collision folding, and baselines still use the full listing, and shadow/archive housekeeping runs only on **full** sweeps. Watch start probes whether the query actually covers the graph root (off the main thread); graphs outside the app ubiquity container always degrade to full.
> 
> The **desktop iCloud controller** passes candidates for conflict signals and arrival ingests, keeps **full** sticky for resume, adoption baseline, and failed-scan retries, and preserves queued scope through mid-sweep replays. **Mobile** pending-download polling uses geometric backoff (1s→4s cap) and stops while hidden, restarting on the next visible resume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c71ba677a60ccbd44b9953d7ff6ac0be442f1ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->