### PR TITLE
fix(desktop): keep daily rows at their last height while reloading

### DIFF
--- a/apps/desktop/src/components/daily-stream.focus.test.tsx
+++ b/apps/desktop/src/components/daily-stream.focus.test.tsx
@@ -84,6 +84,12 @@ vi.mock('@/components/note-pane', () => ({
     )
   },
 }))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({
+    graph: { root: '/g', name: 'g', generation: 1 },
+    indexing: false,
+  }),
+}))
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({
     settings: { dateFormat: 'mdy' },

--- a/apps/desktop/src/components/daily-stream.heights.test.tsx
+++ b/apps/desktop/src/components/daily-stream.heights.test.tsx
@@ -107,6 +107,22 @@ function NavigateTodayProbe({
   return null
 }
 
+/**
+ * Wait for the anchor's imperative scroll to finish: virtua's `scrollToIndex`
+ * keeps re-pinning the target while row sizes settle, so a programmatic
+ * scroll fired too early is snapped back.
+ */
+async function waitForStableScroll(el: Element): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      const before = el.scrollTop
+      await new Promise((resolve) => setTimeout(resolve, 200))
+      expect(el.scrollTop).toBe(before)
+    },
+    { timeout: 10_000 },
+  )
+}
+
 describe('daily note height memory', () => {
   it('stores heights per graph root and date', () => {
     rememberDailyPaneHeight('/a', '2020-01-01', 123)
@@ -147,12 +163,15 @@ describe('daily note height memory', () => {
           document.querySelector(`${todaySelector} [data-testid=fake-editor]`),
         ).not.toBeNull(),
       )
+      await waitForStableScroll(stream.element())
       const rowBefore = document.querySelector(todaySelector)!.getBoundingClientRect().height
 
       // Scroll far into the past so the row unmounts; its cleanup records the
       // pane height.
       stream.element().scrollTop -= 30000
-      await vi.waitFor(() => expect(document.querySelector(todaySelector)).toBeNull())
+      await vi.waitFor(() => expect(document.querySelector(todaySelector)).toBeNull(), {
+        timeout: 5000,
+      })
       const remembered = savedDailyPaneHeight('/g', today)
       expect(remembered).toBeGreaterThanOrEqual(1000)
 
@@ -162,33 +181,34 @@ describe('daily note height memory', () => {
       act(() => {
         navigateToday()
       })
-      await vi.waitFor(() => {
-        const placeholder = document.querySelector(`${todaySelector} .reflect-note-loading`)
-        expect(placeholder).not.toBeNull()
-        expect(placeholder!.getBoundingClientRect().height).toBeCloseTo(remembered!, 0)
-      })
-      expect(
-        document.querySelector(todaySelector)!.getBoundingClientRect().height,
-      ).toBeCloseTo(rowBefore, 0)
-
-      // A never-loaded neighbor keeps the class-based minimum: no inline height.
-      const neighbor = document.querySelector(
-        `[data-index="${todayIndex - 2}"] .reflect-note-loading`,
+      await vi.waitFor(
+        () => {
+          const placeholder = document.querySelector(`${todaySelector} .reflect-note-loading`)
+          expect(placeholder).not.toBeNull()
+          expect(
+            Math.abs(placeholder!.getBoundingClientRect().height - remembered!),
+          ).toBeLessThan(2)
+        },
+        { timeout: 5000 },
       )
-      expect(neighbor).not.toBeNull()
-      expect((neighbor as HTMLElement).style.height).toBe('')
-      expect(neighbor!.className).toMatch(/min-h-/)
+      expect(
+        Math.abs(document.querySelector(todaySelector)!.getBoundingClientRect().height - rowBefore),
+      ).toBeLessThan(2)
 
       // The note arriving must not change the row's size: load it and compare.
+      // (In a waitFor: the loading→ready swap leaves the placeholder's padding
+      // in the computed style for a beat before the recalc settles.)
       await resolveRead(dailyPath(today))
       await vi.waitFor(() =>
         expect(
           document.querySelector(`${todaySelector} [data-testid=fake-editor]`),
         ).not.toBeNull(),
       )
-      expect(
-        document.querySelector(todaySelector)!.getBoundingClientRect().height,
-      ).toBeCloseTo(rowBefore, 0)
+      await vi.waitFor(() =>
+        expect(
+          Math.abs(document.querySelector(todaySelector)!.getBoundingClientRect().height - rowBefore),
+        ).toBeLessThan(2),
+      )
       await view.unmount()
     },
   )

--- a/apps/desktop/src/components/daily-stream.heights.test.tsx
+++ b/apps/desktop/src/components/daily-stream.heights.test.tsx
@@ -1,0 +1,195 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render } from 'vitest-browser-react'
+import { page } from 'vitest/browser'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, useEffect, useState, type ReactElement, type ReactNode } from 'react'
+import { dailyPath, setBridge } from '@reflect/core'
+import { RouterProvider, useRouter } from '@/routing/router'
+import { todayIso } from '@/lib/dates'
+import { createDayWindow, indexOfDate } from '@/lib/day-window'
+import { rememberDailyPaneHeight, savedDailyPaneHeight } from '@/lib/daily-note-heights'
+import '@/test-utils/locator'
+import { DailyStream } from './daily-stream'
+
+/**
+ * The placeholder-height contract: a daily row that scrolls back into view
+ * remounts as a loading placeholder while its note reloads. Without a height
+ * memory the placeholder collapses to the minimum and the row jumps back to
+ * full height when the note arrives — the visible scroll jump. With it, the
+ * placeholder reserves the row's last height, so both transitions are
+ * size-neutral. Reads here resolve only by hand, keeping the loading phase
+ * open for assertions.
+ */
+
+vi.mock('@/editor/note-editor', () => ({
+  NoteEditor: () => <div style={{ height: 1000 }} data-testid="fake-editor" />,
+}))
+vi.mock('@/providers/graph-provider', () => ({
+  useGraph: () => ({
+    graph: { root: '/g', name: 'g', generation: 1 },
+    indexing: false,
+  }),
+}))
+vi.mock('@/providers/settings-provider', () => ({
+  useSettings: () => ({
+    settings: {
+      dateFormat: 'mdy',
+      timeFormat: '12h',
+      editorMarkdownSyntax: 'hide',
+      editorSpellCheck: true,
+      editorSmoothCaretAnimation: false,
+      editorDefaultBullet: false,
+      editorBulletAfterHeading: false,
+      aiProviders: [],
+      defaultAiProviderId: null,
+      chatSystemPrompt: '',
+      aiPrompts: [],
+    },
+    updateSettings: async () => {},
+    updateSettingsWith: () => {},
+  }),
+}))
+
+const pendingReads = new Map<string, Array<(markdown: string) => void>>()
+
+setBridge({
+  invoke: (cmd: string, args?: unknown) => {
+    if (cmd === 'note_read') {
+      const { path } = args as { path: string }
+      return new Promise<string>((resolve) => {
+        const queue = pendingReads.get(path) ?? []
+        queue.push(resolve)
+        pendingReads.set(path, queue)
+      })
+    }
+    return new Promise<never>(() => {})
+  },
+  listen: async () => () => {},
+})
+
+async function resolveRead(path: string): Promise<void> {
+  await vi.waitFor(() => expect(pendingReads.has(path)).toBe(true))
+  await act(async () => {
+    for (const resolve of pendingReads.get(path) ?? []) {
+      resolve('hello')
+    }
+    pendingReads.delete(path)
+  })
+}
+
+afterEach(async () => {
+  await cleanup()
+  pendingReads.clear()
+})
+
+function StreamProviders({ children }: { children: ReactNode }): ReactElement {
+  const [client] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  )
+  return (
+    <QueryClientProvider client={client}>
+      <RouterProvider initialRoute={{ kind: 'today' }}>
+        <div style={{ height: 800 }}>{children}</div>
+      </RouterProvider>
+    </QueryClientProvider>
+  )
+}
+
+function NavigateTodayProbe({
+  onReady,
+}: {
+  onReady: (navigateToday: () => void) => void
+}): null {
+  const { navigate } = useRouter()
+  useEffect(() => {
+    onReady(() => navigate({ kind: 'today' }))
+  }, [navigate, onReady])
+  return null
+}
+
+describe('daily note height memory', () => {
+  it('stores heights per graph root and date', () => {
+    rememberDailyPaneHeight('/a', '2020-01-01', 123)
+    expect(savedDailyPaneHeight('/a', '2020-01-01')).toBe(123)
+    expect(savedDailyPaneHeight('/a', '2020-01-02')).toBeUndefined()
+    expect(savedDailyPaneHeight('/b', '2020-01-01')).toBeUndefined()
+    rememberDailyPaneHeight('/a', '2020-01-01', 456)
+    expect(savedDailyPaneHeight('/a', '2020-01-01')).toBe(456)
+  })
+
+  it(
+    'remounts a row at its remembered height while the note reloads',
+    { timeout: 20_000 },
+    async () => {
+      const today = todayIso()
+      const todayIndex = indexOfDate(createDayWindow(today), today)
+      const todaySelector = `[data-index="${todayIndex}"]`
+      let navigateToday: () => void = () => {
+        throw new Error('navigate not ready')
+      }
+      const view = await render(
+        <StreamProviders>
+          <DailyStream target={{ kind: 'today' }} />
+          <NavigateTodayProbe
+            onReady={(run) => {
+              navigateToday = run
+            }}
+          />
+        </StreamProviders>,
+      )
+      const stream = page.getByTestId('daily-stream')
+      await vi.waitFor(() => expect(stream.element().scrollTop).toBeGreaterThan(0))
+
+      // Load today's note: the row grows to the 1000px editor plus chrome.
+      await resolveRead(dailyPath(today))
+      await vi.waitFor(() =>
+        expect(
+          document.querySelector(`${todaySelector} [data-testid=fake-editor]`),
+        ).not.toBeNull(),
+      )
+      const rowBefore = document.querySelector(todaySelector)!.getBoundingClientRect().height
+
+      // Scroll far into the past so the row unmounts; its cleanup records the
+      // pane height.
+      stream.element().scrollTop -= 30000
+      await vi.waitFor(() => expect(document.querySelector(todaySelector)).toBeNull())
+      const remembered = savedDailyPaneHeight('/g', today)
+      expect(remembered).toBeGreaterThanOrEqual(1000)
+
+      // Return to today. The note read is pending again, so the row is a
+      // loading placeholder — now sized to the remembered height instead of
+      // collapsing to the minimum.
+      act(() => {
+        navigateToday()
+      })
+      await vi.waitFor(() => {
+        const placeholder = document.querySelector(`${todaySelector} .reflect-note-loading`)
+        expect(placeholder).not.toBeNull()
+        expect(placeholder!.getBoundingClientRect().height).toBeCloseTo(remembered!, 0)
+      })
+      expect(
+        document.querySelector(todaySelector)!.getBoundingClientRect().height,
+      ).toBeCloseTo(rowBefore, 0)
+
+      // A never-loaded neighbor keeps the class-based minimum: no inline height.
+      const neighbor = document.querySelector(
+        `[data-index="${todayIndex - 2}"] .reflect-note-loading`,
+      )
+      expect(neighbor).not.toBeNull()
+      expect((neighbor as HTMLElement).style.height).toBe('')
+      expect(neighbor!.className).toMatch(/min-h-/)
+
+      // The note arriving must not change the row's size: load it and compare.
+      await resolveRead(dailyPath(today))
+      await vi.waitFor(() =>
+        expect(
+          document.querySelector(`${todaySelector} [data-testid=fake-editor]`),
+        ).not.toBeNull(),
+      )
+      expect(
+        document.querySelector(todaySelector)!.getBoundingClientRect().height,
+      ).toBeCloseTo(rowBefore, 0)
+      await view.unmount()
+    },
+  )
+})

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -6,8 +6,10 @@ import type { NoteEditorHandle } from '@/editor/note-editor'
 import { formatDayLabel, todayIso } from '@/lib/dates'
 import { cn } from '@/lib/utils'
 import { useSettings } from '@/providers/settings-provider'
+import { useGraph } from '@/providers/graph-provider'
 import { useToday } from '@/lib/use-today'
 import { createDayWindow, dateAtIndex, indexOfDate, neighborDate } from '@/lib/day-window'
+import { rememberDailyPaneHeight, savedDailyPaneHeight } from '@/lib/daily-note-heights'
 import { useSetFocusedDailyDate } from '@/providers/focused-daily-provider'
 import { useRouter } from '@/routing/router'
 
@@ -55,6 +57,41 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
   const today = useToday()
   const targetDate = target.kind === 'today' ? today : target.date
   const { settings } = useSettings()
+  const { graph } = useGraph()
+  const graphRoot = graph?.root ?? null
+
+  // Mirrored like targetDate: the measuring ref callbacks below are cached per
+  // date for their whole life, so they read the root at cleanup time instead
+  // of capturing a possibly stale value.
+  const graphRootRef = useRef(graphRoot)
+  useLayoutEffect(() => {
+    graphRootRef.current = graphRoot
+  }, [graphRoot])
+
+  // One measuring ref callback per date, cached: an inline ref would be a new
+  // function every render, and React 19 re-runs cleanup + setup for a changed
+  // ref — a forced layout read per visible row per render. The cleanup runs
+  // just before the row's DOM leaves the document, capturing the height the
+  // remounted placeholder should reserve.
+  const [paneMeasureRefs] = useState(
+    () => new Map<string, (el: HTMLDivElement) => () => void>(),
+  )
+  const paneMeasureRef = useCallback(
+    (date: string) => {
+      let ref = paneMeasureRefs.get(date)
+      if (ref === undefined) {
+        ref = (el) => () => {
+          const root = graphRootRef.current
+          if (root !== null) {
+            rememberDailyPaneHeight(root, date, el.offsetHeight)
+          }
+        }
+        paneMeasureRefs.set(date, ref)
+      }
+      return ref
+    },
+    [paneMeasureRefs],
+  )
 
   // targetDate is read at arrival time, not reacted to. On the `today` route
   // it follows this component's live clock — the same value that paints the
@@ -234,6 +271,8 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
           const focusSelection =
             pendingFocus !== null && pendingFocus.date === date ? pendingFocus.selection : null
           const autoFocus = focusSelection !== null
+          const paneHeight =
+            graphRoot !== null ? savedDailyPaneHeight(graphRoot, date) : undefined
           return (
             <section
               key={date}
@@ -251,18 +290,21 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
               >
                 {formatDayLabel(date, settings.dateFormat)}
               </h2>
-              <NotePane
-                path={dailyPath(date)}
-                dailyDate={date}
-                registerHandle={registerHandle}
-                onExitBoundary={handleExitBoundary}
-                lazy
-                autoFocus={autoFocus}
-                autoFocusSelection={focusSelection ?? 'start'}
-                onAutoFocused={consumeFocus}
-                gutterClassName={CONTENT_GUTTER}
-                editorClassName={isPast ? 'min-h-[100px]' : 'min-h-[60vh]'}
-              />
+              <div ref={paneMeasureRef(date)}>
+                <NotePane
+                  path={dailyPath(date)}
+                  dailyDate={date}
+                  registerHandle={registerHandle}
+                  onExitBoundary={handleExitBoundary}
+                  lazy
+                  autoFocus={autoFocus}
+                  autoFocusSelection={focusSelection ?? 'start'}
+                  onAutoFocused={consumeFocus}
+                  gutterClassName={CONTENT_GUTTER}
+                  editorClassName={isPast ? 'min-h-[100px]' : 'min-h-[60vh]'}
+                  {...(paneHeight !== undefined ? { placeholderHeight: paneHeight } : {})}
+                />
+              </div>
             </section>
           )
         }}

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -79,6 +79,14 @@ interface NotePaneProps {
    */
   gutterClassName?: string
   /**
+   * Exact height for the loading placeholder: the pane last rendered this
+   * tall at this path, so reserving the same space keeps a virtualized row's
+   * size stable across a remount instead of collapsing and jumping back when
+   * the note arrives. The `editorClassName` min-height stays as the floor and
+   * the first-mount fallback.
+   */
+  placeholderHeight?: number
+  /**
    * Render the built-in desktop backlinks panel below the note (default).
    * The mobile surfaces pass `false` and mount their own touch-chrome
    * `IncomingBacklinks` section over the same data layer.
@@ -125,6 +133,7 @@ export function NotePaneComponent({
   className,
   editorClassName,
   gutterClassName,
+  placeholderHeight,
   showBacklinks = true,
   dailyDate,
   registerHandle,
@@ -257,6 +266,7 @@ export function NotePaneComponent({
     // daily-stream row reads as flicker while the stream anchors.
     return (
       <div
+        {...(placeholderHeight !== undefined ? { style: { height: placeholderHeight } } : {})}
         className={cn(
           'reflect-note-loading px-1 py-2 text-sm text-text-muted',
           gutterClassName,

--- a/apps/desktop/src/lib/daily-note-heights.ts
+++ b/apps/desktop/src/lib/daily-note-heights.ts
@@ -1,0 +1,20 @@
+/**
+ * Last rendered pane height per (graph root, day), so a daily row remounts
+ * its loading placeholder at the height the note will occupy once loaded,
+ * instead of collapsing to the minimum and jumping back when the note
+ * arrives. Heights are hints: a stale value costs one ordinary resize
+ * compensation, never correctness.
+ */
+const heights = new Map<string, number>()
+
+function key(root: string, date: string): string {
+  return `${root}\n${date}`
+}
+
+export function rememberDailyPaneHeight(root: string, date: string, height: number): void {
+  heights.set(key(root, date), height)
+}
+
+export function savedDailyPaneHeight(root: string, date: string): number | undefined {
+  return heights.get(key(root, date))
+}


### PR DESCRIPTION
Remember each daily row's rendered height and size its loading placeholder to match, so rows scrolled back into view no longer collapse and jump when their note loads.