### PR TITLE
fix: restore wiki links with colon titles

### DIFF
--- a/apps/desktop/src/components/backlink-snippet.test.tsx
+++ b/apps/desktop/src/components/backlink-snippet.test.tsx
@@ -2,6 +2,7 @@ import { render } from 'vitest-browser-react'
 import { userEvent } from 'vitest/browser'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WikilinkClickHandler } from '@meowdown/core'
 import type { SnippetTask } from '@reflect/core'
 import { BacklinkSnippet } from './backlink-snippet'
 
@@ -39,14 +40,22 @@ function anchors(): SnippetTask[] {
 }
 
 function renderSnippet(tasks: SnippetTask[] = anchors()) {
+  return renderSnippetText(SNIPPET, vi.fn(), tasks)
+}
+
+function renderSnippetText(
+  text: string,
+  onWikilinkClick: WikilinkClickHandler = vi.fn(),
+  tasks: SnippetTask[] = [],
+) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={client}>
       <BacklinkSnippet
-        text={SNIPPET}
+        text={text}
         notePath="notes/meeting.md"
         tasks={tasks}
-        onWikilinkClick={() => {}}
+        onWikilinkClick={onWikilinkClick}
         resolveImageUrl={() => undefined}
       />
     </QueryClientProvider>,
@@ -149,6 +158,133 @@ describe('BacklinkSnippet task checkboxes', () => {
     const box = view.container.querySelector('input[type="checkbox"]')!
     await userEvent.click(box, { force: true })
     expect(toggleTask).not.toHaveBeenCalled()
+    await view.unmount()
+  })
+})
+
+describe('BacklinkSnippet wiki-link rendering', () => {
+  const regressionMatrix: Array<{ markdown: string; label: string; target: string }> = [
+    {
+      markdown: '[[Test: Colon Link]]',
+      label: 'Test: Colon Link',
+      target: 'Test: Colon Link',
+    },
+    {
+      markdown: '[[Test Colon Link]]',
+      label: 'Test Colon Link',
+      target: 'Test Colon Link',
+    },
+    {
+      markdown: '[[Test:Colon NoSpace Link]]',
+      label: 'Test:Colon NoSpace Link',
+      target: 'Test:Colon NoSpace Link',
+    },
+    {
+      markdown: '[[Test 1:19 Digit Colon]]',
+      label: 'Test 1:19 Digit Colon',
+      target: 'Test 1:19 Digit Colon',
+    },
+    {
+      markdown: '[[Test: Colon And Parens (2026-07-28)]]',
+      label: 'Test: Colon And Parens (2026-07-28)',
+      target: 'Test: Colon And Parens (2026-07-28)',
+    },
+    {
+      markdown: '[[Test Long With Parens & Ampersand Follow-up (2026-07-28 1208) - Suffix Segment]]',
+      label: 'Test Long With Parens & Ampersand Follow-up (2026-07-28 1208) - Suffix Segment',
+      target: 'Test Long With Parens & Ampersand Follow-up (2026-07-28 1208) - Suffix Segment',
+    },
+    {
+      markdown: '[[Meeting: VendorA x CompanyB AI Marketplace (2026-07-27)]]',
+      label: 'Meeting: VendorA x CompanyB AI Marketplace (2026-07-27)',
+      target: 'Meeting: VendorA x CompanyB AI Marketplace (2026-07-27)',
+    },
+    {
+      markdown:
+        '[[Meeting: AI Widget Builder Pricing Strategy & Partner Deal Follow-up (2026-07-28 1208) - CompanyB Forecast Meeting]]',
+      label:
+        'Meeting: AI Widget Builder Pricing Strategy & Partner Deal Follow-up (2026-07-28 1208) - CompanyB Forecast Meeting',
+      target:
+        'Meeting: AI Widget Builder Pricing Strategy & Partner Deal Follow-up (2026-07-28 1208) - CompanyB Forecast Meeting',
+    },
+  ]
+
+  it.each(regressionMatrix)(
+    'renders and clicks $markdown as a wiki link',
+    async ({ markdown, label, target }) => {
+      const onWikilinkClick = vi.fn<WikilinkClickHandler>()
+      const view = await renderSnippetText(`See ${markdown}.`, onWikilinkClick)
+
+      const chip = view.getByTestId('wikilink')
+      await expect.element(chip).toHaveTextContent(label)
+      await chip.click()
+
+      await vi.waitFor(() => expect(onWikilinkClick).toHaveBeenCalledTimes(1))
+      expect(onWikilinkClick.mock.calls[0]?.[0]).toMatchObject({ target })
+      await view.unmount()
+    },
+  )
+
+  const boundaryCases: Array<{ markdown: string; label: string; target: string }> = [
+    { markdown: '[[Test:19]]', label: 'Test:19', target: 'Test:19' },
+    { markdown: '[[19:Test]]', label: '19:Test', target: '19:Test' },
+    { markdown: '[[Trailing:]]', label: 'Trailing:', target: 'Trailing:' },
+    { markdown: '[[:Leading]]', label: ':Leading', target: ':Leading' },
+    { markdown: '[[A:B:C]]', label: 'A:B:C', target: 'A:B:C' },
+    { markdown: '[[James 1:19-20]]', label: 'James 1:19-20', target: 'James 1:19-20' },
+    { markdown: '[[Target: Title|Alias: Display]]', label: 'Alias: Display', target: 'Target: Title' },
+    {
+      markdown:
+        '[[This is a very long title: with a colon and enough words to cover wrapping without changing target extraction]]',
+      label:
+        'This is a very long title: with a colon and enough words to cover wrapping without changing target extraction',
+      target:
+        'This is a very long title: with a colon and enough words to cover wrapping without changing target extraction',
+    },
+    {
+      markdown: '[[Partners: Pricing & Strategy (2026-07-28)]]',
+      label: 'Partners: Pricing & Strategy (2026-07-28)',
+      target: 'Partners: Pricing & Strategy (2026-07-28)',
+    },
+    {
+      markdown: '[[Digest: follow-up — next steps]]',
+      label: 'Digest: follow-up — next steps',
+      target: 'Digest: follow-up — next steps',
+    },
+  ]
+
+  it.each(boundaryCases)(
+    'preserves boundary wiki-link target extraction for $markdown',
+    async ({ markdown, label, target }) => {
+      const onWikilinkClick = vi.fn<WikilinkClickHandler>()
+      const view = await renderSnippetText(markdown, onWikilinkClick)
+
+      const chip = view.getByTestId('wikilink')
+      await expect.element(chip).toHaveTextContent(label)
+      await chip.click()
+
+      await vi.waitFor(() => expect(onWikilinkClick).toHaveBeenCalledTimes(1))
+      expect(onWikilinkClick.mock.calls[0]?.[0]).toMatchObject({ target })
+      await view.unmount()
+    },
+  )
+
+  it('does not turn surrounding markdown syntax into wiki-link chips', async () => {
+    const view = await renderSnippetText(
+      [
+        'Visit https://example.com/path:with-colon and [Docs: API](https://example.com/docs).',
+        'Tag #project:alpha and time 1:19 are not wiki links.',
+        '`[[Code: Literal]]`',
+        '```',
+        '[[Fence: Literal]]',
+        '```',
+        'But [[Actual: Link]] is.',
+      ].join('\n'),
+    )
+
+    const chips = view.container.querySelectorAll('[data-testid="wikilink"]')
+    expect(chips).toHaveLength(1)
+    expect(chips[0]?.textContent).toBe('Actual: Link')
     await view.unmount()
   })
 })

