### PR TITLE
feat: copy note paths from note actions

### DIFF
--- a/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
@@ -13,11 +13,14 @@ const getNote = vi.hoisted(() => vi.fn())
 const toggleNotePinned = vi.hoisted(() => vi.fn(async () => true))
 const toggleNotePrivate = vi.hoisted(() => vi.fn(async () => true))
 const deleteOpenNote = vi.hoisted(() => vi.fn(async () => {}))
+const joinPath = vi.hoisted(() => vi.fn(async (root: string, path: string) => `${root}/${path}`))
+const operationDone = vi.hoisted(() => vi.fn())
 const operationFail = vi.hoisted(() => vi.fn())
 const startOperation = vi.hoisted(() =>
-  vi.fn(() => ({ progress: vi.fn(), done: vi.fn(), fail: operationFail })),
+  vi.fn(() => ({ progress: vi.fn(), done: operationDone, fail: operationFail })),
 )
 const isApplePlatform = vi.hoisted(() => vi.fn(() => false))
+vi.mock('@tauri-apps/api/path', () => ({ join: joinPath }))
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
   hasBridge: () => true,
@@ -58,12 +61,22 @@ beforeEach(() => {
   toggleNotePrivate.mockReset().mockResolvedValue(true)
   deleteOpenNote.mockReset().mockResolvedValue(undefined)
   startOperation.mockClear()
+  joinPath.mockReset().mockImplementation(async (root, path) => `${root}/${path}`)
+  operationDone.mockClear()
   operationFail.mockClear()
   isApplePlatform.mockReturnValue(false)
+  Reflect.deleteProperty(navigator, 'clipboard')
 })
 
 function noteRow(path: string, isPrivate: boolean, title = 'A') {
   return { path, title, dailyDate: null, isPrivate }
+}
+
+function stubClipboard(writeText: (text: string) => Promise<void>): void {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  })
 }
 
 describe('NoteActionsSection pin toggle', () => {
@@ -194,6 +207,56 @@ describe('NoteActionsSection deep-link action', () => {
   it('does not offer Copy deep link in note actions', async () => {
     const view = await renderSection('notes/a.md')
     expect(view.getByRole('button', { name: /Copy deep link/ }).query()).toBeNull()
+    await view.unmount()
+  })
+})
+
+describe('NoteActionsSection copy-path action', () => {
+  it('copies the absolute path of a regular note', async () => {
+    const writeText = vi.fn(async () => {})
+    stubClipboard(writeText)
+    const view = await renderSection('notes/a.md')
+
+    await userEvent.click(view.getByRole('button', { name: 'Copy note path' }))
+
+    await vi.waitFor(() => expect(joinPath).toHaveBeenCalledWith('/g', 'notes/a.md'))
+    expect(writeText).toHaveBeenCalledWith('/g/notes/a.md')
+    expect(startOperation).toHaveBeenCalledWith('Note path copied')
+    expect(operationDone).toHaveBeenCalled()
+    await view.unmount()
+  })
+
+  it('copies the absolute path of a daily note', async () => {
+    const writeText = vi.fn(async () => {})
+    stubClipboard(writeText)
+    const view = await renderSection('daily/2026-06-10.md')
+
+    await userEvent.click(view.getByRole('button', { name: 'Copy note path' }))
+
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith('/g/daily/2026-06-10.md'))
+    await view.unmount()
+  })
+
+  it('surfaces clipboard failures through the operations status', async () => {
+    stubClipboard(vi.fn(async () => Promise.reject(new Error('Document is not focused'))))
+    const view = await renderSection('notes/a.md')
+
+    await userEvent.click(view.getByRole('button', { name: 'Copy note path' }))
+
+    await vi.waitFor(() => expect(startOperation).toHaveBeenCalledWith('Copying note path'))
+    expect(operationFail).toHaveBeenCalledWith('Document is not focused')
+    await view.unmount()
+  })
+
+  it('surfaces path-resolution failures through the operations status', async () => {
+    joinPath.mockRejectedValueOnce(new Error('Path unavailable'))
+    stubClipboard(vi.fn(async () => {}))
+    const view = await renderSection('notes/a.md')
+
+    await userEvent.click(view.getByRole('button', { name: 'Copy note path' }))
+
+    await vi.waitFor(() => expect(startOperation).toHaveBeenCalledWith('Copying note path'))
+    expect(operationFail).toHaveBeenCalledWith('Path unavailable')
     await view.unmount()
   })
 })

--- a/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
@@ -20,6 +20,11 @@ const startOperation = vi.hoisted(() =>
   vi.fn(() => ({ progress: vi.fn(), done: operationDone, fail: operationFail })),
 )
 const isApplePlatform = vi.hoisted(() => vi.fn(() => false))
+const useGraph = vi.hoisted(() =>
+  vi.fn<() => { graph: { root: string; name: string; generation: number } | null }>(() => ({
+    graph: { root: '/g', name: 'g', generation: 7 },
+  })),
+)
 vi.mock('@tauri-apps/api/path', () => ({ join: joinPath }))
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
@@ -35,9 +40,7 @@ vi.mock('@/lib/note-pin', () => ({ toggleNotePinned }))
 vi.mock('@/lib/note-private', () => ({ toggleNotePrivate }))
 vi.mock('@/lib/note-delete', () => ({ deleteOpenNote }))
 vi.mock('@/lib/operations', () => ({ startOperation }))
-vi.mock('@/providers/graph-provider', () => ({
-  useGraph: () => ({ graph: { root: '/g', name: 'g', generation: 7 } }),
-}))
+vi.mock('@/providers/graph-provider', () => ({ useGraph }))
 
 async function renderSection(path: string, showTrash = false) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -65,6 +68,9 @@ beforeEach(() => {
   operationDone.mockClear()
   operationFail.mockClear()
   isApplePlatform.mockReturnValue(false)
+  useGraph.mockReset().mockReturnValue({
+    graph: { root: '/g', name: 'g', generation: 7 },
+  })
   Reflect.deleteProperty(navigator, 'clipboard')
 })
 
@@ -257,6 +263,21 @@ describe('NoteActionsSection copy-path action', () => {
 
     await vi.waitFor(() => expect(startOperation).toHaveBeenCalledWith('Copying note path'))
     expect(operationFail).toHaveBeenCalledWith('Path unavailable')
+    await view.unmount()
+  })
+
+  it('reports when no graph is open', async () => {
+    useGraph.mockReturnValue({ graph: null })
+    const writeText = vi.fn(async () => {})
+    stubClipboard(writeText)
+    const view = await renderSection('notes/a.md')
+
+    await userEvent.click(view.getByRole('button', { name: 'Copy note path' }))
+
+    expect(startOperation).toHaveBeenCalledWith('Copying note path')
+    expect(operationFail).toHaveBeenCalledWith('No graph is open')
+    expect(joinPath).not.toHaveBeenCalled()
+    expect(writeText).not.toHaveBeenCalled()
     await view.unmount()
   })
 })

