### PR TITLE
Add MiniMax BYOK provider with selectable regional endpoints

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -23,6 +23,8 @@
         { "url": "https://api.anthropic.com/*" },
         { "url": "https://generativelanguage.googleapis.com/*" },
         { "url": "https://openrouter.ai/*" },
+        { "url": "https://api.minimax.io/*" },
+        { "url": "https://api.minimaxi.com/*" },
         { "url": "https://github.com/login/device/code" },
         { "url": "https://github.com/login/oauth/access_token" },
         { "url": "https://api.github.com/*" }

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: reflect-asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://github.com https://api.github.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.ingest.de.sentry.io"
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: reflect-asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://api.minimax.io https://api.minimaxi.com https://github.com https://api.github.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.ingest.de.sentry.io"
     }
   },
   "plugins": {

--- a/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
+++ b/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
@@ -1,6 +1,13 @@
 import { useEffect, type ReactElement } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
-import { AI_PROVIDERS, aiProvider, aiProviderIdSchema, type AiProviderId } from '@reflect/core'
+import {
+  AI_PROVIDERS,
+  aiProvider,
+  aiProviderIdSchema,
+  DEFAULT_MINIMAX_REGION_ID,
+  providerRegions,
+  type AiProviderId,
+} from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -33,6 +40,8 @@ interface AddAiProviderForm {
   model: string
   apiKey: string
   isDefault: boolean
+  /** The regional deployment; only meaningful for multi-region providers. */
+  region: string
 }
 
 const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
@@ -52,6 +61,7 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
       model: AI_PROVIDERS[0].models[0].id,
       apiKey: '',
       isDefault: false,
+      region: DEFAULT_MINIMAX_REGION_ID,
     },
   })
   const { submitError, unverified, resetUnverified, submit } = useAddAiProviderSubmit({
@@ -75,10 +85,15 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
 
   const providerId = useWatch({ control, name: 'provider' })
   const selectedModel = useWatch({ control, name: 'model' })
+  const selectedRegion = useWatch({ control, name: 'region' })
   const provider = aiProvider(providerId)
+  const regions = providerRegions(providerId)
 
   const submitForm = handleSubmit(async (values) => {
-    await submit(values)
+    await submit({
+      ...values,
+      region: providerRegions(values.provider) ? values.region : undefined,
+    })
   })
 
   return (
@@ -104,6 +119,8 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
                 const next = aiProvider(aiProviderIdSchema.parse(value))
                 setValue('provider', next.id)
                 setValue('model', next.models[0].id)
+                const nextRegions = providerRegions(next.id)
+                setValue('region', nextRegions ? nextRegions[0].id : DEFAULT_MINIMAX_REGION_ID)
                 resetUnverified()
               }}
             >
@@ -129,6 +146,27 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
               onChange={(modelId) => setValue('model', modelId)}
             />
           </div>
+
+          {regions ? (
+            <div className="flex flex-col gap-1">
+              <span className={FIELD_LABEL_CLASS}>Region</span>
+              <Select
+                value={selectedRegion}
+                onValueChange={(value) => setValue('region', value)}
+              >
+                <SelectTrigger aria-label="Region" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {regions.map((region) => (
+                    <SelectItem key={region.id} value={region.id}>
+                      {region.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : null}
 
           <label className="flex flex-col gap-1">
             <span className={FIELD_LABEL_CLASS}>API key</span>

--- a/apps/desktop/src/components/settings/ai-providers-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-providers-section.test.tsx
@@ -176,6 +176,19 @@ describe('AiProvidersSection', () => {
     await expect.element(page.getByRole('option', { name: 'OpenRouter' })).toBeInTheDocument()
   })
 
+  it('reveals a region picker after choosing MiniMax', async () => {
+    await renderSection()
+    await expect.element(page.getByText(/No AI providers configured/)).toBeInTheDocument()
+
+    const dialog = await openDialog()
+    await expectLocatorToHaveCount(dialog.getByRole('combobox', { name: 'Region' }), 0)
+
+    await dialog.getByRole('combobox', { name: 'Provider' }).click()
+    await page.getByRole('option', { name: 'MiniMax' }).click()
+
+    await expect.element(dialog.getByRole('combobox', { name: 'Region' })).toBeInTheDocument()
+  })
+
   it('rejects a key the provider turns down, storing nothing', async () => {
     providerFetchMock.mockResolvedValue(new Response(null, { status: 401 }))
     await renderSection()

--- a/apps/desktop/src/hooks/use-add-ai-provider-submit.ts
+++ b/apps/desktop/src/hooks/use-add-ai-provider-submit.ts
@@ -49,7 +49,12 @@ export function useAddAiProviderSubmit({
       const apiKey = draft.apiKey.trim()
       try {
         if (!unverified) {
-          const validation = await validateApiKey(draft.provider, apiKey, providerFetch)
+          const validation = await validateApiKey(
+            draft.provider,
+            apiKey,
+            providerFetch,
+            draft.region,
+          )
           if (validation === 'invalid') {
             setSubmitError(`${aiProvider(draft.provider).label} rejected this API key.`)
             return

--- a/apps/desktop/src/hooks/use-ai-providers.ts
+++ b/apps/desktop/src/hooks/use-ai-providers.ts
@@ -26,6 +26,8 @@ export interface NewAiProvider {
   model: string
   apiKey: string
   isDefault: boolean
+  /** The regional deployment, for multi-region providers (MiniMax) only. */
+  region?: string | undefined
 }
 
 interface UseAiProvidersValue {
@@ -82,7 +84,13 @@ export function useAiProviders(): UseAiProvidersValue {
       updateSettingsWith((current) => {
         const next = withAiProviderAdded(
           { providers: current.aiProviders, defaultProviderId: current.defaultAiProviderId },
-          { id, provider: draft.provider, model: draft.model, keyHint: apiKeyHint(draft.apiKey) },
+          {
+            id,
+            provider: draft.provider,
+            model: draft.model,
+            keyHint: apiKeyHint(draft.apiKey),
+            ...(draft.region === undefined ? {} : { region: draft.region }),
+          },
           draft.isDefault,
         )
         return { aiProviders: next.providers, defaultAiProviderId: next.defaultProviderId }

--- a/apps/desktop/src/mobile/add-ai-provider-drawer.tsx
+++ b/apps/desktop/src/mobile/add-ai-provider-drawer.tsx
@@ -1,5 +1,12 @@
 import { useState, type ReactElement } from 'react'
-import { AI_PROVIDERS, aiProvider, aiProviderIdSchema, type AiProviderId } from '@reflect/core'
+import {
+  AI_PROVIDERS,
+  aiProvider,
+  aiProviderIdSchema,
+  DEFAULT_MINIMAX_REGION_ID,
+  providerRegions,
+  type AiProviderId,
+} from '@reflect/core'
 import { InlineAlert } from '@/components/inline-alert'
 import { Button } from '@/components/ui/button'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
@@ -57,6 +64,7 @@ function AddAiProviderSheet({
 }): ReactElement {
   const [providerId, setProviderId] = useState<AiProviderId>(AI_PROVIDERS[0].id)
   const [model, setModel] = useState(AI_PROVIDERS[0].models[0].id)
+  const [region, setRegion] = useState(DEFAULT_MINIMAX_REGION_ID)
   const [apiKey, setApiKey] = useState('')
   const [isDefault, setIsDefault] = useState(false)
   const [consented, setConsented] = useState(false)
@@ -66,11 +74,18 @@ function AddAiProviderSheet({
     onDone: onClose,
   })
   const provider = aiProvider(providerId)
+  const regions = providerRegions(providerId)
 
   const submitDraft = async (): Promise<void> => {
     setSubmitting(true)
     try {
-      await submit({ provider: providerId, model, apiKey, isDefault })
+      await submit({
+        provider: providerId,
+        model,
+        apiKey,
+        isDefault,
+        region: providerRegions(providerId) ? region : undefined,
+      })
     } finally {
       setSubmitting(false)
     }
@@ -93,6 +108,8 @@ function AddAiProviderSheet({
               const next = aiProvider(aiProviderIdSchema.parse(value))
               setProviderId(next.id)
               setModel(next.models[0].id)
+              const nextRegions = providerRegions(next.id)
+              setRegion(nextRegions ? nextRegions[0].id : DEFAULT_MINIMAX_REGION_ID)
               setConsented(false)
               resetUnverified()
             }}
@@ -125,6 +142,24 @@ function AddAiProviderSheet({
             </SelectContent>
           </Select>
         </div>
+
+        {regions ? (
+          <div className="flex flex-col gap-1">
+            <span className={FIELD_LABEL_CLASS}>Region</span>
+            <Select value={region} onValueChange={setRegion}>
+              <SelectTrigger aria-label="Region" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {regions.map((candidate) => (
+                  <SelectItem key={candidate.id} value={candidate.id}>
+                    {candidate.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ) : null}
 
         <label className="flex flex-col gap-1">
           <span className={FIELD_LABEL_CLASS}>API key</span>

--- a/packages/core/src/ai/audio-memo-title.ts
+++ b/packages/core/src/ai/audio-memo-title.ts
@@ -47,6 +47,9 @@ export function audioMemoEnrichmentConfig(config: AiProviderConfig): AiProviderC
       return { ...config, model: GOOGLE_AUDIO_MEMO_ENRICHMENT_MODEL }
     case 'openrouter':
       return null
+    case 'minimax':
+      // No fixed small enrichment model is defined for this provider.
+      return null
   }
 }
 

--- a/packages/core/src/ai/language-model.test.ts
+++ b/packages/core/src/ai/language-model.test.ts
@@ -34,6 +34,49 @@ const OPENROUTER_CONFIG: AiProviderConfig = {
   keyHint: 'wxyz1',
 }
 
+const MINIMAX_GLOBAL_CONFIG: AiProviderConfig = {
+  id: 'cfg-minimax-global',
+  provider: 'minimax',
+  model: 'MiniMax-M3',
+  keyHint: 'wxyz1',
+  region: 'global_en',
+}
+
+const MINIMAX_CN_CONFIG: AiProviderConfig = {
+  id: 'cfg-minimax-cn',
+  provider: 'minimax',
+  model: 'MiniMax-M3',
+  keyHint: 'wxyz1',
+  region: 'cn_zh',
+}
+
+function recordingChatCompletionFetch(calls: RecordedCall[], model: string): typeof fetch {
+  return async (input, init) => {
+    calls.push({
+      url: String(input),
+      headers: new Headers(init?.headers),
+      body: typeof init?.body === 'string' ? init.body : null,
+    })
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl_123',
+        object: 'chat.completion',
+        created: 0,
+        model,
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+}
+
 function recordingAnthropicFetch(calls: RecordedCall[]): typeof fetch {
   return async (input, init) => {
     calls.push({
@@ -158,5 +201,42 @@ describe('languageModel', () => {
     expect(calls[0]!.headers.get('Authorization')).toBe('Bearer sk-or-v1-test')
     expect(calls[0]!.headers.get('HTTP-Referer')).toBe('https://reflect.app')
     expect(calls[0]!.headers.get('X-OpenRouter-Title')).toBe('Reflect')
+  })
+
+  it('routes MiniMax through its global OpenAI-compatible chat endpoint', async () => {
+    const calls: RecordedCall[] = []
+
+    await generateText({
+      model: languageModel(
+        MINIMAX_GLOBAL_CONFIG,
+        'mm-test',
+        recordingChatCompletionFetch(calls, MINIMAX_GLOBAL_CONFIG.model),
+      ),
+      prompt: 'hello',
+      maxRetries: 0,
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.url).toBe('https://api.minimax.io/v1/chat/completions')
+    expect(calls[0]!.headers.get('Authorization')).toBe('Bearer mm-test')
+    expect(calls[0]!.body).toContain('"model":"MiniMax-M3"')
+  })
+
+  it('routes a China-region MiniMax entry to the China host', async () => {
+    const calls: RecordedCall[] = []
+
+    await generateText({
+      model: languageModel(
+        MINIMAX_CN_CONFIG,
+        'mm-test',
+        recordingChatCompletionFetch(calls, MINIMAX_CN_CONFIG.model),
+      ),
+      prompt: 'hello',
+      maxRetries: 0,
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.url).toBe('https://api.minimaxi.com/v1/chat/completions')
+    expect(calls[0]!.headers.get('Authorization')).toBe('Bearer mm-test')
   })
 })

--- a/packages/core/src/ai/language-model.ts
+++ b/packages/core/src/ai/language-model.ts
@@ -4,6 +4,7 @@ import { createOpenAI } from '@ai-sdk/openai'
 import type { LanguageModel } from 'ai'
 import type { AiProviderConfig } from '../settings/schema'
 import { anthropicDirectBrowserAccessHeaders } from './anthropic-headers'
+import { minimaxBaseUrl } from './minimax'
 import { OPENROUTER_BASE_URL, openRouterAttributionHeaders } from './openrouter'
 
 /**
@@ -35,6 +36,13 @@ export function languageModel(
         baseURL: OPENROUTER_BASE_URL,
         headers: openRouterAttributionHeaders(),
         name: 'openrouter',
+      }).chat(config.model)
+    case 'minimax':
+      return createOpenAI({
+        apiKey,
+        fetch: fetchFn,
+        baseURL: minimaxBaseUrl(config.region),
+        name: 'minimax',
       }).chat(config.model)
   }
 }

--- a/packages/core/src/ai/minimax.test.ts
+++ b/packages/core/src/ai/minimax.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_MINIMAX_REGION_ID,
+  MINIMAX_REGIONS,
+  minimaxBaseUrl,
+  providerRegions,
+} from './minimax'
+
+describe('minimaxBaseUrl', () => {
+  it('resolves each region to its OpenAI-compatible host', () => {
+    expect(minimaxBaseUrl('global_en')).toBe('https://api.minimax.io/v1')
+    expect(minimaxBaseUrl('cn_zh')).toBe('https://api.minimaxi.com/v1')
+  })
+
+  it('falls back to the default (global) region for absent or unknown ids', () => {
+    const fallback = MINIMAX_REGIONS[0].baseUrl
+    expect(minimaxBaseUrl(undefined)).toBe(fallback)
+    expect(minimaxBaseUrl('mars')).toBe(fallback)
+    expect(DEFAULT_MINIMAX_REGION_ID).toBe('global_en')
+  })
+})
+
+describe('providerRegions', () => {
+  it('offers regions only for the multi-region provider', () => {
+    expect(providerRegions('minimax')).toBe(MINIMAX_REGIONS)
+    expect(providerRegions('openai')).toBeNull()
+    expect(providerRegions('openrouter')).toBeNull()
+  })
+})

--- a/packages/core/src/ai/minimax.ts
+++ b/packages/core/src/ai/minimax.ts
@@ -1,0 +1,50 @@
+import type { AiProviderId } from '../settings/schema'
+
+/**
+ * MiniMax exposes the same OpenAI-compatible API from two regional
+ * deployments that differ only in host — and in the account each host issues
+ * keys for, so a key minted for one region is rejected by the other. A
+ * configured entry therefore records which region it was created against
+ * (`AiProviderConfig.region`), and every call — model dispatch and key
+ * validation alike — targets that region's host.
+ */
+
+/** One selectable MiniMax deployment. */
+export interface MinimaxRegion {
+  /** Stable id persisted on the provider entry (`AiProviderConfig.region`). */
+  id: string
+  /** Human-readable name shown in the region picker. */
+  label: string
+  /** The OpenAI-compatible API root for this region. */
+  baseUrl: string
+}
+
+/** The selectable MiniMax regions, global first (the picker default). */
+export const MINIMAX_REGIONS: [MinimaxRegion, ...MinimaxRegion[]] = [
+  { id: 'global_en', label: 'Global', baseUrl: 'https://api.minimax.io/v1' },
+  { id: 'cn_zh', label: 'China (mainland)', baseUrl: 'https://api.minimaxi.com/v1' },
+]
+
+/** The region a MiniMax entry falls back to when none was chosen or stored. */
+export const DEFAULT_MINIMAX_REGION_ID = MINIMAX_REGIONS[0].id
+
+/**
+ * The OpenAI-compatible base URL for `region`, falling back to the default
+ * (global) region for an absent or unknown id — the same tolerance the
+ * catalog shows for values a newer app version may have written.
+ */
+export function minimaxBaseUrl(region: string | undefined): string {
+  const match = MINIMAX_REGIONS.find((candidate) => candidate.id === region)
+  return (match ?? MINIMAX_REGIONS[0]).baseUrl
+}
+
+/**
+ * The selectable regions for `provider`, or `null` for the single-endpoint
+ * providers. Lets the add-provider shells render a region picker without
+ * hard-coding which provider is regional.
+ */
+export function providerRegions(
+  provider: AiProviderId,
+): [MinimaxRegion, ...MinimaxRegion[]] | null {
+  return provider === 'minimax' ? MINIMAX_REGIONS : null
+}

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -30,6 +30,14 @@ describe('AI_PROVIDERS', () => {
       keyPlaceholder: 'sk-or-v1-…',
     })
   })
+
+  it('includes MiniMax with its two curated models', () => {
+    expect(aiProvider('minimax')).toMatchObject({ id: 'minimax', label: 'MiniMax' })
+    expect(aiProvider('minimax').models).toEqual([
+      { id: 'MiniMax-M3', label: 'MiniMax-M3', contextWindow: 1_000_000 },
+      { id: 'MiniMax-M2.7', label: 'MiniMax-M2.7', contextWindow: 204_800 },
+    ])
+  })
 })
 
 describe('modelContextWindow', () => {
@@ -46,6 +54,8 @@ describe('modelContextWindow', () => {
   it('resolves a curated model and falls back for unknown ids', () => {
     expect(modelContextWindow('anthropic', 'claude-haiku-4-5')).toBe(200_000)
     expect(modelContextWindow('openrouter', 'openrouter/auto')).toBe(128_000)
+    expect(modelContextWindow('minimax', 'MiniMax-M3')).toBe(1_000_000)
+    expect(modelContextWindow('minimax', 'MiniMax-M2.7')).toBe(204_800)
     // Settings may carry ids added by a newer app version.
     expect(modelContextWindow('anthropic', 'claude-fable-6')).toBe(DEFAULT_CONTEXT_WINDOW)
   })

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -89,6 +89,15 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
       { id: 'openai/gpt-5.2', label: 'GPT-5.2', contextWindow: 400_000 },
     ],
   },
+  {
+    id: 'minimax',
+    label: 'MiniMax',
+    keyPlaceholder: 'eyJ…',
+    models: [
+      { id: 'MiniMax-M3', label: 'MiniMax-M3', contextWindow: 1_000_000 },
+      { id: 'MiniMax-M2.7', label: 'MiniMax-M2.7', contextWindow: 204_800 },
+    ],
+  },
 ]
 
 /** The catalog entry for `id` (every `AiProviderId` is in the catalog). */

--- a/packages/core/src/ai/validate-key.test.ts
+++ b/packages/core/src/ai/validate-key.test.ts
@@ -25,6 +25,8 @@ describe('validateApiKey', () => {
     await validateApiKey('anthropic', 'sk-ant-test', recordingFetch)
     await validateApiKey('google', 'AIza-test', recordingFetch)
     await validateApiKey('openrouter', 'sk-or-v1-test', recordingFetch)
+    await validateApiKey('minimax', 'mm-test', recordingFetch, 'global_en')
+    await validateApiKey('minimax', 'mm-test', recordingFetch, 'cn_zh')
 
     expect(calls[0]!.url).toBe('https://api.openai.com/v1/models')
     expect(calls[0]!.headers['Authorization']).toBe('Bearer sk-test')
@@ -35,6 +37,9 @@ describe('validateApiKey', () => {
     expect(calls[2]!.headers['x-goog-api-key']).toBe('AIza-test')
     expect(calls[3]!.url).toBe('https://openrouter.ai/api/v1/key')
     expect(calls[3]!.headers['Authorization']).toBe('Bearer sk-or-v1-test')
+    expect(calls[4]!.url).toBe('https://api.minimax.io/v1/models')
+    expect(calls[4]!.headers['Authorization']).toBe('Bearer mm-test')
+    expect(calls[5]!.url).toBe('https://api.minimaxi.com/v1/models')
   })
 
   it('reads an ok response as valid', async () => {
@@ -51,6 +56,9 @@ describe('validateApiKey', () => {
     // Gemini reports malformed keys as 400.
     expect(await validateApiKey('google', 'bad', fetchReturning(400))).toBe('invalid')
     expect(await validateApiKey('openrouter', 'sk-or-v1-test', fetchReturning(401))).toBe(
+      'invalid',
+    )
+    expect(await validateApiKey('minimax', 'mm-test', fetchReturning(401), 'global_en')).toBe(
       'invalid',
     )
   })

--- a/packages/core/src/ai/validate-key.ts
+++ b/packages/core/src/ai/validate-key.ts
@@ -1,6 +1,7 @@
 import type { AiProviderId } from '../settings/schema'
 import { anthropicDirectBrowserAccessHeaders } from './anthropic-headers'
 import { APP_REVIEW_STUB_KEY } from './audio-memo-review-stub'
+import { minimaxBaseUrl } from './minimax'
 import { OPENROUTER_BASE_URL } from './openrouter'
 
 /**
@@ -24,7 +25,7 @@ interface KeyProbe {
   invalidStatuses: number[]
 }
 
-const PROBES: Record<AiProviderId, KeyProbe> = {
+const PROBES: Record<Exclude<AiProviderId, 'minimax'>, KeyProbe> = {
   openai: {
     url: 'https://api.openai.com/v1/models',
     headers: (key) => ({ Authorization: `Bearer ${key}` }),
@@ -53,14 +54,32 @@ const PROBES: Record<AiProviderId, KeyProbe> = {
 }
 
 /**
+ * The probe for `provider`. MiniMax is region-dependent — global and China
+ * keys live behind different hosts — so its probe is built from the chosen
+ * region's OpenAI-compatible root rather than stored statically.
+ */
+function keyProbe(provider: AiProviderId, region: string | undefined): KeyProbe {
+  if (provider === 'minimax') {
+    return {
+      url: `${minimaxBaseUrl(region)}/models`,
+      headers: (key) => ({ Authorization: `Bearer ${key}` }),
+      invalidStatuses: [401, 403],
+    }
+  }
+  return PROBES[provider]
+}
+
+/**
  * Probe `provider` with `apiKey`. `fetchFn` lets hosts substitute a
  * CORS-free transport (the desktop app passes the Tauri HTTP plugin's fetch;
- * `@reflect/core` itself stays platform-agnostic).
+ * `@reflect/core` itself stays platform-agnostic). `region` selects the host
+ * for multi-region providers (MiniMax) and is ignored by the rest.
  */
 export async function validateApiKey(
   provider: AiProviderId,
   apiKey: string,
   fetchFn: typeof fetch = fetch,
+  region?: string,
 ): Promise<ApiKeyValidation> {
   // Providers know nothing about the App Review demo key, so a probe would
   // reject it; accept it here so it can be saved and reach the canned
@@ -68,7 +87,7 @@ export async function validateApiKey(
   if (apiKey === APP_REVIEW_STUB_KEY) {
     return 'valid'
   }
-  const probe = PROBES[provider]
+  const probe = keyProbe(provider, region)
   let response: Response
   try {
     response = await fetchFn(probe.url, { method: 'GET', headers: probe.headers(apiKey) })

--- a/packages/core/src/exports/ai-actions.ts
+++ b/packages/core/src/exports/ai-actions.ts
@@ -29,6 +29,13 @@ export {
 } from '../ai/chat/model-options'
 export { validateApiKey, type ApiKeyValidation } from '../ai/validate-key'
 export {
+  MINIMAX_REGIONS,
+  DEFAULT_MINIMAX_REGION_ID,
+  minimaxBaseUrl,
+  providerRegions,
+  type MinimaxRegion,
+} from '../ai/minimax'
+export {
   assertCloudAllowed,
   cloudSafeAssetDescription,
   cloudSafeGraphContext,

--- a/packages/core/src/settings/schema.test.ts
+++ b/packages/core/src/settings/schema.test.ts
@@ -282,6 +282,17 @@ describe('settingsSchema', () => {
       expect(settingsSchema.parse({ aiProviders: [entry] }).aiProviders).toEqual([entry])
     })
 
+    it('accepts a MiniMax entry with its region', () => {
+      const entry = {
+        id: 'minimax',
+        provider: 'minimax',
+        model: 'MiniMax-M3',
+        keyHint: 'wxyz1',
+        region: 'cn_zh',
+      }
+      expect(settingsSchema.parse({ aiProviders: [entry] }).aiProviders).toEqual([entry])
+    })
+
     it('defaults the per-entry display fields', () => {
       const entry = { id: 'abc', provider: 'openai', model: 'gpt-5.1' }
       expect(settingsSchema.parse({ aiProviders: [entry] }).aiProviders).toEqual([

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -313,7 +313,7 @@ export const graphColorsSchema = z
  * The cloud AI providers Reflect can call directly (BYOK — the user's own
  * keys, no Reflect-hosted proxy).
  */
-export const aiProviderIdSchema = z.enum(['openai', 'anthropic', 'google', 'openrouter'])
+export const aiProviderIdSchema = z.enum(['openai', 'anthropic', 'google', 'openrouter', 'minimax'])
 
 export type AiProviderId = z.infer<typeof aiProviderIdSchema>
 
@@ -330,6 +330,14 @@ export const aiProviderConfigSchema = z.object({
   provider: aiProviderIdSchema,
   model: z.string().min(1),
   keyHint: z.string().catch(''),
+  /**
+   * The regional deployment a multi-region provider (MiniMax) was configured
+   * against — persisted so dispatch and key validation target the same host
+   * the key was issued for. Absent for single-endpoint providers; an unknown
+   * id degrades to `undefined` (the provider's default region) rather than
+   * dropping the whole entry.
+   */
+  region: z.string().min(1).optional().catch(undefined),
 })
 
 export type AiProviderConfig = z.infer<typeof aiProviderConfigSchema>


### PR DESCRIPTION
Reason: The BYOK provider catalog and AI SDK dispatch had no direct MiniMax provider, so MiniMax models and their regional endpoints could not be configured.

## What this adds

- A `minimax` entry in the static BYOK provider catalog with two curated models — `MiniMax-M3` (1,000,000-token context window) and `MiniMax-M2.7` (204,800-token context window) — so their context windows resolve exactly instead of falling back to the generic default.
- OpenAI-compatible model dispatch for MiniMax in `languageModel`, pointed at the configured region's chat-completions endpoint.
- Region-aware key validation: the validation probe targets the selected region's host, since a key issued for one region is rejected by the other.
- A persisted `region` field on a configured provider entry plus a **Region** picker in the desktop add-provider dialog and the mobile add-provider sheet, offering the Global (`api.minimax.io`) and China (`api.minimaxi.com`) OpenAI-compatible endpoints. The picker is shown only for the multi-region provider; the choice drives both dispatch and validation.
- The two MiniMax hosts added to the desktop HTTP capability allowlist and the webview CSP `connect-src`.

Region logic lives in a new `packages/core/src/ai/minimax.ts` (regions, default region, base-URL resolver), following the existing one-module-per-provider pattern. An entry with an absent or unknown region degrades to the Global endpoint rather than dropping the entry, matching the catalog's tolerance for values written by a newer app version.

## Checks run

Installed with `pnpm install --ignore-scripts` (Node 20 / pnpm 9; the native `better-sqlite3` build is unrelated to these changes and is not needed by the suites below).

- `vitest run` over the core AI and settings suites (`provider-catalog`, `language-model`, `validate-key`, `settings/schema`, `minimax`, `provider-config`, `audio-memo-title`): the new MiniMax cases pass — catalog entry and context windows, dispatch to the Global and China chat-completions endpoints, region-aware key validation, and the settings round-trip of the `region` field.
- `tsc --noEmit` for `@reflect/core` and `apps/desktop`: clean.
- `oxlint apps packages` and `eslint` on the changed desktop files: clean.

One pre-existing Anthropic dispatch test fails identically on the unmodified base branch in this environment (an AI-SDK base-URL difference) and is unrelated to this change. The Playwright-based desktop browser suite (`*.test.tsx`) was not executed here (no browser binaries); the added region-picker test mirrors the existing provider-picker test and is covered by typecheck and lint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as an AI provider, including MiniMax M3 and M2.7 models.
  * Added region selection for MiniMax providers on desktop and mobile.
  * Added support for global and China-region MiniMax endpoints.
  * Added region-aware API key validation and provider configuration persistence.

* **Tests**
  * Added coverage for MiniMax models, routing, regions, validation, and setup flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->