### PR TITLE
fix(desktop): restore daily stream row heights across remounts

### DIFF
--- a/apps/desktop/src/components/daily-stream.cache.test.tsx
+++ b/apps/desktop/src/components/daily-stream.cache.test.tsx
@@ -1,0 +1,154 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render } from 'vitest-browser-react'
+import { page } from 'vitest/browser'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useState, type ReactElement, type ReactNode } from 'react'
+import type { CacheSnapshot } from 'virtua'
+import { setBridge } from '@reflect/core'
+import { RouterProvider } from '@/routing/router'
+import { todayIso } from '@/lib/dates'
+import { createDayWindow } from '@/lib/day-window'
+import { readDailyStreamSnapshot, saveDailyStreamSnapshot } from '@/lib/daily-stream-cache'
+import '@/test-utils/locator'
+import { DailyStream } from './daily-stream'
+
+/**
+ * The remount contract: virtua's size cache dies with the stream component, so
+ * without persistence a back/forward return lays the window out from the flat
+ * 220px estimate and the restored scroll offset lands on different days. The
+ * snapshot store re-seeds the measurements, so the same offset points at the
+ * same content. Rows here load tall (2000px editors) to make measured and
+ * estimated layouts impossible to confuse.
+ */
+
+vi.mock('@/editor/note-editor', () => ({
+  NoteEditor: () => <div style={{ height: 2000 }} data-testid="fake-editor" />,
+}))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({
+    graph: { root: '/g', name: 'g', generation: 1 },
+    indexing: false,
+  }),
+}))
+vi.mock('@/providers/settings-provider', () => ({
+  useSettings: () => ({
+    settings: {
+      dateFormat: 'mdy',
+      timeFormat: '12h',
+      editorMarkdownSyntax: 'hide',
+      editorSpellCheck: true,
+      editorSmoothCaretAnimation: false,
+      editorDefaultBullet: false,
+      editorBulletAfterHeading: false,
+      aiProviders: [],
+      defaultAiProviderId: null,
+      chatSystemPrompt: '',
+      aiPrompts: [],
+    },
+    updateSettings: async () => {},
+    updateSettingsWith: () => {},
+  }),
+}))
+
+setBridge({
+  // Note reads resolve so every mounted day measures at its real (tall)
+  // height; everything else stays pending.
+  invoke: (cmd: string) =>
+    cmd === 'note_read' ? Promise.resolve('hello') : new Promise<never>(() => {}),
+  listen: async () => () => {},
+})
+
+afterEach(async () => {
+  await cleanup()
+})
+
+function StreamProviders({ children }: { children: ReactNode }): ReactElement {
+  const [client] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  )
+  return (
+    <QueryClientProvider client={client}>
+      <RouterProvider initialRoute={{ kind: 'today' }}>
+        <div style={{ height: 800 }}>{children}</div>
+      </RouterProvider>
+    </QueryClientProvider>
+  )
+}
+
+/** The index of the row under the scroll container's top edge, or -1. */
+function topRowIndex(container: Element): number {
+  const top = container.getBoundingClientRect().top
+  for (const el of container.querySelectorAll<HTMLElement>('[data-index]')) {
+    const rect = el.getBoundingClientRect()
+    if (rect.top <= top + 1 && rect.bottom > top + 1) {
+      return Number(el.dataset['index'])
+    }
+  }
+  return -1
+}
+
+async function waitForLoadedRows(): Promise<void> {
+  await vi.waitFor(() => {
+    expect(document.querySelectorAll('.reflect-note-loading').length).toBe(0)
+    expect(document.querySelectorAll('[data-testid=fake-editor]').length).toBeGreaterThan(0)
+  })
+}
+
+describe('daily-stream-cache', () => {
+  it('keeps a snapshot per graph root and rejects a window-anchor mismatch', () => {
+    const cache = [[100, 200], 220] as unknown as CacheSnapshot
+    saveDailyStreamSnapshot('/a', { cache, windowStart: '2020-01-01' })
+    expect(readDailyStreamSnapshot('/a', '2020-01-01')).toBe(cache)
+    expect(readDailyStreamSnapshot('/a', '2020-01-02')).toBeNull()
+    expect(readDailyStreamSnapshot('/b', '2020-01-01')).toBeNull()
+  })
+
+  it(
+    'remounts with its measured heights so the restored offset shows the same day',
+    { timeout: 20_000 },
+    async () => {
+      const view = await render(
+        <StreamProviders>
+          <DailyStream target={{ kind: 'today' }} />
+        </StreamProviders>,
+      )
+      const stream = page.getByTestId('daily-stream')
+      await vi.waitFor(() => expect(stream.element().scrollTop).toBeGreaterThan(0))
+      await waitForLoadedRows()
+
+      // Walk downward through several rows so the measured layout (2000px
+      // rows) diverges from the estimated one (220px rows) by dozens of rows'
+      // worth of offset.
+      for (let step = 0; step < 3; step++) {
+        stream.element().scrollTop += 3000
+        await waitForLoadedRows()
+      }
+      const container = stream.element()
+      const indexBefore = await vi.waitFor(() => {
+        const index = topRowIndex(container)
+        expect(index).toBeGreaterThan(0)
+        return index
+      })
+
+      // Unmount only the stream: the router (and its saved scroll offset)
+      // survives, as when navigating to a note and back.
+      await view.rerender(<StreamProviders>{null}</StreamProviders>)
+      expect(readDailyStreamSnapshot('/g', createDayWindow(todayIso()).start)).not.toBeNull()
+
+      await view.rerender(
+        <StreamProviders>
+          <DailyStream target={{ kind: 'today' }} />
+        </StreamProviders>,
+      )
+      const remounted = page.getByTestId('daily-stream').element()
+      await vi.waitFor(() => expect(remounted.scrollTop).toBeGreaterThan(0))
+      await waitForLoadedRows()
+      // Without the snapshot the offset lands ~2800px-per-row short and the
+      // top row is off by dozens of indexes; allow one row of settle noise.
+      await vi.waitFor(() =>
+        expect(Math.abs(topRowIndex(remounted) - indexBefore)).toBeLessThanOrEqual(1),
+      )
+      await view.unmount()
+    },
+  )
+})

