### PR TITLE
fix: drain task captures with Reflect's round (+) bullet so they register as tasks

### DIFF
--- a/packages/core/src/actions/capture-drain.test.ts
+++ b/packages/core/src/actions/capture-drain.test.ts
@@ -523,12 +523,12 @@ describe('drainCaptureInbox (text captures)', () => {
     expect(spool.size).toBe(0)
   })
 
-  it('appends a task envelope as an open GFM checkbox', async () => {
+  it('appends a task envelope as a round (+) task the Tasks projection indexes', async () => {
     addTextSpool(textEnvelope({ kind: 'task', text: 'buy milk' }))
 
     await drain()
 
-    expect(files.get(DAILY)).toBe('- [ ] buy milk\n')
+    expect(files.get(DAILY)).toBe('+ [ ] buy milk\n')
   })
 
   it('appends after existing daily content as its own block', async () => {

--- a/packages/core/src/actions/capture-drain.ts
+++ b/packages/core/src/actions/capture-drain.ts
@@ -289,7 +289,10 @@ function parseEnvelope(raw: string): InboxEnvelope | null {
 async function drainTextCapture(envelope: TextCaptureEnvelope, generation: number): Promise<boolean> {
   const daily = dailyPath(captureLocalDate(new Date(envelope.capturedAt)))
   const dailySource = await noteSource(daily, generation)
-  const line = envelope.kind === 'task' ? `- [ ] ${envelope.text}` : `- ${envelope.text}`
+  // `+ ` is Reflect's round-task bullet — the only marker the Tasks
+  // projection indexes (see `snippet-tasks.ts`'s `round`). A `-` bullet here
+  // would render a clickable checkbox that never appears in the Tasks view.
+  const line = envelope.kind === 'task' ? `+ [ ] ${envelope.text}` : `- ${envelope.text}`
   const present = dailySource
     .split('\n')
     .some((existing) => existing.replace(/\r$/, '') === line)

--- a/packages/core/src/actions/capture-envelope.ts
+++ b/packages/core/src/actions/capture-envelope.ts
@@ -96,7 +96,7 @@ export const TEXT_CAPTURE_MAX_LENGTH = 10_000
 /**
  * What a text capture materializes as on the capture-day daily note. One
  * vocabulary end-to-end: the `reflect://append`/`reflect://task` URL verb IS
- * the envelope kind IS the drain behavior (`- ` bullet / `- [ ]` task).
+ * the envelope kind IS the drain behavior (`- ` bullet / `+ [ ]` round task).
  */
 export const textCaptureKindSchema = z.enum(['append', 'task'])
 


### PR DESCRIPTION
## Summary

Fixes #977: text captures spooled with `kind: 'task'` (`reflect://task?text=…`, and any other producer writing a `textCaptureEnvelopeSchema` envelope — e.g. the [Reflect Open Raycast extension](https://www.raycast.com/jaseem_ts/reflect-open), whose user reported this) were drained onto the daily note as a `-`-bulleted GFM checkbox instead of Reflect's round (`+`) task syntax.

`packages/core/src/markdown/extract.ts`'s `hasRoundTaskListMarker` documents the Tasks projection's actual rule:

> A Reflect task is the round Meowdown checkbox syntax… Square checklist items (`- [ ]`/`* [ ]`) are intentionally not projected into Tasks.

So a `kind: 'task'` capture rendered as a clickable-but-inert checkbox that never appeared in the Tasks view — despite `docs/deep-links.md` and the `capture-envelope.ts` schema comment both describing it as producing "an open task."

## Change

One-line fix in `drainTextCapture()` (`packages/core/src/actions/capture-drain.ts`): `kind: 'task'` now writes `+ [ ] …` instead of `- [ ] …`. Plus the one doc comment and one test expectation that encoded the old behavior.

## Testing

- `pnpm test --run` (full suite): **3,732/3,732 passed**, 355 files
- `pnpm typecheck` (all packages): clean
- `pnpm lint`: 0 errors (pre-existing warnings only, in files this PR doesn't touch)
- **No live-diary or desktop-app UI test was performed** — verification is source-level (`extract.ts`, `snippet-tasks.ts`, `use-task-actions.ts` all independently confirm `+` is the only marker the Tasks projection and the app's own native task-creation path use) plus the automated suite above.

## Open question for maintainers

Opening this as a **draft**: the existing test this PR changes named the old behavior accurately rather than aspirationally (`'appends a task envelope as an open GFM checkbox'`), and `extract.ts`'s comment says square checklist items are *intentionally* excluded from Tasks — so it's possible the drain writing `-` instead of `+` for external captures was a deliberate choice (e.g. to avoid an external capture surprising a user by silently populating their curated Tasks view), not an oversight. If that's the case, I'd rather adjust the docs/schema wording (`capture-envelope.ts`, `docs/deep-links.md`) to say "checkbox" instead of "task" than change the drain behavior. Happy to go either direction — flagging so a maintainer can confirm intent before this merges.

Ref #977.
