### PR TITLE
test: stabilize block handle hover tests

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -77,6 +77,7 @@
     "typescript-eslint": "^8.62.0",
     "vite": "^8.1.0",
     "vitest": "^4.1.10",
+    "vitest-browser-commands": "^0.2.1",
     "vitest-browser-react": "^2.2.0",
     "vitest-fail-on-console": "^0.10.1"
   }

--- a/apps/desktop/src/editor/note-editor.test.tsx
+++ b/apps/desktop/src/editor/note-editor.test.tsx
@@ -8,6 +8,7 @@ import { setPlatformSurface } from '@/lib/platform-surface'
 import { expectLocatorToHaveCount } from '@/test-utils/expect'
 import { pasteFiles } from '@/test-utils/file-events'
 import '@/test-utils/locator'
+import { hover, unhover } from '@/test-utils/mouse'
 import { NoteEditor, type NoteEditorHandle } from './note-editor'
 
 vi.mock('@tauri-apps/plugin-opener', () => ({
@@ -158,15 +159,20 @@ describe('NoteEditor touch-surface input hygiene', () => {
   })
 
   it('shows the block handle on hover on desktop', async () => {
+    // Park the mouse first: the pointer position persists across tests, and the
+    // block handle only opens on pointer events, so the hover below must be a
+    // real movement into the fresh editor.
+    await unhover()
     await render(<NoteEditor initialContent="Hello" blockHandle={true} />)
-    await pmRoot.getByText('Hello').hover()
+    await hover(pmRoot.getByText('Hello'))
     await expect.element(page.getByTestId('block-handle')).toBeVisible()
   })
 
   it('pins the block handle off on the touch surface', async () => {
     setPlatformSurface({ touchEditor: true })
+    await unhover()
     await render(<NoteEditor initialContent="Hello" blockHandle={true} />)
-    await pmRoot.getByText('Hello').hover()
+    await hover(pmRoot.getByText('Hello'))
     await expect.element(pmRoot.getByText('Hello')).toBeVisible()
     await expectLocatorToHaveCount(page.getByTestId('block-handle'), 0)
   })

--- a/apps/desktop/src/test-utils/mouse.ts
+++ b/apps/desktop/src/test-utils/mouse.ts
@@ -1,0 +1,32 @@
+import { expect } from 'vitest'
+import { mouse } from 'vitest-browser-commands/playwright'
+import { page, type Locator } from 'vitest/browser'
+
+export interface HoverOptions {
+  /**
+   * A point relative to the top-left corner of the element. Defaults to the
+   * center of the element.
+   */
+  position?: { x: number; y: number }
+}
+
+/**
+ * Hovers an element. More reliable than `locator.hover()` because it sends
+ * multiple mouse move events. Returns the final mouse position.
+ */
+export async function hover(
+  locator: Locator,
+  options?: HoverOptions,
+): Promise<{ x: number; y: number }> {
+  await expect.element(locator).toBeVisible()
+  const box = locator.element().getBoundingClientRect()
+  const x = box.x + (options?.position?.x ?? Math.floor(box.width / 2))
+  const y = box.y + (options?.position?.y ?? Math.floor(box.height / 2))
+  await mouse.move(x, y, { steps: 3 })
+  return { x, y }
+}
+
+/** Parks the mouse at the top-left corner of the page. */
+export async function unhover(): Promise<void> {
+  await hover(page.locate('body'), { position: { x: 0, y: 0 } })
+}

--- a/apps/desktop/vitest.browser.config.ts
+++ b/apps/desktop/vitest.browser.config.ts
@@ -1,5 +1,6 @@
 import tailwindcss from '@tailwindcss/vite'
 import { playwright } from '@vitest/browser-playwright'
+import { playwrightCommands } from 'vitest-browser-commands'
 import { defineDesktopProject } from './vitest.shared'
 
 const browserName = process.env.REFLECT_TEST_BROWSER === 'webkit' ? 'webkit' : 'chromium'
@@ -9,7 +10,7 @@ if (process.env.CI) {
 }
 
 export default defineDesktopProject({
-  plugins: [tailwindcss()],
+  plugins: [tailwindcss(), playwrightCommands()],
   test: {
     name: 'browser',
     include: ['src/**/*.test.tsx'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1)(vite@8.1.5)
+      vitest-browser-commands:
+        specifier: ^0.2.1
+        version: 0.2.1(@vitest/browser-playwright@4.1.10)(vitest@4.1.10)
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.8)(react@19.2.8)(vitest@4.1.10)
@@ -5978,6 +5981,17 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest-browser-commands@0.2.1:
+    resolution: {integrity: sha512-SCA6fjcO8uPLIvkzNzT8i0y+eUHx4hthZR2g7PSzHz01iG3qAm+rjfDuD1ot4taABsXolo1WaDByjKFuQ1IVww==}
+    peerDependencies:
+      '@vitest/browser-playwright': ^4.0.3
+      vitest: ^4.0.3
+    peerDependenciesMeta:
+      '@vitest/browser-playwright':
+        optional: true
+      vitest:
         optional: true
 
   vitest-browser-react@2.2.0:
@@ -12425,6 +12439,11 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       yaml: 2.9.0
+
+  vitest-browser-commands@0.2.1(@vitest/browser-playwright@4.1.10)(vitest@4.1.10):
+    optionalDependencies:
+      '@vitest/browser-playwright': 4.1.10(playwright@1.61.1)(vite@8.1.5)(vitest@4.1.10)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1)(vite@8.1.5)
 
   vitest-browser-react@2.2.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.8)(react@19.2.8)(vitest@4.1.10):
     dependencies:


### PR DESCRIPTION
The block handle only opens on pointer events that arrive after its hover extension attaches, so replace the single-shot `locator.hover()` with a helper that parks the mouse before rendering and hovers with multiple `mouse.move` steps via `vitest-browser-commands`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved desktop editor tests for more reliable hover and pointer interactions.
  * Added support for positioning the mouse during browser-based tests.
  * Updated touch-surface tests to verify block handles remain hidden.

* **Chores**
  * Added browser command support for desktop test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->