### PR TITLE
fix: shrink the day carousel's slide belt

### DIFF
--- a/apps/desktop/src/mobile/use-day-carousel.ts
+++ b/apps/desktop/src/mobile/use-day-carousel.ts
@@ -4,8 +4,8 @@ import { createDayWindow, dateAtIndex, indexWithin, type DayWindow } from '@/lib
 import { getKeyboardHeight } from '@/mobile/use-keyboard'
 
 /**
- * Days either side of the carousel anchor. A generous fixed **symmetric**
- * window (~1 year each way) lets Embla page between days without runtime
+ * Days either side of the carousel anchor. A fixed **symmetric** window
+ * (three months each way) lets Embla page between days without runtime
  * re-anchoring in ordinary use; only the slides near the selection mount an
  * editor, so the empty ones are cheap spacers. Swiping within
  * {@link RECENTER_MARGIN} of an edge (or a date-link beyond the window)
@@ -14,8 +14,16 @@ import { getKeyboardHeight } from '@/mobile/use-keyboard'
  * ({@link createDayWindow}) with a wider, asymmetric reach — but it truly
  * virtualizes its rows, where the carousel renders every slide spacer and
  * only mounts the editors near the selection.
+ *
+ * The spacers are cheap but not free: every slide is a React child
+ * reconciled on each selection change and a DOM node under Embla's
+ * `ResizeObserver`, and a re-anchor re-measures them all — the home
+ * screen's swipe cost scales linearly with this number (the iOS battery
+ * audit's finding at the old ~1-year radius). 90 keeps 60 swipes of
+ * headroom from center before a re-anchor at {@link RECENTER_MARGIN},
+ * far beyond a realistic swipe burst, at a quarter of the belt.
  */
-export const CAROUSEL_RADIUS = 366
+export const CAROUSEL_RADIUS = 90
 
 /**
  * How close (in slides) a settled swipe may get to a window edge before the
@@ -168,6 +176,12 @@ export function useDayCarousel(
     align: 'center',
     skipSnaps: false,
     watchDrag: dragAllowedWithKeyboardClosed,
+    // The container's direct children change only on a re-anchor, and the
+    // follow effect below already reInits synchronously (layout effect —
+    // before Embla's MutationObserver microtask would fire). Watching
+    // slides would just re-measure the whole belt a second time per
+    // re-anchor. `watchResize` stays on: it owns rotation/split-view.
+    watchSlides: false,
   }))
   const [emblaRef, emblaApi] = useEmblaCarousel(emblaOptions)
   const routeIndex = indexWithin(dayWindow, date)


### PR DESCRIPTION
## Problem

The mobile Daily carousel keeps a fixed window of day slides around the selection so swiping feels infinite. That window was ±366 days — **733 slides**. Only ~3 mount an editor; the rest are empty spacers, but they are not free (iOS battery audit): 733 React children rebuilt and diffed on every swipe of the app's home screen, 733 DOM nodes observed by Embla's `ResizeObserver`, a full 733-rect re-measure on every window re-anchor — plus a *duplicate* re-measure from Embla's own `MutationObserver`, because the explicit `reInit` in the follow effect and `watchSlides`' mutation-triggered `reInit` both fire on the same re-anchor.

## Changes

- `CAROUSEL_RADIUS` 366 → 90: 181 slides, a ~4× cut in per-swipe reconciliation and observed nodes. `RECENTER_MARGIN` (30) is unchanged, so there are still 60 swipes of headroom from center before a re-anchor — far beyond a realistic swipe burst; past that, the existing re-anchor path rebuilds the window invisibly (reInit onto the slide the user is already looking at).
- `watchSlides: false`: verified against Embla 8.6 source — `SlidesHandler` is a childList observer on the container's **direct** children, which change only on a re-anchor, where `useDayCarousel`'s follow effect already calls `reInit({ startIndex })` synchronously in a layout effect (before the observer's microtask). Embla's reinit was a strict duplicate. `watchResize` stays on — it owns rotation/split-view re-measurement.

## Testing

- `use-day-carousel.test.tsx` (16 tests — recenter, reinit-vs-scroll reconciliation, echo guards) plus the carousel-adjacent suites (`use-daily-arrivals`, `use-wake-to-today`, `month-title`) all pass; `pnpm check` clean. The tests use `CAROUSEL_RADIUS` symbolically, so they exercise the new geometry directly.
- Live pass in the mobile browser harness (`?platform=ios`, 375×812): belt renders exactly 181 slides with 3 mounted editors; a drag-swipe snaps to the next day with the calendar strip and Today chip following, and settles cleanly on the new route.
- Owed: a device swipe-burst pass. This file has a race history (Embla 8.6 settle-before-select re-entrancy, Today-tap-mid-swipe navigationKey scoping), and the radius cut exercises the re-anchor path ~4× more often — the unit tests cover the reconciliation logic, but sustained real-device swiping is the honest gate.

## Risk

Behavior-preserving by design: the re-anchor mechanism, mount radius, and selection flow are untouched — only the belt size and a redundant observer change. The failure mode to watch for on device is a visible hitch or mis-position at the re-anchor boundary (~60 fast swipes in one direction); a revert is a two-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the home-screen swipe path and re-anchor frequency; logic is unchanged but sustained device swiping near the new window edge is the main regression surface.
> 
> **Overview**
> **Shrinks the mobile home day carousel’s fixed slide window** from ±366 days (~733 slides) to ±90 (~181), cutting per-swipe React reconciliation, DOM nodes, and Embla resize work on the main swipe path while keeping `RECENTER_MARGIN` at 30 (still ~60 swipes from center before re-anchor).
> 
> **Disables Embla `watchSlides`** in `useDayCarousel` because slide children only change on re-anchor and the follow layout effect already calls `reInit` synchronously—so the mutation observer was triggering a second full belt re-measure. `watchResize` stays enabled for rotation/split-view.
> 
> Docs on `CAROUSEL_RADIUS` now spell out the linear swipe-cost tradeoff and why 90 days is enough headroom.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fe67bb2ef0d2881da26a454f6dd7cf38e073e83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved day carousel responsiveness by limiting the available paging range to approximately three months around the selected day.
  * Reduced unnecessary slide measurements during carousel re-anchoring for smoother navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->