--- a/apps/desktop/src/components/daily-stream.cache.test.tsx
+++ b/apps/desktop/src/components/daily-stream.cache.test.tsx
@@ -88,10 +88,29 @@ function topRowIndex(container: Element): number {
 }
 
 async function waitForLoadedRows(): Promise<void> {
-  await vi.waitFor(() => {
-    expect(document.querySelectorAll('.reflect-note-loading').length).toBe(0)
-    expect(document.querySelectorAll('[data-testid=fake-editor]').length).toBeGreaterThan(0)
-  })
+  await vi.waitFor(
+    () => {
+      expect(document.querySelectorAll('.reflect-note-loading').length).toBe(0)
+      expect(document.querySelectorAll('[data-testid=fake-editor]').length).toBeGreaterThan(0)
+    },
+    { timeout: 5000 },
+  )
+}
+
+/**
+ * Wait for the anchor's imperative scroll to finish: virtua's `scrollToIndex`
+ * keeps re-pinning the target while row sizes settle, so a programmatic
+ * scroll fired too early is snapped back.
+ */
+async function waitForStableScroll(el: Element): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      const before = el.scrollTop
+      await new Promise((resolve) => setTimeout(resolve, 200))
+      expect(el.scrollTop).toBe(before)
+    },
+    { timeout: 10_000 },
+  )
 }
 
 describe('daily-stream-cache', () => {
@@ -115,6 +134,7 @@ describe('daily-stream-cache', () => {
       const stream = page.getByTestId('daily-stream')
       await vi.waitFor(() => expect(stream.element().scrollTop).toBeGreaterThan(0))
       await waitForLoadedRows()
+      await waitForStableScroll(stream.element())
 
       // Walk downward through several rows so the measured layout (2000px
       // rows) diverges from the estimated one (220px rows) by dozens of rows'
@@ -122,6 +142,7 @@ describe('daily-stream-cache', () => {
       for (let step = 0; step < 3; step++) {
         stream.element().scrollTop += 3000
         await waitForLoadedRows()
+        await waitForStableScroll(stream.element())
       }
       const container = stream.element()
       const indexBefore = await vi.waitFor(() => {
@@ -145,8 +166,9 @@ describe('daily-stream-cache', () => {
       await waitForLoadedRows()
       // Without the snapshot the offset lands ~2800px-per-row short and the
       // top row is off by dozens of indexes; allow one row of settle noise.
-      await vi.waitFor(() =>
-        expect(Math.abs(topRowIndex(remounted) - indexBefore)).toBeLessThanOrEqual(1),
+      await vi.waitFor(
+        () => expect(Math.abs(topRowIndex(remounted) - indexBefore)).toBeLessThanOrEqual(1),
+        { timeout: 5000 },
       )
       await view.unmount()
     },

--- a/apps/desktop/src/components/daily-stream.focus.test.tsx
+++ b/apps/desktop/src/components/daily-stream.focus.test.tsx
@@ -84,6 +84,12 @@ vi.mock('@/components/note-pane', () => ({
     )
   },
 }))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({
+    graph: { root: '/g', name: 'g', generation: 1 },
+    indexing: false,
+  }),
+}))
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({
     settings: { dateFormat: 'mdy' },

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -244,7 +244,6 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
         {...(restoredCache !== null ? { cache: restoredCache } : {})}
         itemSize={ESTIMATED_DAY_HEIGHT}
         bufferSize={2 * ESTIMATED_DAY_HEIGHT}
-        shift={true}
       >
         {(_, index) => {
           const date = dateAtIndex(dayWindow, index)

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -6,8 +6,10 @@ import type { NoteEditorHandle } from '@/editor/note-editor'
 import { formatDayLabel, todayIso } from '@/lib/dates'
 import { cn } from '@/lib/utils'
 import { useSettings } from '@/providers/settings-provider'
+import { useGraph } from '@/providers/graph-provider'
 import { useToday } from '@/lib/use-today'
 import { createDayWindow, dateAtIndex, indexOfDate, neighborDate } from '@/lib/day-window'
+import { readDailyStreamSnapshot, saveDailyStreamSnapshot } from '@/lib/daily-stream-cache'
 import { useSetFocusedDailyDate } from '@/providers/focused-daily-provider'
 import { useRouter } from '@/routing/router'
 
@@ -55,6 +57,26 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
   const today = useToday()
   const targetDate = target.kind === 'today' ? today : target.date
   const { settings } = useSettings()
+  const { graph } = useGraph()
+  const graphRoot = graph?.root ?? null
+
+  // virtua's size cache dies with the component; without it a remount lays the
+  // whole window out from the flat estimate and a restored scroll offset lands
+  // on different content. Re-seed measurements from the last unmount's
+  // snapshot. Read in the state initializer: the `cache` prop is consumed once
+  // at store creation, so it must be present on the first render.
+  const [restoredCache] = useState(() =>
+    graphRoot !== null ? readDailyStreamSnapshot(graphRoot, dayWindow.start) : null,
+  )
+  useLayoutEffect(() => {
+    const handle = virtualizerRef.current
+    if (handle === null || graphRoot === null) {
+      return
+    }
+    return () => {
+      saveDailyStreamSnapshot(graphRoot, { cache: handle.cache, windowStart: dayWindow.start })
+    }
+  }, [graphRoot, dayWindow])
 
   // targetDate is read at arrival time, not reacted to. On the `today` route
   // it follows this component's live clock — the same value that paints the
@@ -219,6 +241,7 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
       <Virtualizer
         ref={virtualizerRef}
         data={data}
+        {...(restoredCache !== null ? { cache: restoredCache } : {})}
         itemSize={ESTIMATED_DAY_HEIGHT}
         bufferSize={2 * ESTIMATED_DAY_HEIGHT}
         shift={true}

--- a/apps/desktop/src/lib/daily-stream-cache.ts
+++ b/apps/desktop/src/lib/daily-stream-cache.ts
@@ -1,0 +1,30 @@
+import type { CacheSnapshot } from 'virtua'
+
+interface DailyStreamSnapshot {
+  cache: CacheSnapshot
+  /**
+   * The day window's first day when the snapshot was taken. The snapshot is
+   * positional (size per index) and the window anchors at mount-day, so the
+   * index↔date mapping shifts across midnight; alignment is only valid while
+   * this matches the mounting window's start.
+   */
+  windowStart: string
+}
+
+/**
+ * The daily stream's measured row heights, per graph root, surviving the
+ * stream's unmount (virtua's own cache dies with the component). Restoring
+ * them on remount keeps a saved scroll offset pointing at the same content
+ * instead of a layout re-estimated from scratch. Heights are hints: a stale
+ * value costs one ordinary resize compensation, never correctness.
+ */
+const snapshots = new Map<string, DailyStreamSnapshot>()
+
+export function saveDailyStreamSnapshot(root: string, snapshot: DailyStreamSnapshot): void {
+  snapshots.set(root, snapshot)
+}
+
+export function readDailyStreamSnapshot(root: string, windowStart: string): CacheSnapshot | null {
+  const saved = snapshots.get(root)
+  return saved !== undefined && saved.windowStart === windowStart ? saved.cache : null
+}


### PR DESCRIPTION
Persist the daily stream's virtua measurement cache across unmounts so back/forward returns land on the same content instead of drifting.