--- a/apps/desktop/src/editor/use-wiki-link-navigation.test.tsx
+++ b/apps/desktop/src/editor/use-wiki-link-navigation.test.tsx
@@ -79,6 +79,20 @@ describe('useWikiLinkNavigation', () => {
     await view.unmount()
   })
 
+  it('passes colon-bearing wiki-link targets through to resolution', async () => {
+    resolveOrCreateNoteWithTitle.mockResolvedValue({
+      kind: 'resolved',
+      path: 'notes/test-colon-link.md',
+    })
+    const view = await renderHost()
+
+    lastHandler?.('Test: Colon Link')
+
+    await vi.waitFor(() => expect(currentRoute(view)).toContain('notes/test-colon-link.md'))
+    expect(resolveOrCreateNoteWithTitle).toHaveBeenCalledWith('Test: Colon Link', 1)
+    await view.unmount()
+  })
+
   it('arrives at a resolved note without a focus intent (no keyboard on navigation)', async () => {
     resolveOrCreateNoteWithTitle.mockResolvedValue({
       kind: 'resolved',

--- a/docs/desktop-wikilink-colon-clickability/final-report.md
+++ b/docs/desktop-wikilink-colon-clickability/final-report.md
@@ -1,0 +1,45 @@
+# Desktop Wiki-Link Colon Clickability Final Report
+
+## Root Cause
+
+Reflect's indexer was not the failing layer. The shared Reflect parser in `packages/core/src/markdown/grammar.ts` already treats any non-empty single-line `[[...]]` as a wiki link, including colons, aliases, parentheses, ampersands, and Unicode punctuation.
+
+The inert desktop behavior was in the editor rendering/tokenization dependency path. Reflect delegates the primary editor and Markdown preview/snippet rendering to Meowdown; with `@meowdown/core`/`@meowdown/react` `0.50.0`, colon-bearing wiki-link source could fail to become an editor `mdWikilink` chip in the desktop beta path. The current `master` base already contains `@meowdown/core`/`@meowdown/react` `0.61.0`, whose tokenizer restores `mdWikilink` rendering/click payloads for colon-bearing targets.
+
+## Change
+
+- Rebuilt the PR on `origin/master`, preserving its existing `@meowdown/core` and `@meowdown/react` `^0.61.0` dependency state without package or lockfile churn.
+- Added desktop rendering/click regression coverage in `BacklinkSnippet`, which uses Meowdown's rendered wiki-link chip path.
+- Added Reflect navigation coverage proving `Test: Colon Link` reaches `resolveOrCreateNoteWithTitle` unchanged.
+- Added core scanner coverage proving indexing/backlink parsing continues to accept colon-bearing wiki links.
+
+## Regression Matrix
+
+Covered supplied cases and A/B controls:
+
+- `[[Test: Colon Link]]`
+- `[[Test Colon Link]]`
+- `[[Test:Colon NoSpace Link]]`
+- `[[Test 1:19 Digit Colon]]`
+- `[[Test: Colon And Parens (2026-07-28)]]`
+- `[[Test Long With Parens & Ampersand Follow-up (2026-07-28 1208) - Suffix Segment]]`
+- `[[Meeting: VendorA x CompanyB AI Marketplace (2026-07-27)]]`
+- `[[Meeting: AI Widget Builder Pricing Strategy & Partner Deal Follow-up (2026-07-28 1208) - CompanyB Forecast Meeting]]`
+
+Covered boundaries:
+
+- letter:digit, digit:letter, leading colon, trailing colon, multiple colons, digit:digit, alias with colon, long title, parentheses/ampersands, Unicode punctuation.
+- Markdown links, bare URLs, tags, time text, code spans, and fenced code remain non-wiki-link syntax unless explicitly wrapped in `[[...]]`.
+
+## Verification
+
+- `pnpm exec vitest run --config ../../vitest.config.ts --project browser src/components/backlink-snippet.test.tsx src/editor/use-wiki-link-navigation.test.tsx`
+- `pnpm exec vitest run --config /tmp/reflect-core-vitest.config.mjs src/markdown/scan.test.ts src/markdown/grammar.test.ts src/markdown/extract.test.ts`
+- `pnpm check`
+- `pnpm --filter @reflect/desktop build`
+- Started the Vite desktop dev server on `http://localhost:1420/` and confirmed `curl -I` returned `200 OK`; stopped the server afterward.
+
+## Limitations
+
+- A full Tauri GUI click pass was not possible from this shell: there is no available browser/Tauri automation hook for the native desktop app.
+- A malformed initial focused-test command accidentally ran the full desktop Vitest suite and hit an unrelated existing `localStorage` failure in `src/lib/semantic.test.ts`; the intended focused suites pass.

--- a/docs/desktop-wikilink-colon-clickability/plan.md
+++ b/docs/desktop-wikilink-colon-clickability/plan.md
@@ -1,0 +1,29 @@
+# Desktop Wiki-Link Colon Clickability Plan
+
+## Goal
+
+Fix the desktop editor regression where wiki-links whose titles contain a colon outside a digit-colon-digit sequence render as inert text, while keeping the indexer/backlinks behavior unchanged.
+
+## Current Findings
+
+- The Reflect indexer and shared markdown scanner use `packages/core/src/markdown/grammar.ts`, whose `WikiLink` extension accepts any non-empty single-line `[[...]]` body.
+- Desktop editing is delegated to `@meowdown/react`/`@meowdown/core` through `apps/desktop/src/editor/note-editor.tsx`; Reflect passes `onWikiLinkClick` through to Meowdown and handles target resolution in `apps/desktop/src/editor/use-wiki-link-navigation.ts`.
+- The iOS/mobile route in Reflect also uses `NoteEditor`, but the report says the iOS app path works; compare any mobile-specific rendering/touch behavior before changing Reflect grammar.
+- Recent relevant history includes repeated Meowdown dependency bumps, ending with `fix: update meowdown to ^0.50.0 (#798)`.
+
+## Plan
+
+1. Reproduce the parser/decorator mismatch in an isolated test by exercising the editor-facing wiki-link recognition path, not only the core index scanner.
+2. Inspect Meowdown's published grammar/decorator/click code and compare it to Reflect's shared `wikiLinkExtension` and mobile/touch path.
+3. Choose the narrowest canonical fix:
+   - Prefer a shared parser/decorator utility if Reflect owns it.
+   - If Meowdown owns the broken parser and there is no local Meowdown checkout, patch Reflect's dependency/version path only if a released upstream fix exists; otherwise add a focused Reflect-side compatibility adapter only after documenting why the canonical upstream layer is unavailable in this worktree.
+4. Add regression coverage for rendering/decorations and target extraction/click navigation:
+   - Supplied A/B matrix links.
+   - Boundary cases: `letter:digit`, `digit:letter`, trailing colon, leading colon, multiple colons, digit:digit, aliases, long titles, parentheses/ampersands, Unicode punctuation.
+   - Non-regression syntax: protocols/URLs, Markdown links, tags, time/verse text, code spans/fences, empty/unclosed/multiline wiki-link candidates, and selections where relevant.
+5. Confirm indexing/backlinks remain unchanged by running the existing focused core markdown/indexing tests and adding assertions only if they document the invariant.
+6. Run focused Vitest suites for the touched editor/core paths, `pnpm check`, and any reasonably scoped package build or desktop test.
+7. Attempt a desktop interaction pass. If the local app cannot run, document the exact limitation in `final-report.md`.
+8. Update `status.md` throughout, then complete `final-report.md` with root cause, regression matrix, verification, and residual risk.
+9. Commit, push, open a ready PR against `master`, and check for immediate CI/PR blockers.

--- a/docs/desktop-wikilink-colon-clickability/status.md
+++ b/docs/desktop-wikilink-colon-clickability/status.md
@@ -1,0 +1,37 @@
+# Desktop Wiki-Link Colon Clickability Status
+
+## Status
+
+PR opened: https://github.com/team-reflect/reflect-open/pull/987
+
+## Checklist
+
+- [x] Read AGENTS.md and confirm worktree/branch.
+- [x] Create planning artifacts before code edits.
+- [x] Reproduce the desktop editor parser/decorator failure.
+- [x] Compare desktop path with mobile/iOS behavior and shared wiki-link utilities.
+- [x] Check history/blame for intentional colon behavior or recent regression.
+- [x] Implement the narrowest root-cause fix.
+- [x] Add rendering/decorations and click target extraction regression coverage.
+- [x] Confirm indexing/backlinks behavior remains unchanged.
+- [x] Run focused tests.
+- [x] Run `pnpm check`.
+- [x] Attempt desktop interaction/repro pass or document limitation.
+- [x] Commit, push, and open ready PR.
+
+## Notes
+
+- Worktree: `/Users/cloud/repos/team-reflect/reflect-open-wikilink-colon`
+- Branch: `fix/desktop-wikilink-colon-clickability`
+- PR: https://github.com/team-reflect/reflect-open/pull/987
+- Original base reported by user: fresh `origin/next` at `3d0eae96`
+- Corrected PR base: fresh `origin/master` at `3ca924bf`
+- Initial `git status` was clean.
+- `origin/master` already contains `@meowdown/core`/`@meowdown/react` `^0.61.0`; the reconstructed PR preserves that dependency state and does not modify `apps/desktop/package.json` or `pnpm-lock.yaml`.
+- Focused tests passing:
+  - `pnpm exec vitest run --config ../../vitest.config.ts --project browser src/components/backlink-snippet.test.tsx src/editor/use-wiki-link-navigation.test.tsx`
+  - `pnpm exec vitest run --config /tmp/reflect-core-vitest.config.mjs src/markdown/scan.test.ts src/markdown/grammar.test.ts src/markdown/extract.test.ts`
+- `pnpm check` passed with existing unrelated warnings.
+- `pnpm --filter @reflect/desktop build` passed; Sentry source-map upload was skipped because no auth token is configured locally.
+- Vite desktop dev server started on `http://localhost:1420/` and returned `200 OK` to `curl -I`; it was stopped afterward. No full Tauri GUI click pass was possible from this shell because there is no browser/Tauri automation hook available for the native desktop app.
+- A malformed first attempt at a focused desktop test (`pnpm --filter @reflect/desktop test -- --run ...`) ran the whole desktop suite and hit an unrelated existing `localStorage` failure in `src/lib/semantic.test.ts`.

--- a/packages/core/src/markdown/scan.test.ts
+++ b/packages/core/src/markdown/scan.test.ts
@@ -27,6 +27,36 @@ describe('scanInlineWikiLinks', () => {
     expect(text.slice(link.displayFrom, link.displayTo)).toBe('Target')
   })
 
+  it('keeps colon-bearing wiki-link targets indexable', () => {
+    const text = [
+      '[[Test: Colon Link]]',
+      '[[Test:Colon NoSpace Link]]',
+      '[[Test:19]]',
+      '[[19:Test]]',
+      '[[Trailing:]]',
+      '[[:Leading]]',
+      '[[A:B:C]]',
+      '[[James 1:19-20]]',
+      '[[Target: Title|Alias: Display]]',
+      '[[Partners: Pricing & Strategy (2026-07-28)]]',
+      '[[Digest: follow-up — next steps]]',
+    ].join(' ')
+
+    expect(scanInlineWikiLinks(text).map((link) => [link.target, link.alias])).toEqual([
+      ['Test: Colon Link', null],
+      ['Test:Colon NoSpace Link', null],
+      ['Test:19', null],
+      ['19:Test', null],
+      ['Trailing:', null],
+      [':Leading', null],
+      ['A:B:C', null],
+      ['James 1:19-20', null],
+      ['Target: Title', 'Alias: Display'],
+      ['Partners: Pricing & Strategy (2026-07-28)', null],
+      ['Digest: follow-up — next steps', null],
+    ])
+  })
+
   it('respects code contexts, same as the indexer grammar', () => {
     expect(scanInlineWikiLinks('code `[[NotALink]]` stays literal')).toEqual([])
     expect(scanInlineWikiLinks('and [[]] is not a link')).toEqual([])
@@ -73,6 +103,22 @@ describe('scanInlineSegments', () => {
     expect(scanInlineSegments('[[2026-06-20|Friday]] ship')).toEqual([
       { kind: 'wikiLink', target: '2026-06-20', alias: 'Friday' },
       { kind: 'text', text: ' ship' },
+    ])
+  })
+
+  it('segments colon-bearing wiki links without confusing markdown links or URLs', () => {
+    expect(
+      scanInlineSegments(
+        'See [[Meeting: Plan|Plan: Alias]], [Docs: API](https://example.com/a:b), and https://example.com/a:b.',
+      ),
+    ).toEqual([
+      { kind: 'text', text: 'See ' },
+      { kind: 'wikiLink', target: 'Meeting: Plan', alias: 'Plan: Alias' },
+      { kind: 'text', text: ', ' },
+      { kind: 'link', text: 'Docs: API', href: 'https://example.com/a:b' },
+      { kind: 'text', text: ', and ' },
+      { kind: 'link', text: 'https://example.com/a:b', href: 'https://example.com/a:b' },
+      { kind: 'text', text: '.' },
     ])
   })
 


### PR DESCRIPTION
## Root cause

The indexer/backlink parser was already accepting colon-bearing `[[wiki links]]`; Reflect's shared scanner still parses these targets correctly. The regression was in the desktop editor rendering/tokenization dependency path: Meowdown 0.50 could leave colon-bearing wiki-link source as inert text instead of an `mdWikilink` chip, so Reflect never received a click payload.

This PR is now rebuilt on `master`. `master` already contains `@meowdown/core` and `@meowdown/react` `0.61.0`, where the editor markdown tokenizer recognizes colon-bearing targets. The PR therefore preserves the existing master dependency/lockfile state and adds focused regression coverage plus planning/report docs only.

## Regression coverage

Desktop rendered/click coverage now includes the supplied A/B matrix:

- `[[Test: Colon Link]]`
- `[[Test Colon Link]]`
- `[[Test:Colon NoSpace Link]]`
- `[[Test 1:19 Digit Colon]]`
- `[[Test: Colon And Parens (2026-07-28)]]`
- `[[Test Long With Parens & Ampersand Follow-up (2026-07-28 1208) - Suffix Segment]]`
- `[[Meeting: VendorA x CompanyB AI Marketplace (2026-07-27)]]`
- `[[Meeting: AI Widget Builder Pricing Strategy & Partner Deal Follow-up (2026-07-28 1208) - CompanyB Forecast Meeting]]`

Boundary coverage includes letter:digit, digit:letter, leading colon, trailing colon, multiple colons, digit:digit, alias display, long titles, parentheses/ampersands, and Unicode punctuation. Non-wiki markdown syntax remains covered for markdown links, bare URLs, tags, time text, code spans, and fenced code.

## Verification

- `pnpm exec vitest run --config ../../vitest.config.ts --project browser src/components/backlink-snippet.test.tsx src/editor/use-wiki-link-navigation.test.tsx`
- `pnpm exec vitest run --config /tmp/reflect-core-vitest.config.mjs src/markdown/scan.test.ts src/markdown/grammar.test.ts src/markdown/extract.test.ts`
- `pnpm check`
- `pnpm --filter @reflect/desktop build`
- Started Vite desktop dev server on `http://localhost:1420/`, confirmed `curl -I` returned `200 OK`, then stopped it.

A full Tauri GUI click pass was not possible from this shell because there is no browser/Tauri automation hook available for the native desktop app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wiki-links with colons in their titles are now rendered as clickable links.
  * Clicking these links correctly navigates to or resolves the intended note.
  * Colon-bearing wiki-links remain properly indexed, including aliased links.
  * URLs, inline code, and fenced code blocks are not incorrectly treated as wiki-links.

* **Documentation**
  * Added planning, status, and verification documentation for the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->