### PR TITLE
feat: add a checkbox text-capture kind and drain task as a round task

### DIFF
--- a/apps/desktop/src/lib/deep-links/deep-link.ts
+++ b/apps/desktop/src/lib/deep-links/deep-link.ts
@@ -25,7 +25,7 @@ export const DEEP_LINK_TEXT_MAX_LENGTH = TEXT_CAPTURE_MAX_LENGTH
  *   `tasks`) that map straight onto {@link Route}.
  * - `openNote` — `note/<target>`, where `<target>` still needs resolution
  *   (frontmatter id → date → title → alias) against the open graph's index.
- * - `capture` — `append`/`task` write links, spooled into `.reflect/inbox/`.
+ * - `capture` — `append`/`checkbox`/`task` write links, spooled into `.reflect/inbox/`.
  *   The capture kind is core's {@link TextCaptureKind} — the URL verb, the
  *   envelope kind, and the drain behavior share the one vocabulary.
  */

--- a/apps/desktop/src/lib/deep-links/handle.test.ts
+++ b/apps/desktop/src/lib/deep-links/handle.test.ts
@@ -163,6 +163,17 @@ describe('handleDeepLink', () => {
     expect(operationHandle.done).toHaveBeenCalled()
   })
 
+  it('spools a checkbox envelope for a checkbox link', async () => {
+    await handle('reflect://checkbox?text=pack+a+bag')
+
+    const [, json] = spoolMock.mock.calls[0]!
+    const envelope = textCaptureEnvelopeSchema.parse(JSON.parse(json))
+    expect(envelope.kind).toBe('checkbox')
+    expect(envelope.text).toBe('pack a bag')
+    expect(startOperationMock).toHaveBeenCalledWith('Checkbox added to today')
+    expect(operationHandle.done).toHaveBeenCalled()
+  })
+
   it('surfaces a spool failure instead of claiming success', async () => {
     spoolMock.mockRejectedValue(new Error('stale generation'))
 

--- a/apps/desktop/src/lib/deep-links/handle.ts
+++ b/apps/desktop/src/lib/deep-links/handle.ts
@@ -63,7 +63,12 @@ export async function handleDeepLink(url: string, io: DeepLinkIo): Promise<void>
       return
     }
     case 'capture': {
-      const label = link.capture === 'task' ? 'Task added to today' : 'Added to today'
+      const label =
+        link.capture === 'task'
+          ? 'Task added to today'
+          : link.capture === 'checkbox'
+            ? 'Checkbox added to today'
+            : 'Added to today'
       try {
         // The URL parser enforces the same text constraints, so this parse is
         // belt-and-braces — but it is fallible, and a schema tightening must

--- a/apps/desktop/src/lib/deep-links/parse.test.ts
+++ b/apps/desktop/src/lib/deep-links/parse.test.ts
@@ -83,6 +83,11 @@ describe('parseDeepLink', () => {
       capture: 'append',
       text: 'hello world',
     })
+    expect(parseDeepLink('reflect://checkbox?text=pack+a+bag')).toEqual({
+      kind: 'capture',
+      capture: 'checkbox',
+      text: 'pack a bag',
+    })
     expect(parseDeepLink('reflect://task?text=Buy+milk')).toEqual({
       kind: 'capture',
       capture: 'task',

--- a/apps/desktop/src/lib/deep-links/parse.ts
+++ b/apps/desktop/src/lib/deep-links/parse.ts
@@ -44,6 +44,8 @@ export function parseDeepLink(raw: string): DeepLink | null {
       return argument === '' ? null : { kind: 'openNote', target: argument }
     case 'append':
       return captureLink('append', url, argument)
+    case 'checkbox':
+      return captureLink('checkbox', url, argument)
     case 'task':
       return captureLink('task', url, argument)
     default:

--- a/docs/deep-links.md
+++ b/docs/deep-links.md
@@ -39,8 +39,13 @@ are addressed by date instead. A human-written
 
 ```text
 reflect://append?text=call%20the%20bank    a bullet on today's daily note
-reflect://task?text=buy%20milk             an open task on today's daily note
+reflect://checkbox?text=pack%20a%20bag     a square checkbox on today's daily note
+reflect://task?text=buy%20milk             a round task on today's daily note (shows in Tasks)
 ```
+
+`task` writes Reflect's round (`+`) task, so it appears in the Tasks view;
+`checkbox` writes a plain square (`- [ ]`) checkbox that stays on the daily
+note only. `append` writes a plain bullet.
 
 A URL scheme is a world-invokable surface — any web page can attempt
 `reflect://` — so writes are deliberately narrow: **one line of plain text,
@@ -51,9 +56,9 @@ browser captures use — never spliced directly into a note by the URL
 handler. There is no URL that writes into an arbitrary note, creates a note
 with content, or runs a command.
 
-Success and failure surface on the status line ("Added to today", "Task
-added to today"); the appended line is deduplicated exactly, so a crashed
-drain re-runs cleanly.
+Success and failure surface on the status line ("Added to today", "Checkbox
+added to today", "Task added to today"); the appended line is deduplicated
+exactly, so a crashed drain re-runs cleanly.
 
 ## Platform notes
 

--- a/packages/core/src/actions/capture-drain.test.ts
+++ b/packages/core/src/actions/capture-drain.test.ts
@@ -523,12 +523,20 @@ describe('drainCaptureInbox (text captures)', () => {
     expect(spool.size).toBe(0)
   })
 
-  it('appends a task envelope as an open GFM checkbox', async () => {
+  it('appends a task envelope as a round (+) task the Tasks view projects', async () => {
     addTextSpool(textEnvelope({ kind: 'task', text: 'buy milk' }))
 
     await drain()
 
-    expect(files.get(DAILY)).toBe('- [ ] buy milk\n')
+    expect(files.get(DAILY)).toBe('+ [ ] buy milk\n')
+  })
+
+  it('appends a checkbox envelope as a square GFM checkbox', async () => {
+    addTextSpool(textEnvelope({ kind: 'checkbox', text: 'pack a bag' }))
+
+    await drain()
+
+    expect(files.get(DAILY)).toBe('- [ ] pack a bag\n')
   })
 
   it('appends after existing daily content as its own block', async () => {

--- a/packages/core/src/actions/capture-drain.ts
+++ b/packages/core/src/actions/capture-drain.ts
@@ -289,7 +289,14 @@ function parseEnvelope(raw: string): InboxEnvelope | null {
 async function drainTextCapture(envelope: TextCaptureEnvelope, generation: number): Promise<boolean> {
   const daily = dailyPath(captureLocalDate(new Date(envelope.capturedAt)))
   const dailySource = await noteSource(daily, generation)
-  const line = envelope.kind === 'task' ? `- [ ] ${envelope.text}` : `- ${envelope.text}`
+  // `task` is Reflect's round `+` checkbox, the only marker the Tasks
+  // projection reads; `checkbox` is the square `- [ ]`, an inert daily item.
+  const line =
+    envelope.kind === 'task'
+      ? `+ [ ] ${envelope.text}`
+      : envelope.kind === 'checkbox'
+        ? `- [ ] ${envelope.text}`
+        : `- ${envelope.text}`
   const present = dailySource
     .split('\n')
     .some((existing) => existing.replace(/\r$/, '') === line)

--- a/packages/core/src/actions/capture-envelope.ts
+++ b/packages/core/src/actions/capture-envelope.ts
@@ -95,10 +95,14 @@ export const TEXT_CAPTURE_MAX_LENGTH = 10_000
 
 /**
  * What a text capture materializes as on the capture-day daily note. One
- * vocabulary end-to-end: the `reflect://append`/`reflect://task` URL verb IS
- * the envelope kind IS the drain behavior (`- ` bullet / `- [ ]` task).
+ * vocabulary end-to-end: the `reflect://append`/`reflect://checkbox`/
+ * `reflect://task` URL verb IS the envelope kind IS the drain behavior
+ * (`- ` bullet / `- [ ]` square checkbox / `+ [ ]` round task). Only the
+ * round `+` task is projected into the Tasks view; `checkbox` is an inert
+ * daily-note item, the same square-vs-round split the editor draws between a
+ * plain checkbox and a real task.
  */
-export const textCaptureKindSchema = z.enum(['append', 'task'])
+export const textCaptureKindSchema = z.enum(['append', 'checkbox', 'task'])
 
 /**
  * Where a text capture originated. Deliberately separate from
@@ -110,11 +114,12 @@ export const textCaptureKindSchema = z.enum(['append', 'task'])
 export const textCaptureSourceSchema = z.enum(['deep-link', 'ios-share'])
 
 /**
- * A text write (`reflect://append?text=…` / `reflect://task?text=…`),
- * spooled into the same capture inbox the native-messaging host writes. One
- * single line of plain text — the drain appends it to the capture-day daily
- * note as a bullet (`append`) or an open task (`task`), so an envelope can
- * never smuggle extra markdown blocks into the graph.
+ * A text write (`reflect://append?text=…` / `reflect://checkbox?text=…` /
+ * `reflect://task?text=…`), spooled into the same capture inbox the
+ * native-messaging host writes. One single line of plain text — the drain
+ * appends it to the capture-day daily note as a bullet (`append`), a square
+ * checkbox (`checkbox`), or a round task (`task`), so an envelope can never
+ * smuggle extra markdown blocks into the graph.
  */
 export const textCaptureEnvelopeSchema = z.object({
   /** Envelope format version; bump on breaking changes. */


### PR DESCRIPTION
Resolves #977
Resolves #978

Resolves #977 by giving text captures three explicit kinds: `append` (plain bullet), `checkbox` (square `- [ ]`), and `task` (round `+ [ ]`, projected into the Tasks view), so a captured task registers as a real task while an inert checkbox stays available under its own `reflect://checkbox` verb. This is a superset alternative to the binary fix in #978.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `reflect://checkbox?text=...` links to create square checklist items in today’s daily note.
  * Added checkbox-specific success messaging and capture handling.
  * Preserved existing task and text capture behavior, including duplicate prevention.

* **Documentation**
  * Documented the new checkbox deep-link format and its daily-note behavior.

* **Tests**
  * Added coverage for parsing, handling, and rendering checkbox captures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->