### PR TITLE
docs: fix changelog path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+./apps/desktop/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,0 @@
-./apps/desktop/CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ another git remote are connected directly by the user.
 
 You can also [build from source](#building-from-source).
 
-See [CHANGELOG.md](CHANGELOG.md) for release notes.
+See [CHANGELOG.md](apps/desktop/CHANGELOG.md) for release notes.
 
 ## Your Notes Are Files
 


### PR DESCRIPTION
Closes https://github.com/team-reflect/reflect-open/issues/961 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the installation instructions so the “release notes” link points to the desktop app’s changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->