--- a/apps/desktop/src/components/context-sidebar/note-actions-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-actions-section.tsx
@@ -7,6 +7,7 @@ import { keybindingFor } from '@/lib/commands/app-commands'
 import { toggleNotePinned } from '@/lib/note-pin'
 import { toggleNotePrivate } from '@/lib/note-private'
 import { useOptimisticPinToggle } from '@/lib/notes/use-optimistic-pin-toggle'
+import { NoteCopyPathAction } from './note-copy-path-action'
 import { NoteGistAction } from './note-gist-action'
 import { NoteTrashAction } from './note-trash-action'
 import { NoteToggleAction } from './note-toggle-action'
@@ -68,6 +69,7 @@ export function NoteActionsSection({
         keybinding={PRIVATE_KEYBINDING}
         tooltip="Locks this note out of AI. Backup and sync still include it."
       />
+      <NoteCopyPathAction path={path} />
       <NoteGistAction path={path} keybinding={GIST_KEYBINDING} />
       {showTrash ? <NoteTrashAction path={path} /> : null}
     </SidebarSection>

--- a/apps/desktop/src/components/context-sidebar/note-copy-path-action.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-copy-path-action.tsx
@@ -11,9 +11,10 @@ interface NoteCopyPathActionProps {
 }
 
 /**
- * Copies the note's absolute filesystem path for pasting into agent chats and
- * other tools outside Reflect. Joining through Tauri preserves the host
- * platform's path syntax.
+ * Resolves the note at the graph-relative `path` prop to an absolute filesystem
+ * path and copies it for use in agent chats and other tools outside Reflect.
+ * Joining through Tauri preserves the host platform's path syntax; success and
+ * failure feedback appears through the app-wide operations status.
  */
 export function NoteCopyPathAction({ path }: NoteCopyPathActionProps): ReactElement {
   const { graph } = useGraph()

--- a/apps/desktop/src/components/context-sidebar/note-copy-path-action.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-copy-path-action.tsx
@@ -20,6 +20,7 @@ export function NoteCopyPathAction({ path }: NoteCopyPathActionProps): ReactElem
 
   const copyPath = async (): Promise<void> => {
     if (graph === null) {
+      startOperation('Copying note path').fail('No graph is open')
       return
     }
     try {

--- a/apps/desktop/src/components/context-sidebar/note-copy-path-action.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-copy-path-action.tsx
@@ -1,0 +1,46 @@
+import type { ReactElement } from 'react'
+import { join } from '@tauri-apps/api/path'
+import { errorMessage } from '@reflect/core'
+import { Copy } from 'lucide-react'
+import { startOperation } from '@/lib/operations'
+import { useGraph } from '@/providers/graph-provider'
+
+interface NoteCopyPathActionProps {
+  /** Graph-relative path of the note whose absolute path should be copied. */
+  path: string
+}
+
+/**
+ * Copies the note's absolute filesystem path for pasting into agent chats and
+ * other tools outside Reflect. Joining through Tauri preserves the host
+ * platform's path syntax.
+ */
+export function NoteCopyPathAction({ path }: NoteCopyPathActionProps): ReactElement {
+  const { graph } = useGraph()
+
+  const copyPath = async (): Promise<void> => {
+    if (graph === null) {
+      return
+    }
+    try {
+      const absolutePath = await join(graph.root, path)
+      await navigator.clipboard.writeText(absolutePath)
+      startOperation('Note path copied').done()
+    } catch (cause) {
+      startOperation('Copying note path').fail(errorMessage(cause))
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void copyPath()}
+      className="group relative flex w-full items-center space-x-2 rounded-lg px-3 py-2 text-start transition-colors duration-100 hover:bg-surface-hover"
+    >
+      <span className="flex h-5 w-5 flex-none items-center justify-center text-text-muted transition-colors duration-100 group-hover:text-text">
+        <Copy size={14} aria-hidden />
+      </span>
+      <span className="min-w-0 flex-1 truncate text-xs font-medium">Copy note path</span>
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary

- add a Copy note path action to the desktop note context sidebar
- copy an OS-native absolute path for regular and daily notes
- report copy and path-resolution failures through the operations status

## Testing

- pnpm test --run apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an action to copy the current note’s absolute file path to the clipboard.
  * Displays a success notification after the path is copied.
  * Reports clear errors when copying fails or no graph is open.

* **Tests**
  * Added coverage for regular and daily notes, successful copying, path resolution failures, clipboard errors, and cases where no graph is open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->