### PR TITLE
fix: prevent Enter from sending during IME composition

### DIFF
--- a/apps/desktop/src/components/chat/chat-input.tsx
+++ b/apps/desktop/src/components/chat/chat-input.tsx
@@ -109,6 +109,9 @@ export function ChatInput(): ReactElement {
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
           onKeyDown={(event) => {
+            if (event.nativeEvent.isComposing) {
+              return
+            }
             if (event.key === 'Enter' && !event.shiftKey) {
               event.preventDefault()
               submit()

--- a/apps/desktop/src/components/chat/chat-input.tsx
+++ b/apps/desktop/src/components/chat/chat-input.tsx
@@ -22,6 +22,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { imageFilesFrom } from '@/lib/chat-attachments'
 import { groupModelOptions } from '@/lib/chat-model-groups'
 import { keybindingFor } from '@/lib/commands/app-commands'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 import { useChatSession } from '@/providers/chat-provider'
 import { ChatHistoryMenu } from './chat-history-menu'
 
@@ -109,7 +110,7 @@ export function ChatInput(): ReactElement {
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
           onKeyDown={(event) => {
-            if (event.nativeEvent.isComposing) {
+            if (isKeyboardEventComposing(event.nativeEvent)) {
               return
             }
             if (event.key === 'Enter' && !event.shiftKey) {

--- a/apps/desktop/src/components/command-palette/command-palette.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.tsx
@@ -150,8 +150,12 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
           value={selectedValue}
           onValueChange={setSelectedValue}
           onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+            if (event.nativeEvent.isComposing) {
+              return
+            }
             // cmdk dispatches its custom select event after this handler. Drop
             // any abandoned pointer intent so Enter can never inherit it.
+
             if (event.key === 'Enter') {
               pendingNoteClickRef.current = null
             }

--- a/apps/desktop/src/components/command-palette/command-palette.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.tsx
@@ -152,11 +152,15 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
           onValueChange={setSelectedValue}
           onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
             if (isKeyboardEventComposing(event.nativeEvent)) {
+              // preventDefault keeps cmdk's root handler from selecting the
+              // highlighted item on the Enter that commits the composition.
+              if (event.key === 'Enter') {
+                event.preventDefault()
+              }
               return
             }
             // cmdk dispatches its custom select event after this handler. Drop
             // any abandoned pointer intent so Enter can never inherit it.
-
             if (event.key === 'Enter') {
               pendingNoteClickRef.current = null
             }

--- a/apps/desktop/src/components/command-palette/command-palette.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.tsx
@@ -8,6 +8,7 @@ import { useNoteLinkNavigation } from '@/hooks/use-note-link-navigation'
 import { runCommand } from '@/lib/commands/registry'
 import type { CommandContext } from '@/lib/commands/types'
 import { formatDayLabel } from '@/lib/dates'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 import { cn } from '@/lib/utils'
 import type { NewWindowClickEvent } from '@/lib/windows/open-in-new-window'
 import { useSettings } from '@/providers/settings-provider'
@@ -150,7 +151,7 @@ export function CommandPalette({ context }: CommandPaletteProps): ReactElement |
           value={selectedValue}
           onValueChange={setSelectedValue}
           onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
-            if (event.nativeEvent.isComposing) {
+            if (isKeyboardEventComposing(event.nativeEvent)) {
               return
             }
             // cmdk dispatches its custom select event after this handler. Drop

--- a/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
+++ b/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
@@ -17,6 +17,7 @@ import {
   type AutocompleteEntry,
 } from '@/editor/wiki-autocomplete-entries'
 import { useContactsAuthorization } from '@/hooks/use-contacts-authorization'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
@@ -150,7 +151,7 @@ export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): R
   }
 
   const onKeyDown = (keyEvent: KeyboardEvent<HTMLInputElement>): void => {
-    if (keyEvent.nativeEvent.isComposing) {
+    if (isKeyboardEventComposing(keyEvent.nativeEvent)) {
       return
     }
     if (keyEvent.key === 'Enter') {

--- a/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
+++ b/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
@@ -150,6 +150,9 @@ export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): R
   }
 
   const onKeyDown = (keyEvent: KeyboardEvent<HTMLInputElement>): void => {
+    if (keyEvent.nativeEvent.isComposing) {
+      return
+    }
     if (keyEvent.key === 'Enter') {
       // Ours alone: preventDefault stops the dialog form submitting,
       // stopPropagation keeps cmdk's root handler from double-selecting.

--- a/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
+++ b/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
@@ -152,6 +152,11 @@ export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): R
 
   const onKeyDown = (keyEvent: KeyboardEvent<HTMLInputElement>): void => {
     if (isKeyboardEventComposing(keyEvent.nativeEvent)) {
+      // preventDefault keeps cmdk's root handler from selecting the highlighted
+      // entry on the Enter that commits the composition.
+      if (keyEvent.key === 'Enter') {
+        keyEvent.preventDefault()
+      }
       return
     }
     if (keyEvent.key === 'Enter') {

--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -288,6 +288,9 @@ function IcloudCard({
               aria-invalid={nameTaken}
               onChange={(event) => setTypedName(event.target.value)}
               onKeyDown={(event) => {
+                if (event.nativeEvent.isComposing) {
+                  return
+                }
                 if (event.key === 'Enter') {
                   void create()
                 }
@@ -320,6 +323,9 @@ function IcloudCard({
               disabled={!available || pending}
               onChange={(event) => setTypedName(event.target.value)}
               onKeyDown={(event) => {
+                if (event.nativeEvent.isComposing) {
+                  return
+                }
                 if (event.key === 'Enter') {
                   void create()
                 }

--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
 import { useGraphColors } from '@/hooks/use-graph-colors'
 import { cleanGraphName, graphNameFromRoot, isGraphNameTaken } from '@/lib/graph-names'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 import { ICLOUD_STATUS_QUERY_KEY } from '@/lib/query-client'
 import { graphColorCss } from '@/lib/graph-colors'
 import { cn } from '@/lib/utils'
@@ -288,7 +289,7 @@ function IcloudCard({
               aria-invalid={nameTaken}
               onChange={(event) => setTypedName(event.target.value)}
               onKeyDown={(event) => {
-                if (event.nativeEvent.isComposing) {
+                if (isKeyboardEventComposing(event.nativeEvent)) {
                   return
                 }
                 if (event.key === 'Enter') {
@@ -323,7 +324,7 @@ function IcloudCard({
               disabled={!available || pending}
               onChange={(event) => setTypedName(event.target.value)}
               onKeyDown={(event) => {
-                if (event.nativeEvent.isComposing) {
+                if (isKeyboardEventComposing(event.nativeEvent)) {
                   return
                 }
                 if (event.key === 'Enter') {

--- a/apps/desktop/src/components/note-find-bar.tsx
+++ b/apps/desktop/src/components/note-find-bar.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useRef, type KeyboardEvent, type ReactElement } from 'react'
 import { ChevronDownIcon, ChevronUpIcon, XIcon } from 'lucide-react'
 import { SearchIcon } from '@/components/icons/search-icon'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 import { useNoteFind } from '@/providers/note-find-provider'
 
 const FIND_BUTTON_CLASS =
@@ -34,7 +35,7 @@ export function NoteFindBar(): ReactElement | null {
   const canNavigate = total > 0
 
   function handleSearchKeyDown(event: KeyboardEvent<HTMLDivElement>): void {
-    if (event.nativeEvent.isComposing) {
+    if (isKeyboardEventComposing(event.nativeEvent)) {
       return
     }
     if (event.key !== 'Escape') {
@@ -46,7 +47,7 @@ export function NoteFindBar(): ReactElement | null {
   }
 
   function handleKeyDown(event: KeyboardEvent<HTMLInputElement>): void {
-    if (event.nativeEvent.isComposing) {
+    if (isKeyboardEventComposing(event.nativeEvent)) {
       return
     }
     const mod = event.metaKey || event.ctrlKey

--- a/apps/desktop/src/components/note-find-bar.tsx
+++ b/apps/desktop/src/components/note-find-bar.tsx
@@ -34,7 +34,10 @@ export function NoteFindBar(): ReactElement | null {
   const canNavigate = total > 0
 
   function handleSearchKeyDown(event: KeyboardEvent<HTMLDivElement>): void {
-    if (event.key !== 'Escape' || event.nativeEvent.isComposing) {
+    if (event.nativeEvent.isComposing) {
+      return
+    }
+    if (event.key !== 'Escape') {
       return
     }
     event.preventDefault()

--- a/apps/desktop/src/components/settings/destructive-section.tsx
+++ b/apps/desktop/src/components/settings/destructive-section.tsx
@@ -142,6 +142,9 @@ export function DestructiveSection(): ReactElement {
             disabled={deleting}
             onChange={(event) => setDeleteName(event.target.value)}
             onKeyDown={(event) => {
+              if (event.nativeEvent.isComposing) {
+                return
+              }
               if (event.key === 'Enter') {
                 event.preventDefault()
                 void deleteGraphToTrash()

--- a/apps/desktop/src/components/settings/destructive-section.tsx
+++ b/apps/desktop/src/components/settings/destructive-section.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 import { useGraph } from '@/providers/graph-provider'
 import { SettingsField } from './field'
 import { SettingsSection } from './section'
@@ -142,7 +143,7 @@ export function DestructiveSection(): ReactElement {
             disabled={deleting}
             onChange={(event) => setDeleteName(event.target.value)}
             onKeyDown={(event) => {
-              if (event.nativeEvent.isComposing) {
+              if (isKeyboardEventComposing(event.nativeEvent)) {
                 return
               }
               if (event.key === 'Enter') {

--- a/apps/desktop/src/components/settings/model-combobox.tsx
+++ b/apps/desktop/src/components/settings/model-combobox.tsx
@@ -83,6 +83,11 @@ export function ModelCombobox({
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (isKeyboardEventComposing(event.nativeEvent)) {
+      // preventDefault keeps cmdk's root handler from selecting the highlighted
+      // model on the Enter that commits the composition.
+      if (event.key === 'Enter') {
+        event.preventDefault()
+      }
       return
     }
     if (event.key === 'Enter' && filteredCountRef.current === 0 && inputValue.trim()) {

--- a/apps/desktop/src/components/settings/model-combobox.tsx
+++ b/apps/desktop/src/components/settings/model-combobox.tsx
@@ -81,6 +81,9 @@ export function ModelCombobox({
   }
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.nativeEvent.isComposing) {
+      return
+    }
     if (event.key === 'Enter' && filteredCountRef.current === 0 && inputValue.trim()) {
       event.preventDefault()
       commit(inputValue.trim())

--- a/apps/desktop/src/components/settings/model-combobox.tsx
+++ b/apps/desktop/src/components/settings/model-combobox.tsx
@@ -12,6 +12,7 @@ import {
   CommandList,
 } from '@/components/ui/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 
 interface FilterCountSyncProps {
   countRef: React.MutableRefObject<number>
@@ -81,7 +82,7 @@ export function ModelCombobox({
   }
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.nativeEvent.isComposing) {
+    if (isKeyboardEventComposing(event.nativeEvent)) {
       return
     }
     if (event.key === 'Enter' && filteredCountRef.current === 0 && inputValue.trim()) {

--- a/apps/desktop/src/components/tasks/task-row.tsx
+++ b/apps/desktop/src/components/tasks/task-row.tsx
@@ -8,6 +8,7 @@ import {
 import { Circle, CircleCheck } from 'lucide-react'
 import type { OpenTask } from '@reflect/core'
 import { formatDayLabel } from '@/lib/dates'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 import { taskKey } from '@/lib/tasks/task-identity'
 import { useTaskCheckboxToggle } from '@/lib/tasks/use-task-checkbox-toggle'
 import { cn } from '@/lib/utils'
@@ -96,7 +97,7 @@ export function TaskRow({
   const done = task.checked
   const label = task.text || 'Empty task'
   const selectFromKeyboard = (event: KeyboardEvent<HTMLDivElement>): void => {
-    if (event.nativeEvent.isComposing) {
+    if (isKeyboardEventComposing(event.nativeEvent)) {
       return
     }
     if (event.key !== 'Enter' && event.key !== ' ') {

--- a/apps/desktop/src/components/tasks/task-row.tsx
+++ b/apps/desktop/src/components/tasks/task-row.tsx
@@ -96,6 +96,9 @@ export function TaskRow({
   const done = task.checked
   const label = task.text || 'Empty task'
   const selectFromKeyboard = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (event.nativeEvent.isComposing) {
+      return
+    }
     if (event.key !== 'Enter' && event.key !== ' ') {
       return
     }

--- a/apps/desktop/src/hooks/use-sidebar-resize.ts
+++ b/apps/desktop/src/hooks/use-sidebar-resize.ts
@@ -12,6 +12,7 @@ import {
   SIDEBAR_WIDTH_RANGE,
   type SidebarWidthRange,
 } from '@reflect/core'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 import { useSettings } from '@/providers/settings-provider'
 
 /** How far one arrow-key press moves the divider, in CSS pixels. */
@@ -322,7 +323,7 @@ export function useSidebarResize(panel: ResizableSidebarPanel): SidebarResize {
 
   const onKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLElement>): void => {
-      if (event.nativeEvent.isComposing) {
+      if (isKeyboardEventComposing(event.nativeEvent)) {
         return
       }
       if (dragRef.current !== null) {

--- a/apps/desktop/src/hooks/use-sidebar-resize.ts
+++ b/apps/desktop/src/hooks/use-sidebar-resize.ts
@@ -322,6 +322,9 @@ export function useSidebarResize(panel: ResizableSidebarPanel): SidebarResize {
 
   const onKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLElement>): void => {
+      if (event.nativeEvent.isComposing) {
+        return
+      }
       if (dragRef.current !== null) {
         return
       }

--- a/apps/desktop/src/lib/keyboard.test.tsx
+++ b/apps/desktop/src/lib/keyboard.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { isKeyboardEventComposing } from './keyboard'
+
+function keydown(init?: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent('keydown', { key: 'Enter', ...init })
+}
+
+describe('isKeyboardEventComposing', () => {
+  it('reports false for a plain keydown', () => {
+    expect(isKeyboardEventComposing(keydown())).toBe(false)
+  })
+
+  it('reports true while composing', () => {
+    expect(isKeyboardEventComposing(keydown({ isComposing: true }))).toBe(true)
+  })
+
+  it('reports true for the keydown WebKit fires right after compositionend', () => {
+    window.dispatchEvent(new CompositionEvent('compositionend'))
+    expect(isKeyboardEventComposing(keydown())).toBe(true)
+  })
+
+  it('reports false again once the composition end is in the past', async () => {
+    window.dispatchEvent(new CompositionEvent('compositionend'))
+    await new Promise((resolve) => setTimeout(resolve, 60))
+    expect(isKeyboardEventComposing(keydown())).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/keyboard.ts
+++ b/apps/desktop/src/lib/keyboard.ts
@@ -4,16 +4,18 @@ let timer : ReturnType<typeof setTimeout> | undefined
 // Workaround for a bug in WebKit where the isComposing property is reset to false event when the IME is still composing.
 // https://bugs.webkit.org/show_bug.cgi?id=311717
 export function isKeyboardEventComposing(event: KeyboardEvent): boolean {
-  if (timer) {
-    clearTimeout(timer)
-    timer = undefined
-  }
+
 
   if (event.isComposing) {
+    if (timer) {
+      clearTimeout(timer)
+      timer = undefined
+    }
     isComposing = true
   } else if (isComposing) {
     timer = setTimeout(() => {
       isComposing = false
+      timer = undefined
     }, 40)
   }
 

--- a/apps/desktop/src/lib/keyboard.ts
+++ b/apps/desktop/src/lib/keyboard.ts
@@ -1,21 +1,21 @@
-let isComposing = false
-let timer : ReturnType<typeof setTimeout> | undefined
+const COMPOSITION_TAIL_MS = 40
 
-// Workaround for a bug in WebKit where the isComposing property is reset to false event when the IME is still composing.
+let lastCompositionEndedAt = -Infinity
+
+if (typeof window !== 'undefined') {
+  window.addEventListener(
+    'compositionend',
+    (event) => {
+      lastCompositionEndedAt = event.timeStamp
+    },
+    true,
+  )
+}
+
+// Workaround for WebKit firing compositionend before the keydown that commits an
+// IME composition, which makes that keydown report `isComposing` as false.
+// https://bugs.webkit.org/show_bug.cgi?id=165004
 // https://bugs.webkit.org/show_bug.cgi?id=311717
 export function isKeyboardEventComposing(event: KeyboardEvent): boolean {
-  if (event.isComposing) {
-    if (timer) {
-      clearTimeout(timer)
-      timer = undefined
-    }
-    isComposing = true
-  } else if (isComposing && !timer) {
-    timer = setTimeout(() => {
-      isComposing = false
-      timer = undefined
-    }, 40)
-  }
-
-  return isComposing
+  return event.isComposing || event.timeStamp - lastCompositionEndedAt < COMPOSITION_TAIL_MS
 }

--- a/apps/desktop/src/lib/keyboard.ts
+++ b/apps/desktop/src/lib/keyboard.ts
@@ -1,0 +1,22 @@
+
+let isComposing = false
+let timer : ReturnType<typeof setTimeout> | undefined
+
+// Workaround for a bug in WebKit where the isComposing property is reset to false event when the IME is still composing.
+// https://bugs.webkit.org/show_bug.cgi?id=311717
+export function isKeyboardEventComposing(event: KeyboardEvent): boolean {
+  if (timer) {
+    clearTimeout(timer)
+    timer = undefined
+  }
+
+  if (event.isComposing) {
+    isComposing = true
+  } else if (isComposing) {
+    timer = setTimeout(() => {
+      isComposing = false
+    }, 40)
+  }
+
+  return isComposing
+}

--- a/apps/desktop/src/lib/keyboard.ts
+++ b/apps/desktop/src/lib/keyboard.ts
@@ -1,4 +1,3 @@
-
 let isComposing = false
 let timer : ReturnType<typeof setTimeout> | undefined
 

--- a/apps/desktop/src/lib/keyboard.ts
+++ b/apps/desktop/src/lib/keyboard.ts
@@ -4,15 +4,13 @@ let timer : ReturnType<typeof setTimeout> | undefined
 // Workaround for a bug in WebKit where the isComposing property is reset to false event when the IME is still composing.
 // https://bugs.webkit.org/show_bug.cgi?id=311717
 export function isKeyboardEventComposing(event: KeyboardEvent): boolean {
-
-
   if (event.isComposing) {
     if (timer) {
       clearTimeout(timer)
       timer = undefined
     }
     isComposing = true
-  } else if (isComposing) {
+  } else if (isComposing && !timer) {
     timer = setTimeout(() => {
       isComposing = false
       timer = undefined

--- a/apps/desktop/src/lib/tasks/use-task-keyboard.ts
+++ b/apps/desktop/src/lib/tasks/use-task-keyboard.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, type RefObject } from 'react'
 import { type OpenTask } from '@reflect/core'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 import { taskKey } from '@/lib/tasks/task-identity'
 import {
   insertTargetForBucket,
@@ -84,6 +85,9 @@ export function useTaskKeyboard({
       // Respect anything a focused widget already handled (e.g. the filters menu's
       // own arrow/Escape navigation).
       if (event.defaultPrevented) {
+        return
+      }
+      if (isKeyboardEventComposing(event)) {
         return
       }
       // ⌘⇧E toggles the filters menu (V1) — a screen-level chord that fires

--- a/apps/desktop/src/mobile/connect-github-drawer.tsx
+++ b/apps/desktop/src/mobile/connect-github-drawer.tsx
@@ -99,6 +99,9 @@ function ConnectWizardSheet({
                   enterKeyHint="go"
                   onChange={(event) => wizard.setRepoName(event.target.value)}
                   onKeyDown={(event) => {
+                    if (event.nativeEvent.isComposing) {
+                      return
+                    }
                     if (event.key === 'Enter') {
                       wizard.continueFromRepo()
                     }
@@ -129,6 +132,9 @@ function ConnectWizardSheet({
                   enterKeyHint="go"
                   onChange={(event) => wizard.setExistingRepo(event.target.value)}
                   onKeyDown={(event) => {
+                    if (event.nativeEvent.isComposing) {
+                      return
+                    }
                     if (event.key === 'Enter') {
                       wizard.continueFromRepo()
                     }

--- a/apps/desktop/src/mobile/connect-github-drawer.tsx
+++ b/apps/desktop/src/mobile/connect-github-drawer.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
 import { Input } from '@/components/ui/input'
 import { useConnectGithubWizard, type ConnectWizardStep } from '@/hooks/use-connect-github-wizard'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 
 interface ConnectGithubDrawerProps {
   open: boolean
@@ -99,7 +100,7 @@ function ConnectWizardSheet({
                   enterKeyHint="go"
                   onChange={(event) => wizard.setRepoName(event.target.value)}
                   onKeyDown={(event) => {
-                    if (event.nativeEvent.isComposing) {
+                    if (isKeyboardEventComposing(event.nativeEvent)) {
                       return
                     }
                     if (event.key === 'Enter') {
@@ -132,7 +133,7 @@ function ConnectWizardSheet({
                   enterKeyHint="go"
                   onChange={(event) => wizard.setExistingRepo(event.target.value)}
                   onKeyDown={(event) => {
-                    if (event.nativeEvent.isComposing) {
+                    if (isKeyboardEventComposing(event.nativeEvent)) {
                       return
                     }
                     if (event.key === 'Enter') {

--- a/apps/desktop/src/mobile/new-graph-drawer.tsx
+++ b/apps/desktop/src/mobile/new-graph-drawer.tsx
@@ -84,6 +84,9 @@ export function NewGraphDrawer({
               enterKeyHint="go"
               onChange={(event) => setTypedName(event.target.value)}
               onKeyDown={(event) => {
+                if (event.nativeEvent.isComposing) {
+                  return
+                }
                 if (event.key === 'Enter') {
                   create()
                 }

--- a/apps/desktop/src/mobile/new-graph-drawer.tsx
+++ b/apps/desktop/src/mobile/new-graph-drawer.tsx
@@ -5,6 +5,7 @@ import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
 import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
 import { cleanGraphName, graphRootForName, isGraphNameTaken } from '@/lib/graph-names'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 
 interface NewGraphDrawerProps {
   open: boolean
@@ -84,7 +85,7 @@ export function NewGraphDrawer({
               enterKeyHint="go"
               onChange={(event) => setTypedName(event.target.value)}
               onKeyDown={(event) => {
-                if (event.nativeEvent.isComposing) {
+                if (isKeyboardEventComposing(event.nativeEvent)) {
                   return
                 }
                 if (event.key === 'Enter') {

--- a/apps/desktop/src/mobile/onboarding-icloud-section.tsx
+++ b/apps/desktop/src/mobile/onboarding-icloud-section.tsx
@@ -103,6 +103,9 @@ export function OnboardingIcloudSection(props: OnboardingIcloudSectionProps): Re
                 enterKeyHint="go"
                 onChange={(event) => setTypedName(event.target.value)}
                 onKeyDown={(event) => {
+                  if (event.nativeEvent.isComposing) {
+                    return
+                  }
                   if (event.key === 'Enter') {
                     create()
                   }

--- a/apps/desktop/src/mobile/onboarding-icloud-section.tsx
+++ b/apps/desktop/src/mobile/onboarding-icloud-section.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
 import { cleanGraphName, graphNameFromRoot, graphRootForName, isGraphNameTaken } from '@/lib/graph-names'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 import { OnboardingIcloudHeader } from '@/mobile/onboarding-icloud-header'
 
 const DEFAULT_ICLOUD_NOTES_NAME = 'Notes'
@@ -103,7 +104,7 @@ export function OnboardingIcloudSection(props: OnboardingIcloudSectionProps): Re
                 enterKeyHint="go"
                 onChange={(event) => setTypedName(event.target.value)}
                 onKeyDown={(event) => {
-                  if (event.nativeEvent.isComposing) {
+                  if (isKeyboardEventComposing(event.nativeEvent)) {
                     return
                   }
                   if (event.key === 'Enter') {

--- a/apps/desktop/src/mobile/search-input.tsx
+++ b/apps/desktop/src/mobile/search-input.tsx
@@ -45,6 +45,9 @@ export function SearchInput({
         value={value}
         onChange={(event) => onValueChange(event.target.value)}
         onKeyDown={(event) => {
+          if (event.nativeEvent.isComposing) {
+            return
+          }
           if (event.key === 'Enter') {
             event.currentTarget.blur()
           }

--- a/apps/desktop/src/mobile/search-input.tsx
+++ b/apps/desktop/src/mobile/search-input.tsx
@@ -2,6 +2,7 @@ import { type ComponentProps, type ReactElement } from 'react'
 import { CircleX } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 import { cn } from '@/lib/utils'
 
 type SearchInputProps = Omit<
@@ -45,7 +46,7 @@ export function SearchInput({
         value={value}
         onChange={(event) => onValueChange(event.target.value)}
         onKeyDown={(event) => {
-          if (event.nativeEvent.isComposing) {
+          if (isKeyboardEventComposing(event.nativeEvent)) {
             return
           }
           if (event.key === 'Enter') {

--- a/apps/desktop/src/mobile/task-row.tsx
+++ b/apps/desktop/src/mobile/task-row.tsx
@@ -65,6 +65,9 @@ export function MobileTaskRow({ task, showSource, onEdit }: MobileTaskRowProps):
         aria-label={`Edit: ${label}`}
         onClick={edit}
         onKeyDown={(event) => {
+          if (event.nativeEvent.isComposing) {
+            return
+          }
           if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault()
             edit()

--- a/apps/desktop/src/mobile/task-row.tsx
+++ b/apps/desktop/src/mobile/task-row.tsx
@@ -3,6 +3,7 @@ import { Circle, CircleCheck } from 'lucide-react'
 import type { OpenTask } from '@reflect/core'
 import { TaskText } from '@/components/tasks/task-text'
 import { formatShortDate } from '@/lib/dates'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 import { taskKey } from '@/lib/tasks/task-identity'
 import { useTaskCheckboxToggle } from '@/lib/tasks/use-task-checkbox-toggle'
 import { cn } from '@/lib/utils'
@@ -65,7 +66,7 @@ export function MobileTaskRow({ task, showSource, onEdit }: MobileTaskRowProps):
         aria-label={`Edit: ${label}`}
         onClick={edit}
         onKeyDown={(event) => {
-          if (event.nativeEvent.isComposing) {
+          if (isKeyboardEventComposing(event.nativeEvent)) {
             return
           }
           if (event.key === 'Enter' || event.key === ' ') {

--- a/apps/desktop/src/providers/note-find-provider.tsx
+++ b/apps/desktop/src/providers/note-find-provider.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react'
 import type { SearchStatus } from '@meowdown/core'
 import { noteEditorHandleFor } from '@/editor/editor-handle-registry'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 import {
   listenForFocusedNoteMenuCommands,
   type FocusedNoteMenuCommand,
@@ -138,7 +139,7 @@ export function NoteFindProvider({ children }: { children: ReactNode }): ReactEl
   useEffect(() => {
     if (target === null) return
     function onEscape(event: KeyboardEvent): void {
-      if (event.key !== 'Escape' || event.defaultPrevented || event.isComposing) return
+      if (event.key !== 'Escape' || event.defaultPrevented || isKeyboardEventComposing(event)) return
       // Never consume the key: meowdown owns Escape inside the editor (its
       // menus close on it) and an overlay above the bar owns its own. This
       // only ends a Find session the user has already navigated away from.
@@ -182,7 +183,7 @@ export function NoteFindProvider({ children }: { children: ReactNode }): ReactEl
       })
 
     function onKeyDown(event: KeyboardEvent): void {
-      if (event.defaultPrevented || event.altKey || event.repeat || event.isComposing) return
+      if (event.defaultPrevented || event.altKey || event.repeat || isKeyboardEventComposing(event)) return
       if (!event.metaKey && !event.ctrlKey) return
       const key = event.key.toLowerCase()
       if (key === 'f' && !event.shiftKey) {

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -314,6 +314,9 @@ export function useAppShortcuts(): CommandContext {
     }
 
     function onKeyDown(event: KeyboardEvent) {
+      if (event.isComposing) {
+        return
+      }
       if (event.defaultPrevented) {
         // The focused editor gets first refusal. meowdown's `Mod-k` consumes the
         // keydown (preventDefault) only when it turns a selection or the link at

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -4,6 +4,7 @@ import { registerKeymap } from '@/editor/keymap'
 import { APP_COMMANDS } from '@/lib/commands/app-commands'
 import { runCommand } from '@/lib/commands/registry'
 import { todayIso } from '@/lib/dates'
+import { isKeyboardEventComposing } from '@/lib/keyboard'
 import { setMenuCommandDispatch } from '@/lib/native-menu/dispatch'
 import { isNativeMenuInstalled } from '@/lib/native-menu/menu'
 import { isMacosDesktop } from '@/lib/platform'
@@ -314,7 +315,7 @@ export function useAppShortcuts(): CommandContext {
     }
 
     function onKeyDown(event: KeyboardEvent) {
-      if (event.isComposing) {
+      if (isKeyboardEventComposing(event)) {
         return
       }
       if (event.defaultPrevented) {

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -303,6 +303,9 @@ export function useAppShortcuts(): CommandContext {
     }
 
     function onHistoryKeyDownCapture(event: KeyboardEvent) {
+      if (isKeyboardEventComposing(event)) {
+        return
+      }
       const id = idForKeyDown(event)
       if (id === null || isNativeMacosMenuCommand(id) || !HISTORY_COMMAND_IDS.has(id)) {
         return


### PR DESCRIPTION
Ignore the keydown that commits an IME composition (WebKit fires it after compositionend with isComposing false) so committing Japanese text can't send the chat message, select a cmdk item, or trigger app shortcuts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text input with IMEs by preventing Enter, Escape, keyboard shortcuts, and related actions (such as submissions, selections, and navigation) from triggering while text is still being composed.
  * Applied consistent IME-safe key handling across chat, command palette, search/find, tasks, settings dialogs, graph creation, onboarding, and mobile inputs.
  * Kept the original keyboard behavior once composition is complete.
* **Tests**
  * Added automated coverage for the IME/composition key-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->