### PR TITLE
feat: cycle iOS editor list style

### DIFF
--- a/apps/desktop/src/editor/formatting-toolbar-bridge.test.tsx
+++ b/apps/desktop/src/editor/formatting-toolbar-bridge.test.tsx
@@ -29,6 +29,7 @@ function makeFakeEditor() {
     blur: vi.fn(),
     view: { dom },
     commands: {
+      cyclePlainList: makeCommand(),
       cycleCheckableList: makeCommand(),
       toggleList: makeCommand(),
       indentList: makeCommand(),
@@ -131,7 +132,7 @@ describe('FormattingToolbarBridge', () => {
     const commands = store.result.current!.commands
 
     commands.toggleBulletList()
-    expect(editor.commands.toggleList).toHaveBeenCalledWith({ kind: 'bullet' })
+    expect(editor.commands.cyclePlainList).toHaveBeenCalledWith()
     commands.cycleCheckableList()
     expect(editor.commands.cycleCheckableList).toHaveBeenCalledWith()
     commands.indent()

--- a/apps/desktop/src/editor/formatting-toolbar-bridge.tsx
+++ b/apps/desktop/src/editor/formatting-toolbar-bridge.tsx
@@ -70,7 +70,7 @@ export function FormattingToolbarBridge(): null {
       }
 
       const commands: FormattingToolbarCommands = {
-        toggleBulletList: () => run(() => editor.commands.toggleList({ kind: 'bullet' })),
+        toggleBulletList: () => run(() => editor.commands.cyclePlainList()),
         cycleCheckableList: () => run(() => editor.commands.cycleCheckableList()),
         indent: () => run(() => editor.commands.indentList()),
         dedent: () => run(() => editor.commands.dedentList()),

--- a/apps/desktop/src/editor/formatting-toolbar-store.ts
+++ b/apps/desktop/src/editor/formatting-toolbar-store.ts
@@ -22,6 +22,7 @@ export type FormattingTriggerText = '/' | '[[' | '#'
  * editor's identity or path.
  */
 export interface FormattingToolbarCommands {
+  /** Cycle text -> bullet -> ordered -> text using the editor's list transaction. */
   toggleBulletList: () => void
   /** Cycle other content → square checklist → round task → square checklist. */
   cycleCheckableList: () => void

--- a/apps/desktop/src/mobile/formatting-toolbar.test.tsx
+++ b/apps/desktop/src/mobile/formatting-toolbar.test.tsx
@@ -56,7 +56,7 @@ describe('MobileFormattingToolbar', () => {
     const buttons = screen.getAllByRole('button')
     expect(buttons.map((button) => button.getAttribute('aria-label'))).toEqual([
       'Slash command',
-      'Bullet list',
+      'Cycle list style',
       'Cycle checklist and task',
       'Link note',
       'Tag',
@@ -81,7 +81,7 @@ describe('MobileFormattingToolbar', () => {
     render(<MobileFormattingToolbar />)
     act(() => publishFormattingToolbar(owner, makeToolbar()))
 
-    const bullet = screen.getByRole('button', { name: 'Bullet list' })
+    const bullet = screen.getByRole('button', { name: 'Cycle list style' })
     // fireEvent returns false when a handler called preventDefault — the
     // contract that keeps the editor focused (and the keyboard up) mid-tap.
     expect(fireEvent.pointerDown(bullet)).toBe(false)
@@ -93,7 +93,7 @@ describe('MobileFormattingToolbar', () => {
     render(<MobileFormattingToolbar />)
     act(() => publishFormattingToolbar(owner, toolbar))
 
-    fireEvent.click(screen.getByRole('button', { name: 'Bullet list' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cycle list style' }))
     expect(toolbar.commands.toggleBulletList).toHaveBeenCalledOnce()
 
     fireEvent.click(screen.getByRole('button', { name: 'Cycle checklist and task' }))

--- a/apps/desktop/src/mobile/formatting-toolbar.tsx
+++ b/apps/desktop/src/mobile/formatting-toolbar.tsx
@@ -52,7 +52,7 @@ export function MobileFormattingToolbar(): ReactElement | null {
           onPress={() => commands.insertTrigger('/')}
         />
         <ToolbarButton
-          label="Bullet list"
+          label="Cycle list style"
           icon={<List className="size-5" />}
           onPress={commands.toggleBulletList}
         />

--- a/docs/ios-context-list-cycle/final-report.md
+++ b/docs/ios-context-list-cycle/final-report.md
@@ -1,0 +1,41 @@
+# iOS Context List Cycle Final Report
+
+## Implementation
+
+- Added upstream Meowdown command `cyclePlainList` in prosekit/meowdown#396.
+- Pinned Reflect to the Meowdown PR snapshot for commit `df741bb`.
+- Changed Reflect's iOS formatting toolbar bullet/list button to call `editor.commands.cyclePlainList()`.
+- Updated the button's accessibility label from `Bullet list` to `Cycle list style`.
+- Kept the existing task icon on `cycleCheckableList()`, including its haptics and focus-preserving tap behavior.
+
+## State Table
+
+| Current editor state | Next state |
+| --- | --- |
+| Not a plain bullet or ordered list | Unordered list |
+| Unordered list | Ordered list |
+| Ordered list | No list |
+
+Task items are treated as non-plain-list content on the first press. They convert to a plain unordered list item and Meowdown clears stale task attrs so checkbox state is not silently preserved after the task marker is removed.
+
+Nested selections use Meowdown's existing closest-list convention, matching `cycleCheckableList`. Keyboard list shortcuts continue to use their existing `toggleList` bindings.
+
+## Verification
+
+Meowdown:
+
+- `pnpm test --run packages/core/src/extensions/list.test.ts`
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm build`
+- PR: prosekit/meowdown#396
+
+Reflect:
+
+- `pnpm --filter @reflect/desktop test --run src/editor/formatting-toolbar-bridge.test.tsx src/mobile/formatting-toolbar.test.tsx src/editor/formatting-toolbar-store.test.ts`
+- `pnpm check`
+- `pnpm --filter @reflect/desktop build`
+
+## QA Limits
+
+iOS simulator/device QA could not run on this host because `xcrun simctl list devices available` fails with `xcrun: error: unable to find utility "simctl", not a developer tool or in PATH`. No dev app for this worktree appeared to be running, so there was nothing to rebuild/restart.

--- a/docs/ios-context-list-cycle/implementation-plan.md
+++ b/docs/ios-context-list-cycle/implementation-plan.md
@@ -1,0 +1,69 @@
+# iOS Context List Cycle Implementation Plan
+
+## Goal
+
+Change the Reflect iOS editor context bar bullet-list button so it cycles the active block or selection through:
+
+| Current editor state | Next state |
+| --- | --- |
+| Not a plain bullet or ordered list | Unordered list |
+| Unordered list | Ordered list |
+| Ordered list | No list |
+
+The behavior must use editor transactions, not Markdown text insertion, so it preserves selection, undo grouping, nesting, marker serialization, empty list items, and multi-line selections.
+
+## Traced Surfaces
+
+- Reflect iOS toolbar UI: `apps/desktop/src/mobile/formatting-toolbar.tsx`
+- Reflect toolbar command bridge: `apps/desktop/src/editor/formatting-toolbar-bridge.tsx`
+- Reflect toolbar store/tests: `apps/desktop/src/editor/formatting-toolbar-store.ts`, `apps/desktop/src/editor/formatting-toolbar-bridge.test.tsx`, `apps/desktop/src/mobile/formatting-toolbar.test.tsx`
+- Meowdown list commands/keymaps/tests: `packages/core/src/extensions/list.ts`, `packages/core/src/extensions/list.test.ts`
+- Existing task toggle pattern: Meowdown `cycleCheckableList`, `rotateSquareTask`, `rotateCircleTask`; Reflect iOS task icon calls `editor.commands.cycleCheckableList()`
+
+## Design
+
+Add a canonical Meowdown command named `cyclePlainList` next to the existing task cycle commands.
+
+The command will:
+
+- Inspect the closest enclosing `list` node at the selection, matching the existing `getListAttrsAtSelection` convention.
+- Treat only `kind: 'bullet'` and `kind: 'ordered'` as participating states.
+- Use ProseKit `toggleList`/`wrapInList` primitives for the actual transaction.
+- Convert bullet to ordered in place with preserved nesting/content.
+- Unwrap ordered list items to text using the same behavior as existing keyboard `Mod-Shift-7`.
+- Convert task and other list-like blocks to a plain unordered list rather than stripping task semantics through a two-step cycle. This matches the table's "anything else -> unordered list" rule and avoids deleting task state on the first press.
+
+Reflect will then wire `FormattingToolbarCommands.toggleBulletList` to `editor.commands.cyclePlainList()` while keeping the public toolbar command name stable for a small reviewable diff. The task icon remains on `cycleCheckableList()`.
+
+## Edge Cases To Test
+
+- Paragraph: first press creates `- item`.
+- Bullet: next press converts to `1. item`.
+- Ordered: next press unwraps to `item`.
+- Task: first press converts to plain bullet without silently preserving stale `checked` attrs as task semantics.
+- Nested list: only the closest selected list item changes, matching `cycleCheckableList`.
+- Keyboard commands: existing `Mod-Shift-7`, `Mod-Shift-8`, and task keymaps keep their current behavior.
+- Reflect bridge: bullet toolbar command calls `cyclePlainList`; task toolbar command still calls `cycleCheckableList`.
+- Reflect mobile toolbar: labels, focus behavior, and button dispatch remain unchanged.
+
+## Verification Plan
+
+Meowdown:
+
+- `pnpm test --run packages/core/src/extensions/list.test.ts`
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm build` if practical after focused checks pass
+
+Reflect:
+
+- `pnpm test --run apps/desktop/src/editor/formatting-toolbar-bridge.test.tsx apps/desktop/src/mobile/formatting-toolbar.test.tsx apps/desktop/src/editor/formatting-toolbar-store.test.ts`
+- `pnpm check`
+- Scoped build if practical: `pnpm --filter @reflect/desktop build`
+- iOS QA: attempt simulator QA via the documented iOS flow if the host has an available simulator and dependencies; otherwise document the exact blocker.
+
+## PR Plan
+
+1. Commit, push, and open a ready Meowdown PR against `master` if `cyclePlainList` is added upstream.
+2. Wire Reflect to the new command in the dedicated Reflect worktree.
+3. Commit, push, and open a ready Reflect PR against `next`, clearly marking the Meowdown dependency and linking the upstream PR.

--- a/docs/ios-context-list-cycle/status.md
+++ b/docs/ios-context-list-cycle/status.md
@@ -1,0 +1,24 @@
+# iOS Context List Cycle Status
+
+## Current Status
+
+- [x] Read Reflect `AGENTS.md`.
+- [x] Confirmed Reflect branch/worktree.
+- [x] Confirmed Meowdown branch/worktree and package scripts.
+- [x] Traced Reflect iOS formatting toolbar UI and command bridge.
+- [x] Traced Meowdown list command surface and existing task cycle pattern.
+- [x] Created implementation plan before code edits.
+- [x] Implement Meowdown `cyclePlainList` command and tests.
+- [x] Run Meowdown focused tests and required checks.
+- [x] Open Meowdown PR if required: prosekit/meowdown#396.
+- [x] Wire Reflect toolbar bridge to upstream command.
+- [x] Run Reflect focused tests and required checks.
+- [x] Attempt/document iOS QA.
+- [ ] Commit, push, and open ready Reflect PR.
+
+## Working Notes
+
+- Meowdown currently has `cycleCheckableList` for the task icon and `toggleList` for direct list toggles. It does not expose the exact three-state plain-list cycle required by the iOS toolbar.
+- Reflect's iOS bullet-list button currently calls `editor.commands.toggleList({ kind: 'bullet' })`, which cannot produce the requested bullet-to-ordered next state.
+- Reflect is pinned to the Meowdown PR snapshot for commit `df741bb` so the branch is portable while the upstream PR is pending.
+- iOS simulator QA is blocked on this host: `xcrun simctl list devices available` fails with `xcrun: error: unable to find utility "simctl", not a developer tool or in PATH`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,10 @@ settings:
   dedupePeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@meowdown/core': https://pkg.pr.new/prosekit/meowdown/@meowdown/core@df741bb
+  '@meowdown/react': https://pkg.pr.new/prosekit/meowdown/@meowdown/react@df741bb
+
 importers:
 
   .:
@@ -37,11 +41,11 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.7)
       '@meowdown/core':
-        specifier: ^0.50.0
-        version: 0.50.0(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)
+        specifier: https://pkg.pr.new/prosekit/meowdown/@meowdown/core@df741bb
+        version: https://pkg.pr.new/prosekit/meowdown/@meowdown/core@df741bb(@lezer/common@1.5.2)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)
       '@meowdown/react':
-        specifier: ^0.50.0
-        version: 0.50.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)(react-dom@19.2.7)(react@19.2.7)
+        specifier: https://pkg.pr.new/prosekit/meowdown/@meowdown/react@df741bb
+        version: https://pkg.pr.new/prosekit/meowdown/@meowdown/react@df741bb(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)(react-dom@19.2.7)(react@19.2.7)
       '@reflect/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -1066,6 +1070,9 @@ packages:
   '@lezer/markdown@1.7.1':
     resolution: {integrity: sha512-MEBZeFSBxgteUjEC3Wxg2Dwld5/JxRKG267L3bMFdibm8KjqSdiJYBeFw1Nt1CM8+zKMpSIEHblY8FD9z38sJQ==}
 
+  '@lezer/markdown@1.7.2':
+    resolution: {integrity: sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ==}
+
   '@lezer/php@1.0.5':
     resolution: {integrity: sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==}
 
@@ -1090,11 +1097,17 @@ packages:
   '@marijn/find-cluster-break@1.0.3':
     resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
 
-  '@meowdown/core@0.50.0':
-    resolution: {integrity: sha512-RifZi5gwe05DZNe6CRv+M4KDBJ/RqsubMsNEbdilJ8sLb0BoA4m54RemAuxjs7Vx51x2hzUUJUxIPTYxXfqhEg==}
+  '@meowdown/core@https://pkg.pr.new/prosekit/meowdown/@meowdown/core@df741bb':
+    resolution: {integrity: sha512-9hocnxMXL8ESSnFWpfKMm4vZNSsNOm0b9ao15we22qO6iLINJh2rw2UXuVKeb9QdGGZY04Octt8TGSrPnwtoWQ==, tarball: https://pkg.pr.new/prosekit/meowdown/@meowdown/core@df741bb}
+    version: 0.61.0
 
-  '@meowdown/react@0.50.0':
-    resolution: {integrity: sha512-nUGAQaLUFXpTy8htBhDSh3/q0/5TxU73kUMTJ+mNTa1ZwXSAPtI2Xg88IV2jNzdxKP9uhqWpuZ6UkSoTRmuRhg==}
+  '@meowdown/markdown@https://pkg.pr.new/prosekit/meowdown/@meowdown/markdown@df741bb':
+    resolution: {integrity: sha512-GSkOnWrEG5LO83x/rGXh3ZEsee1xoYM0SIly0SugcGGn+1f7LwJ0ZY3PeUd8G5Gkkj2u4CfCRwWsdktKBQlNMg==, tarball: https://pkg.pr.new/prosekit/meowdown/@meowdown/markdown@df741bb}
+    version: 0.61.0
+
+  '@meowdown/react@https://pkg.pr.new/prosekit/meowdown/@meowdown/react@df741bb':
+    resolution: {integrity: sha512-qRGb+/fPN1RISYaHv2Vi5DCqm/3NPJlni1bI+AW/MOu2Q7Rm0/u74YJJEBLxdrRIVp8cP+PdgEFq0qYFN+tWuw==, tarball: https://pkg.pr.new/prosekit/meowdown/@meowdown/react@df741bb}
+    version: 0.61.0
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -1343,11 +1356,11 @@ packages:
     resolution: {integrity: sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==}
     engines: {node: '>=12'}
 
-  '@prosekit/core@0.13.0-beta.6':
-    resolution: {integrity: sha512-Wj3RSXJagztK6I/4aVDoEYIXXHl1R87bGNdvBjBqCan8NmA64ZZUHP9NojXgJKo/7AzFnmJhygo5o0UUygYeFg==}
+  '@prosekit/core@0.13.0-beta.7':
+    resolution: {integrity: sha512-yqB8EcMoQeEnbfqSwx2dJccaQPx1+LT16AihXwdOQznXH6zIe2F94pxaKzyZavVw8navM4pKbiBBGS7tL9FVug==}
 
-  '@prosekit/extensions@0.18.0-beta.16':
-    resolution: {integrity: sha512-dsbqDFV+ILKOyafgDc8Xu8R1L3q/q2paO1Qqs4tSa/1oZlL4z/b8W2Ce+WJnzF+U1uiugpeEf2DE0tRjtTONxQ==}
+  '@prosekit/extensions@0.18.0-beta.19':
+    resolution: {integrity: sha512-3l8egSsTWU201q3bREkEGSFv4NYFUn0zUYiSK0GUFmiWbL2GgMcQDVY9HnKyUX2o803+06tHPGciNToAo1CHOA==}
     peerDependencies:
       loro-crdt: '>= 1.10.0'
       loro-prosemirror: '>= 0.4.1'
@@ -1363,11 +1376,11 @@ packages:
       yjs:
         optional: true
 
-  '@prosekit/pm@0.1.19-beta.3':
-    resolution: {integrity: sha512-rT+DNrAggLD1vx2zwsFjGuxrlO0r5CQNOHaP/hnJxWvs5YL3UXayyJh+qEialmjAC1LvoH5GYKYpOCGKIfSkiA==}
+  '@prosekit/pm@0.1.19-beta.4':
+    resolution: {integrity: sha512-zBbLJJOGH3Y/fZwa+XJgnyJ2pxIthaPHhLLkfjSMlyMiVb1i9FKjUe2qBJLq5gxJEljzeDtJPGVkczmfdtIX4g==}
 
-  '@prosekit/react@0.8.0-beta.21':
-    resolution: {integrity: sha512-7y+VSvNVSif95rH1Z6Os0UkqrQqKNwpY8w8+dyTQFDIwFyRbPE0Pal63QK64staGV0bmuLdMOdcfEYpyp1YzSQ==}
+  '@prosekit/react@0.8.0-beta.24':
+    resolution: {integrity: sha512-U7BBzZd+/CaQOYAXRF39Uy79XQQkz22tIdzLJPMp9l5XyuW69Y3Q/B1hjVPktR7FBTTCrt9tQw1vzMEySnSS0Q==}
     peerDependencies:
       react: '>= 18.2.0'
       react-dom: '>= 18.2.0'
@@ -1377,14 +1390,14 @@ packages:
       react-dom:
         optional: true
 
-  '@prosekit/web@0.9.0-beta.21':
-    resolution: {integrity: sha512-JR+ois0Zf1B0HNGHsrLBfCN7PFaDfMxawRA5u+FJelBQahcncKH+l6YSgfdS3GNrNa+I2ZG0wj8hblaMSmUmbA==}
+  '@prosekit/web@0.9.0-beta.24':
+    resolution: {integrity: sha512-7URj4WpD8sbBzJqO/pA6QNgxDxViFP+sV8Bj91NGYmcEf0tg+xZC7qzbphahj0SziQ0AA9OL9PX1UR3+SyqQgQ==}
 
-  '@prosemirror-adapter/core@0.5.3':
-    resolution: {integrity: sha512-jGcI/eq3USFqf1fCaejgCmifmXYDyFco6/5KjyyNBnuEhLqyLjD+020CtcduEOsnN4xPZr5ikclgHIR6kEFkQg==}
+  '@prosemirror-adapter/core@0.5.5':
+    resolution: {integrity: sha512-R1BV/up0qApb0mtZt81I4TCBmalclqb43ecCQXiVHD5LpoarYHMMBzEoZFanSFg+8YxB1CmvbJwN+DLqbXJwsg==}
 
-  '@prosemirror-adapter/react@0.5.3':
-    resolution: {integrity: sha512-k/dpqT6FrC8vH/OeX9yZswQ3Acap1In4PeKj9SAh6BfMXPWOWFclU7K1mWwpD9aC1Va1npz+FZTMmXSsiQTsnw==}
+  '@prosemirror-adapter/react@0.5.5':
+    resolution: {integrity: sha512-bU6YakJ7wk6K1N+HfiJ8vKkMRl53nzAouazXdtEtzftFJNQ50c9gZPmoMOJM+EsOV1J9T7jnFh3v0TuwL4QnTA==}
     peerDependencies:
       react: '*'
       react-dom: '*'
@@ -3139,6 +3152,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  beautiful-mermaid@1.1.3:
+    resolution: {integrity: sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg==}
+
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
 
@@ -3656,6 +3672,9 @@ packages:
   electron-to-chromium@1.5.387:
     resolution: {integrity: sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==}
 
+  elkjs@0.11.1:
+    resolution: {integrity: sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==}
+
   embla-carousel-react@8.6.0:
     resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
     peerDependencies:
@@ -4042,6 +4061,9 @@ packages:
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -4504,8 +4526,8 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
-  katex@0.17.0:
-    resolution: {integrity: sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==}
+  katex@0.18.1:
+    resolution: {integrity: sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ==}
     hasBin: true
 
   keyv@4.5.4:
@@ -4740,6 +4762,11 @@ packages:
 
   lucide-react@1.24.0:
     resolution: {integrity: sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lucide-react@1.27.0:
+    resolution: {integrity: sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -5448,6 +5475,9 @@ packages:
 
   prosemirror-view@1.42.1:
     resolution: {integrity: sha512-rRqzZnRgkyh69XoOMrfFJHwauHscLBmHbq772kwbic1ymQAM8gXjzEbJse5j1ep2UO2HRIAQL0bY3kZ/RoqjVw==}
+
+  prosemirror-view@1.42.2:
+    resolution: {integrity: sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==}
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
@@ -6197,6 +6227,9 @@ packages:
   undici@7.27.2:
     resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
     engines: {node: '>=20.18.1'}
+
+  unicode-by-name@0.2.0:
+    resolution: {integrity: sha512-aM5tvjLgtm6tgTLlGN0U6wU0ep44stCVcbE9GEar7+zNNA69izfT8V1BmlUdrFtDnDIgSDidN2v+RrmqRGvf1Q==}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -7591,6 +7624,11 @@ snapshots:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
 
+  '@lezer/markdown@1.7.2':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+
   '@lezer/php@1.0.5':
     dependencies:
       '@lezer/common': 1.5.2
@@ -7631,28 +7669,33 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.3': {}
 
-  '@meowdown/core@0.50.0(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)':
+  '@meowdown/core@https://pkg.pr.new/prosekit/meowdown/@meowdown/core@df741bb(@lezer/common@1.5.2)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)':
     dependencies:
       '@codemirror/language': 6.12.4
       '@codemirror/language-data': 6.5.2
       '@floating-ui/dom': 1.8.0
-      '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
-      '@lezer/markdown': 1.7.1
+      '@meowdown/markdown': https://pkg.pr.new/prosekit/meowdown/@meowdown/markdown@df741bb
       '@ocavue/utils': 1.7.0
-      '@prosekit/core': 0.13.0-beta.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/extensions': 0.18.0-beta.16(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)
-      '@prosekit/pm': 0.1.19-beta.3
-      '@prosekit/web': 0.9.0-beta.21(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)
-      katex: 0.17.0
+      '@prosekit/core': 0.13.0-beta.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/extensions': 0.18.0-beta.19(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)
+      '@prosekit/pm': 0.1.19-beta.4
+      '@prosekit/web': 0.9.0-beta.24(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)
+      hast-util-to-mdast: 10.1.2
+      katex: 0.18.1
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
       prosemirror-flat-list: 0.7.1
-      prosemirror-highlight: 0.15.3(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)
+      prosemirror-highlight: 0.15.3(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)
       rehype-parse: 9.0.1
       rehype-remark: 10.0.1
       remark-gfm: 4.0.1
       remark-stringify: 11.0.0
+      unicode-by-name: 0.2.0
       unified: 11.0.5
     transitivePeerDependencies:
+      - '@lezer/common'
       - '@shikijs/types'
       - '@types/hast'
       - highlight.js
@@ -7669,16 +7712,23 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@meowdown/react@0.50.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)(react-dom@19.2.7)(react@19.2.7)':
+  '@meowdown/markdown@https://pkg.pr.new/prosekit/meowdown/@meowdown/markdown@df741bb':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.7.2
+
+  '@meowdown/react@https://pkg.pr.new/prosekit/meowdown/@meowdown/react@df741bb(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(@types/react@19.2.17)(date-fns@4.4.0)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)(react-dom@19.2.7)(react@19.2.7)':
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7)(react@19.2.7)
-      '@meowdown/core': 0.50.0(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)
+      '@meowdown/core': https://pkg.pr.new/prosekit/meowdown/@meowdown/core@df741bb(@lezer/common@1.5.2)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)
       '@ocavue/utils': 1.7.0
-      '@prosekit/core': 0.13.0-beta.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/pm': 0.1.19-beta.3
-      '@prosekit/react': 0.8.0-beta.21(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)(react-dom@19.2.7)(react@19.2.7)
+      '@prosekit/core': 0.13.0-beta.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/pm': 0.1.19-beta.4
+      '@prosekit/react': 0.8.0-beta.24(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)(react-dom@19.2.7)(react@19.2.7)
+      beautiful-mermaid: 1.1.3
       clsx: 2.1.1
-      lucide-react: 1.24.0(react@19.2.7)
+      github-slugger: 2.0.0
+      lucide-react: 1.27.0(react@19.2.7)
       react-property: 2.0.2
     optionalDependencies:
       react: 19.2.7
@@ -7895,10 +7945,10 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@prosekit/core@0.13.0-beta.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
+  '@prosekit/core@0.13.0-beta.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
     dependencies:
       '@ocavue/utils': 1.7.0
-      '@prosekit/pm': 0.1.19-beta.3
+      '@prosekit/pm': 0.1.19-beta.4
       orderedmap: 2.1.1
       prosemirror-splittable: 1.1.0(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       type-fest: 5.8.0
@@ -7907,18 +7957,18 @@ snapshots:
       - prosemirror-state
       - prosemirror-transform
 
-  '@prosekit/extensions@0.18.0-beta.16(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)':
+  '@prosekit/extensions@0.18.0-beta.19(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)':
     dependencies:
       '@ocavue/utils': 1.7.0
-      '@prosekit/core': 0.13.0-beta.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/pm': 0.1.19-beta.3
+      '@prosekit/core': 0.13.0-beta.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/pm': 0.1.19-beta.4
       prosemirror-changeset: 2.4.1
       prosemirror-drop-indicator: 0.1.4
       prosemirror-dropcursor: 1.8.3
       prosemirror-enter-rules: 0.1.6
       prosemirror-flat-list: 0.7.1
       prosemirror-gapcursor: 1.4.1
-      prosemirror-highlight: 0.15.3(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)
+      prosemirror-highlight: 0.15.3(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)
       prosemirror-math: 0.2.2
       prosemirror-search: 1.1.1
       prosemirror-tables: 1.8.5
@@ -7938,7 +7988,7 @@ snapshots:
       - refractor
       - sugar-high
 
-  '@prosekit/pm@0.1.19-beta.3':
+  '@prosekit/pm@0.1.19-beta.4':
     dependencies:
       prosemirror-commands: 1.7.1
       prosemirror-history: 1.5.0
@@ -7947,15 +7997,15 @@ snapshots:
       prosemirror-model: 1.25.11
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
-      prosemirror-view: 1.42.1
+      prosemirror-view: 1.42.2
 
-  '@prosekit/react@0.8.0-beta.21(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)(react-dom@19.2.7)(react@19.2.7)':
+  '@prosekit/react@0.8.0-beta.24(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)(react-dom@19.2.7)(react@19.2.7)':
     dependencies:
-      '@prosekit/core': 0.13.0-beta.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/pm': 0.1.19-beta.3
-      '@prosekit/web': 0.9.0-beta.21(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)
-      '@prosemirror-adapter/core': 0.5.3
-      '@prosemirror-adapter/react': 0.5.3(react-dom@19.2.7)(react@19.2.7)
+      '@prosekit/core': 0.13.0-beta.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/pm': 0.1.19-beta.4
+      '@prosekit/web': 0.9.0-beta.24(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)
+      '@prosemirror-adapter/core': 0.5.5
+      '@prosemirror-adapter/react': 0.5.5(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -7977,16 +8027,16 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@prosekit/web@0.9.0-beta.21(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)':
+  '@prosekit/web@0.9.0-beta.24(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)':
     dependencies:
       '@aria-ui/core': 0.2.1
       '@aria-ui/elements': 0.1.12
       '@aria-ui/utils': 0.1.7
       '@floating-ui/dom': 1.8.0
       '@ocavue/utils': 1.7.0
-      '@prosekit/core': 0.13.0-beta.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      '@prosekit/extensions': 0.18.0-beta.16(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1)
-      '@prosekit/pm': 0.1.19-beta.3
+      '@prosekit/core': 0.13.0-beta.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      '@prosekit/extensions': 0.18.0-beta.19(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2)
+      '@prosekit/pm': 0.1.19-beta.4
       prosemirror-tables: 1.8.5
     transitivePeerDependencies:
       - '@lezer/common'
@@ -8006,19 +8056,19 @@ snapshots:
       - y-prosemirror
       - yjs
 
-  '@prosemirror-adapter/core@0.5.3':
+  '@prosemirror-adapter/core@0.5.5':
     dependencies:
       '@ocavue/utils': 1.7.0
       prosemirror-model: 1.25.11
       prosemirror-state: 1.4.4
-      prosemirror-view: 1.42.1
+      prosemirror-view: 1.42.2
 
-  '@prosemirror-adapter/react@0.5.3(react-dom@19.2.7)(react@19.2.7)':
+  '@prosemirror-adapter/react@0.5.5(react-dom@19.2.7)(react@19.2.7)':
     dependencies:
-      '@prosemirror-adapter/core': 0.5.3
+      '@prosemirror-adapter/core': 0.5.5
       prosemirror-model: 1.25.11
       prosemirror-state: 1.4.4
-      prosemirror-view: 1.42.1
+      prosemirror-view: 1.42.2
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -9681,6 +9731,11 @@ snapshots:
 
   baseline-browser-mapping@2.10.42: {}
 
+  beautiful-mermaid@1.1.3:
+    dependencies:
+      elkjs: 0.11.1
+      entities: 7.0.1
+
   before-after-hook@2.2.3: {}
 
   better-sqlite3@12.11.1:
@@ -10184,6 +10239,8 @@ snapshots:
 
   electron-to-chromium@1.5.387: {}
 
+  elkjs@0.11.1: {}
+
   embla-carousel-react@8.6.0(react@19.2.7):
     dependencies:
       embla-carousel: 8.6.0
@@ -10618,6 +10675,8 @@ snapshots:
   giget@3.2.0: {}
 
   github-from-package@0.0.0: {}
+
+  github-slugger@2.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -11092,7 +11151,7 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
-  katex@0.17.0:
+  katex@0.18.1:
     dependencies:
       commander: 8.3.0
 
@@ -11276,6 +11335,10 @@ snapshots:
       yallist: 4.0.0
 
   lucide-react@1.24.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
+  lucide-react@1.27.0(react@19.2.7):
     dependencies:
       react: 19.2.7
 
@@ -12119,7 +12182,7 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-view: 1.42.1
 
-  prosemirror-highlight@0.15.3(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.1):
+  prosemirror-highlight@0.15.3(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.3.1)(@types/hast@3.0.4)(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.42.2):
     optionalDependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -12128,7 +12191,7 @@ snapshots:
       prosemirror-model: 1.25.11
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
-      prosemirror-view: 1.42.1
+      prosemirror-view: 1.42.2
 
   prosemirror-history@1.5.0:
     dependencies:
@@ -12196,6 +12259,12 @@ snapshots:
       prosemirror-model: 1.25.11
 
   prosemirror-view@1.42.1:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-view@1.42.2:
     dependencies:
       prosemirror-model: 1.25.11
       prosemirror-state: 1.4.4
@@ -13117,6 +13186,8 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici@7.27.2: {}
+
+  unicode-by-name@0.2.0: {}
 
   unicorn-magic@0.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ minimumReleaseAgeExclude:
   - '@floating-ui/utils@0.2.12'
   - prosemirror-model@1.25.11
 
-# overrides:
-#   '@meowdown/core': https://pkg.pr.new/prosekit/meowdown/@meowdown/core@623bc43
-#   '@meowdown/react': https://pkg.pr.new/prosekit/meowdown/@meowdown/react@623bc43
-# blockExoticSubdeps: false
+overrides:
+  '@meowdown/core': https://pkg.pr.new/prosekit/meowdown/@meowdown/core@df741bb
+  '@meowdown/react': https://pkg.pr.new/prosekit/meowdown/@meowdown/react@df741bb
+blockExoticSubdeps: false


### PR DESCRIPTION
## Summary
- changes the iOS editor context bar list button to cycle text -> unordered list -> ordered list -> text
- wires Reflect to Meowdown `cyclePlainList()` from prosekit/meowdown#396 via the pkg.pr.new snapshot for commit `df741bb`
- updates the toolbar button accessibility label to `Cycle list style` while preserving haptics and focus handling

## State table
| Current editor state | Next state |
| --- | --- |
| Not a plain bullet or ordered list | Unordered list |
| Unordered list | Ordered list |
| Ordered list | No list |

## Edge-case behavior
- Task items are treated as non-plain-list content on the first press: they become plain unordered list items and Meowdown clears stale task attrs so checkbox semantics are not silently preserved after removing the marker.
- Nested selections follow Meowdown’s existing closest-list convention, matching the task local/global cycle behavior.
- Existing desktop keyboard commands remain on their current Meowdown `toggleList` key bindings (`Mod-Shift-7`, `Mod-Shift-8`, `Mod-Shift-9`).
- The task icon continues to dispatch `cycleCheckableList()`.

## Verification
Meowdown local checks:
- `pnpm test --run packages/core/src/extensions/list.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

Reflect local checks:
- `pnpm --filter @reflect/desktop test --run src/editor/formatting-toolbar-bridge.test.tsx src/mobile/formatting-toolbar.test.tsx src/editor/formatting-toolbar-store.test.ts`
- `pnpm check`
- `pnpm --filter @reflect/desktop build`

## QA limits
- iOS simulator/device QA could not run on this host because `xcrun simctl list devices available` fails with `xcrun: error: unable to find utility "simctl", not a developer tool or in PATH`.
- No dev app for this worktree appeared to be running, so there was nothing to rebuild/restart.

## Dependency status
- Depends on prosekit/meowdown#396. The Meowdown PR snapshot for `df741bb` is pinned in `pnpm-workspace.yaml` and `pnpm-lock.yaml`.
- Snapshot publication/Continuous Releases succeeded; Meowdown CI was still waiting on one Windows Chromium shard when this Reflect PR was opened.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mobile editor list semantics and depends on an unreleased Meowdown snapshot; scope is limited to the touch formatting toolbar with focused test coverage.
> 
> **Overview**
> The iOS formatting toolbar **list** control no longer toggles only bullets; it now drives a **three-state cycle** (plain text → unordered → ordered → plain) by routing `toggleBulletList` through Meowdown’s new `cyclePlainList()` instead of `toggleList({ kind: 'bullet' })`. The mobile button label changes from **Bullet list** to **Cycle list style**; the checklist/task button still uses `cycleCheckableList()`.
> 
> Reflect is **pinned** to Meowdown commit `df741bb` (prosekit/meowdown#396) via `pnpm-workspace.yaml` overrides and lockfile updates until that upstream PR lands. Bridge and mobile toolbar tests were updated to match the new command and labels; short implementation docs were added under `docs/ios-context-list-cycle/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571ef145b8ea0df24ddc33a396db99609d21b937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->