### PR TITLE
feat(mobile): add an image button to the keyboard toolbar

### DIFF
--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -6,6 +6,12 @@
 <dict>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Reflect uses the microphone to record audio memos that are transcribed into your daily note.</string>
+	<!-- The keyboard toolbar's image button opens the webview file picker,
+	     whose iOS sheet always offers "Take Photo or Video" — that branch
+	     presents the camera in-process, so the key is required even though
+	     most picks come from the photo library. -->
+	<key>NSCameraUsageDescription</key>
+	<string>Reflect uses the camera so you can take a photo and add it to a note. Photos are saved into your notes folder on this device.</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>
 	<string>Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.</string>
 	<!-- Pre-Sonoma systems prompt with the legacy key. -->

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -79,6 +79,7 @@ targets:
         # xcodegen regens keep them in the committed generated Info.plist
         # instead of silently dropping them.
         NSMicrophoneUsageDescription: Reflect uses the microphone to record audio memos that are transcribed into your daily note.
+        NSCameraUsageDescription: Reflect uses the camera so you can take a photo and add it to a note. Photos are saved into your notes folder on this device.
         NSCalendarsFullAccessUsageDescription: Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.
         NSCalendarsUsageDescription: Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.
         # Audio memos keep recording through screen lock and backgrounding

--- a/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open_iOS/Info.plist
@@ -41,6 +41,8 @@
 	<string>Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Reflect reads your calendar to show the day's meetings beside your daily note. Access is read-only and stays on this device.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Reflect uses the camera so you can take a photo and add it to a note. Photos are saved into your notes folder on this device.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>Reflect reads your contacts to suggest details for person notes. Nothing is stored or sent anywhere.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/apps/desktop/src/editor/formatting-toolbar-bridge.test.tsx
+++ b/apps/desktop/src/editor/formatting-toolbar-bridge.test.tsx
@@ -25,13 +25,18 @@ interface Setup {
   rerender: (nextEditor: boolean) => Promise<void>
 }
 
-async function setupEditor(initialContent: string, touchEditor = true): Promise<Setup> {
+async function setupEditor(
+  initialContent: string,
+  touchEditor = true,
+  saveFile?: (file: File) => Promise<string | null>,
+): Promise<Setup> {
   setPlatformSurface({ touchEditor })
   const grabbed: { current: NoteEditorHandle | null } = { current: null }
   const editor = (
     <NoteEditor
       initialContent={initialContent}
       onWikilinkSearch={async () => []}
+      {...(saveFile !== undefined ? { saveFile } : {})}
       handleRef={(handle) => {
         grabbed.current = handle
       }}
@@ -74,6 +79,7 @@ describe('FormattingToolbarBridge', () => {
       canDedent: true,
       canMoveUp: true,
       canMoveDown: false,
+      canAttachFiles: false,
     })
   })
 
@@ -156,6 +162,44 @@ describe('FormattingToolbarBridge', () => {
 
     captured.toolbar?.commands.insertTrigger('[[')
     await expect.element(page.getByTestId('wikilink-menu')).toBeInTheDocument()
+  })
+
+  it('persists attached files and inserts their markdown', async () => {
+    const saveFile = vi.fn(async (file: File) => `assets/${file.name}`)
+    const { handle } = await setupEditor('alpha', true, saveFile)
+
+    await pmRoot.getByText('alpha').click()
+    await expect.element(toolbarState).toHaveTextContent('has-toolbar')
+    expect(captured.toolbar?.capabilities.canAttachFiles).toBe(true)
+    handle.setSelection('end')
+
+    await captured.toolbar?.commands.attachFiles([
+      new File(['png'], 'photo.png', { type: 'image/png' }),
+      new File(['txt'], 'notes.txt', { type: 'text/plain' }),
+    ])
+
+    expect(saveFile).toHaveBeenCalledTimes(2)
+    await vi.waitFor(() => {
+      // An image becomes an embed and any other file a link, exactly as a
+      // paste of the same files would.
+      expect(handle.getMarkdown()).toContain('![](assets/photo.png)')
+      expect(handle.getMarkdown()).toContain('[notes.txt](assets/notes.txt)')
+    })
+  })
+
+  it('inserts nothing when the save declines the file', async () => {
+    const saveFile = vi.fn(async () => null)
+    const { handle } = await setupEditor('alpha', true, saveFile)
+
+    await pmRoot.getByText('alpha').click()
+    await expect.element(toolbarState).toHaveTextContent('has-toolbar')
+
+    await captured.toolbar?.commands.attachFiles([
+      new File(['png'], 'photo.png', { type: 'image/png' }),
+    ])
+
+    expect(saveFile).toHaveBeenCalledOnce()
+    expect(handle.getMarkdown()).toBe('alpha\n')
   })
 
   it('clears its published toolbar on unmount', async () => {

--- a/apps/desktop/src/editor/formatting-toolbar-bridge.tsx
+++ b/apps/desktop/src/editor/formatting-toolbar-bridge.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
 import { useEditor } from '@meowdown/react'
-import type { EditorExtension } from '@meowdown/core'
+import { buildFileMarkdown, type EditorExtension } from '@meowdown/core'
+import { toPortableImageFile } from '@/lib/image-file'
 import { isTouchEditorSurface } from '@/lib/platform-surface'
 import {
   clearFormattingToolbar,
@@ -28,9 +29,26 @@ import {
  *
  * The command surface also carries `scrollCaretIntoView` for the keyboard's
  * caret reveal; no toolbar button calls it.
+ *
+ * `saveFile` is the same handler meowdown gets for paste and drop, so the
+ * toolbar's attach button persists files down the one path and inserts the
+ * markdown a paste would have inserted. Editors without one publish
+ * `canAttachFiles: false` and the toolbar leaves the button out.
  */
-export function FormattingToolbarBridge(): null {
+export function FormattingToolbarBridge({
+  saveFile,
+}: {
+  /** Persist a file and resolve its markdown destination (undefined declines). */
+  saveFile?: (file: File) => Promise<string | undefined>
+}): null {
   const editor = useEditor<EditorExtension>()
+  // Read through a ref like the editor's other host callbacks: a changing
+  // identity must not tear down and re-attach the published toolbar.
+  const saveFileRef = useRef(saveFile)
+  useLayoutEffect(() => {
+    saveFileRef.current = saveFile
+  }, [saveFile])
+  const canAttachFiles = saveFile !== undefined
 
   useEffect(() => {
     if (!isTouchEditorSurface()) {
@@ -57,6 +75,7 @@ export function FormattingToolbarBridge(): null {
           canDedent: editor.commands.dedentList.canExec(),
           canMoveUp: editor.commands.moveList.canExec('up'),
           canMoveDown: editor.commands.moveList.canExec('down'),
+          canAttachFiles,
         }
       }
 
@@ -79,6 +98,31 @@ export function FormattingToolbarBridge(): null {
         insertTrigger: (text: FormattingTriggerText) =>
           run(() => editor.commands.insertTrigger(text)),
         dismissKeyboard: () => editor.blur(),
+        attachFiles: async (files: File[]) => {
+          const save = saveFileRef.current
+          if (save === undefined) {
+            return
+          }
+          const markdown: string[] = []
+          for (const picked of files) {
+            const file = await toPortableImageFile(picked)
+            // `saveFile` owns its failures (it resolves undefined and the
+            // pane raises the banner), so a file that did not land is
+            // skipped and the ones that did are still linked.
+            const destination = await save(file)
+            if (destination !== undefined) {
+              markdown.push(buildFileMarkdown(file, destination))
+            }
+          }
+          // The picker outlives the keyboard, and on iOS the sheet took focus
+          // away to open — refocusing puts the caret (and the keyboard) back
+          // where the tap left them, and the insert lands there.
+          if (markdown.length === 0 || !editor.mounted) {
+            return
+          }
+          editor.focus()
+          run(() => editor.commands.insertMarkdown(markdown.join('\n')))
+        },
         // Not wrapped in `run()`: this never changes the document. Skipped
         // mid-composition, where a dispatch would end the composition and eat
         // a half-typed CJK character.
@@ -145,7 +189,10 @@ export function FormattingToolbarBridge(): null {
       }
       teardown?.()
     }
-  }, [editor])
+    // `canAttachFiles` is fixed per editor in practice (a pane either has a
+    // saveFile or does not), so re-attaching on a flip costs nothing and
+    // keeps the published capability honest.
+  }, [editor, canAttachFiles])
 
   return null
 }

--- a/apps/desktop/src/editor/formatting-toolbar-store.test.tsx
+++ b/apps/desktop/src/editor/formatting-toolbar-store.test.tsx
@@ -17,6 +17,7 @@ function makeToolbar(
       canDedent: false,
       canMoveUp: false,
       canMoveDown: false,
+      canAttachFiles: false,
       ...overrides,
     },
     commands: {
@@ -28,6 +29,7 @@ function makeToolbar(
       moveDown: vi.fn(),
       insertTrigger: vi.fn(),
       dismissKeyboard: vi.fn(),
+      attachFiles: vi.fn(),
       scrollCaretIntoView: vi.fn(),
     },
   }

--- a/apps/desktop/src/editor/formatting-toolbar-store.ts
+++ b/apps/desktop/src/editor/formatting-toolbar-store.ts
@@ -11,6 +11,12 @@ export interface FormattingToolbarCapabilities {
   canDedent: boolean
   canMoveUp: boolean
   canMoveDown: boolean
+  /**
+   * Whether this editor can persist files. Only a pane that was given a
+   * `saveFile` can (the inline task editor, for one, was not), and an attach
+   * button over an editor without one is a button that does nothing.
+   */
+  canAttachFiles: boolean
 }
 
 /** Autocomplete-trigger characters the toolbar can type into the editor. */
@@ -34,6 +40,13 @@ export interface FormattingToolbarCommands {
   insertTrigger: (text: FormattingTriggerText) => void
   /** Blur the editor, dropping the software keyboard (and this toolbar). */
   dismissKeyboard: () => void
+  /**
+   * Persist picked files into the graph's `assets/` and insert their markdown
+   * at the caret — `![](…)` for an image, a `[name](…)` link otherwise, the
+   * same markdown a paste or drop produces. A no-op without
+   * {@link FormattingToolbarCapabilities.canAttachFiles}.
+   */
+  attachFiles: (files: File[]) => Promise<void>
   /**
    * Scroll the caret back into view if it left the visible area; a no-op
    * while it is visible. Called by the keyboard reveal, not a toolbar button.
@@ -73,7 +86,8 @@ function capabilitiesEqual(
     left.canIndent === right.canIndent &&
     left.canDedent === right.canDedent &&
     left.canMoveUp === right.canMoveUp &&
-    left.canMoveDown === right.canMoveDown
+    left.canMoveDown === right.canMoveDown &&
+    left.canAttachFiles === right.canAttachFiles
   )
 }
 

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -467,7 +467,11 @@ export function NoteEditor({
         onExitBoundary={handleExitBoundary}
       >
         <EditorInputTraits />
-        <FormattingToolbarBridge />
+        {/* Only a pane that persists files gets the toolbar's attach button;
+            `handleFilePaste` is the same handler meowdown pastes through. */}
+        <FormattingToolbarBridge
+          {...(saveFile !== undefined ? { saveFile: handleFilePaste } : {})}
+        />
         {renderWikilinkHoverCard !== undefined ? (
           <WikilinkHoverCard className="reflect-hover-card">
             {renderWikilinkHoverCard}

--- a/apps/desktop/src/lib/image-file.test.tsx
+++ b/apps/desktop/src/lib/image-file.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { toPortableImageFile } from './image-file'
+
+/** A decodable image, wrapped under whatever name and type the test needs. */
+async function imageFile(name: string, type: string): Promise<File> {
+  const canvas = document.createElement('canvas')
+  canvas.width = 4
+  canvas.height = 2
+  const blob = await new Promise<Blob | null>((resolve) => {
+    canvas.toBlob(resolve, 'image/png')
+  })
+  return new File([blob!], name, { type })
+}
+
+describe('toPortableImageFile', () => {
+  it('transcodes a HEIC pick to JPEG', async () => {
+    const picked = await imageFile('photo.heic', 'image/heic')
+    const portable = await toPortableImageFile(picked)
+
+    expect(portable.name).toBe('photo.jpg')
+    expect(portable.type).toBe('image/jpeg')
+    expect(portable.size).toBeGreaterThan(0)
+  })
+
+  it('recognizes HEIF by filename when the pick carries no type', async () => {
+    const picked = await imageFile('IMG_0001.HEIF', '')
+    expect((await toPortableImageFile(picked)).name).toBe('IMG_0001.jpg')
+  })
+
+  it('passes every other format through untouched', async () => {
+    const picked = await imageFile('screenshot.png', 'image/png')
+    expect(await toPortableImageFile(picked)).toBe(picked)
+  })
+
+  it('keeps the original when the webview cannot decode it', async () => {
+    const picked = new File(['not an image'], 'broken.heic', { type: 'image/heic' })
+    expect(await toPortableImageFile(picked)).toBe(picked)
+  })
+})

--- a/apps/desktop/src/lib/image-file.ts
+++ b/apps/desktop/src/lib/image-file.ts
@@ -1,0 +1,59 @@
+/** JPEG quality for a transcoded photo: visually lossless at a sane size. */
+const JPEG_QUALITY = 0.92
+
+/** True for the format an iPhone's photo library hands over for camera shots. */
+function isAppleImageFormat(file: File): boolean {
+  const type = file.type.toLowerCase()
+  return type === 'image/heic' || type === 'image/heif' || /\.hei[cf]$/i.test(file.name)
+}
+
+/** `photo.heic` → `photo.jpg`; a name without an extension just gains one. */
+function withJpegExtension(name: string): string {
+  const separator = name.lastIndexOf('.')
+  return `${separator === -1 ? name : name.slice(0, separator)}.jpg`
+}
+
+/**
+ * Re-encode a HEIC/HEIF pick as JPEG, or return the file untouched.
+ *
+ * The iOS photo library hands over the camera's native format, and a `.heic`
+ * written into the graph is a file GitHub, Obsidian, and every non-Apple
+ * viewer refuse to render — the vault is meant to outlive this app on any
+ * platform. Every other format passes through byte for byte: a note asset is
+ * the user's own photo, not a payload to shrink (an oversized one still gets
+ * the large-file warning every save gets).
+ *
+ * Falls back to the original file when the webview has no decoder for it,
+ * which is the honest outcome: the photo lands in the note either way, and
+ * the format question surfaces where it can be seen.
+ */
+export async function toPortableImageFile(file: File): Promise<File> {
+  if (!isAppleImageFormat(file) || typeof createImageBitmap !== 'function') {
+    return file
+  }
+  let bitmap: ImageBitmap
+  try {
+    bitmap = await createImageBitmap(file)
+  } catch {
+    return file
+  }
+  try {
+    const canvas = document.createElement('canvas')
+    canvas.width = bitmap.width
+    canvas.height = bitmap.height
+    const context = canvas.getContext('2d')
+    if (context === null) {
+      return file
+    }
+    context.drawImage(bitmap, 0, 0)
+    const encoded = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob(resolve, 'image/jpeg', JPEG_QUALITY)
+    })
+    if (encoded === null) {
+      return file
+    }
+    return new File([encoded], withJpegExtension(file.name), { type: 'image/jpeg' })
+  } finally {
+    bitmap.close()
+  }
+}

--- a/apps/desktop/src/lib/pick-files.test.tsx
+++ b/apps/desktop/src/lib/pick-files.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { pickFiles } from './pick-files'
+
+function openedInput(): HTMLInputElement {
+  const input = document.body.querySelector<HTMLInputElement>('input[type="file"]')
+  if (input === null) {
+    throw new Error('pickFiles did not attach an input to the body')
+  }
+  return input
+}
+
+describe('pickFiles', () => {
+  it('resolves with the chosen files and detaches its input', async () => {
+    const pending = pickFiles({ accept: 'image/*', multiple: true })
+    const input = openedInput()
+    expect(input.accept).toBe('image/*')
+    expect(input.multiple).toBe(true)
+
+    const transfer = new DataTransfer()
+    transfer.items.add(new File(['png'], 'photo.png', { type: 'image/png' }))
+    input.files = transfer.files
+    input.dispatchEvent(new Event('change'))
+
+    const files = await pending
+    expect(files.map((file) => file.name)).toEqual(['photo.png'])
+    expect(document.body.querySelector('input[type="file"]')).toBeNull()
+  })
+
+  it('resolves empty when the picker is dismissed', async () => {
+    const pending = pickFiles()
+    const input = openedInput()
+    expect(input.multiple).toBe(false)
+
+    input.dispatchEvent(new Event('cancel'))
+
+    await expect(pending).resolves.toEqual([])
+    expect(document.body.querySelector('input[type="file"]')).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/pick-files.ts
+++ b/apps/desktop/src/lib/pick-files.ts
@@ -1,0 +1,45 @@
+/** Options for {@link pickFiles}. */
+export interface PickFilesOptions {
+  /** The picker's `accept` list, e.g. `image/*`. Omitted offers every type. */
+  accept?: string
+  /** Whether more than one file can be chosen. */
+  multiple?: boolean
+}
+
+/**
+ * Open the webview's own file picker and resolve with the chosen files (empty
+ * when it is dismissed).
+ *
+ * The input is created on `document.body` instead of being rendered by the
+ * calling component on purpose: on iOS the picker takes over the screen and
+ * drops the software keyboard, and the mobile shell swaps the whole
+ * formatting toolbar out for the tab bar while the keyboard is down — a
+ * toolbar-owned input would be torn out of the DOM with the sheet still open,
+ * losing its `change` event. A detached input outlives its caller.
+ *
+ * Must be called from a user gesture's own call stack: `click()` on a file
+ * input needs the activation, so callers cannot await anything first.
+ */
+export function pickFiles({ accept, multiple = false }: PickFilesOptions = {}): Promise<File[]> {
+  const input = document.createElement('input')
+  input.type = 'file'
+  if (accept !== undefined) {
+    input.accept = accept
+  }
+  input.multiple = multiple
+  input.style.display = 'none'
+  document.body.append(input)
+
+  return new Promise<File[]>((resolve) => {
+    const settle = (files: File[]): void => {
+      input.remove()
+      resolve(files)
+    }
+    input.addEventListener('change', () => settle([...(input.files ?? [])]), { once: true })
+    // `cancel` is WebKit 16.4+ and the app's deployment target is iOS 14, so
+    // on older webviews a dismissal leaves the input attached until the next
+    // pick collects it. Cleanup, never correctness.
+    input.addEventListener('cancel', () => settle([]), { once: true })
+    input.click()
+  })
+}

--- a/apps/desktop/src/mobile/formatting-toolbar.test.tsx
+++ b/apps/desktop/src/mobile/formatting-toolbar.test.tsx
@@ -7,10 +7,12 @@ import {
   publishFormattingToolbar,
   type FormattingToolbar,
 } from '@/editor/formatting-toolbar-store'
+import { pickFiles } from '@/lib/pick-files'
 import { fireEvent } from '@/test-utils/fire-event'
 import { MobileFormattingToolbar } from './formatting-toolbar'
 
 vi.mock('@/mobile/haptics', () => ({ hapticImpactLight: vi.fn() }))
+vi.mock('@/lib/pick-files', () => ({ pickFiles: vi.fn(async () => []) }))
 
 function makeToolbar(
   capabilities: Partial<FormattingToolbar['capabilities']> = {},
@@ -21,6 +23,7 @@ function makeToolbar(
       canDedent: true,
       canMoveUp: true,
       canMoveDown: true,
+      canAttachFiles: true,
       ...capabilities,
     },
     commands: {
@@ -32,6 +35,7 @@ function makeToolbar(
       moveDown: vi.fn(),
       insertTrigger: vi.fn(),
       dismissKeyboard: vi.fn(),
+      attachFiles: vi.fn(),
       scrollCaretIntoView: vi.fn(),
     },
   }
@@ -67,6 +71,7 @@ describe('MobileFormattingToolbar', () => {
       'Indent',
       'Move up',
       'Move down',
+      'Insert image',
       'Hide keyboard',
     ])
     await expect.element(page.getByRole('button', { name: 'Outdent' })).toBeDisabled()
@@ -107,5 +112,27 @@ describe('MobileFormattingToolbar', () => {
 
     fireEvent.click(page.getByRole('button', { name: 'Hide keyboard' }))
     expect(toolbar.commands.dismissKeyboard).toHaveBeenCalledOnce()
+  })
+
+  it('hides the image button for an editor that cannot persist files', async () => {
+    await render(<MobileFormattingToolbar />)
+    await act(() => publishFormattingToolbar(owner, makeToolbar({ canAttachFiles: false })))
+
+    expect(page.getByRole('button', { name: 'Insert image' }).query()).toBeNull()
+  })
+
+  it('hands the picked images to the editor', async () => {
+    const picked = [new File(['png'], 'photo.png', { type: 'image/png' })]
+    vi.mocked(pickFiles).mockResolvedValueOnce(picked)
+    const toolbar = makeToolbar()
+    await render(<MobileFormattingToolbar />)
+    await act(() => publishFormattingToolbar(owner, toolbar))
+
+    fireEvent.click(page.getByRole('button', { name: 'Insert image' }))
+
+    expect(pickFiles).toHaveBeenCalledWith({ accept: 'image/*', multiple: true })
+    await vi.waitFor(() => {
+      expect(toolbar.commands.attachFiles).toHaveBeenCalledWith(picked)
+    })
   })
 })

--- a/apps/desktop/src/mobile/formatting-toolbar.tsx
+++ b/apps/desktop/src/mobile/formatting-toolbar.tsx
@@ -5,6 +5,7 @@ import {
   Brackets,
   ChevronDown,
   Hash,
+  Image as ImageIcon,
   IndentDecrease,
   IndentIncrease,
   List,
@@ -12,6 +13,7 @@ import {
   Slash,
 } from 'lucide-react'
 import { useFormattingToolbar } from '@/editor/formatting-toolbar-store'
+import { pickFiles } from '@/lib/pick-files'
 import { hapticImpactLight } from '@/mobile/haptics'
 
 /**
@@ -24,11 +26,11 @@ import { hapticImpactLight } from '@/mobile/haptics'
  * free because the plugin reports their overlap as 0.
  *
  * Item set and order are V1's toolbar spec (the porting doc's requirements
- * list) minus AI prediction and image capture, which have no v2 substrate
- * yet — plus a dismiss button, which V1 never needed because iOS gives a
- * `contenteditable` no Done key. Renders nothing while no editor is focused:
- * the All-tab search field raises the keyboard too, and formatting buttons
- * would be dead weight there.
+ * list) minus AI prediction, which has no v2 substrate yet — plus a dismiss
+ * button, which V1 never needed because iOS gives a `contenteditable` no
+ * Done key. Renders nothing while no editor is focused: the All-tab search
+ * field raises the keyboard too, and formatting buttons would be dead weight
+ * there.
  *
  * The dismiss button is pinned outside the scrollable region so it stays
  * visible even when the formatting buttons overflow on narrow screens.
@@ -95,6 +97,18 @@ export function MobileFormattingToolbar(): ReactElement | null {
           disabled={!capabilities.canMoveDown}
           onPress={commands.moveDown}
         />
+        {capabilities.canAttachFiles ? (
+          <ToolbarButton
+            label="Insert image"
+            icon={<ImageIcon className="size-5" />}
+            // `commands` is read here, not after the picker returns: the
+            // sheet takes focus from the editor, which clears the published
+            // toolbar, but the command still holds its own editor.
+            onPress={() =>
+              void pickFiles({ accept: 'image/*', multiple: true }).then(commands.attachFiles)
+            }
+          />
+        ) : null}
       </div>
       <div className="shrink-0 border-l border-border px-1">
         <ToolbarButton

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -690,7 +690,13 @@ describe('MobileShell', () => {
 
     await act(() =>
       publishFormattingToolbar(owner, {
-        capabilities: { canIndent: true, canDedent: false, canMoveUp: true, canMoveDown: true },
+        capabilities: {
+          canIndent: true,
+          canDedent: false,
+          canMoveUp: true,
+          canMoveDown: true,
+          canAttachFiles: false,
+        },
         commands: {
           cycleBulletOrderedList: vi.fn(),
           cycleCheckableList: vi.fn(),
@@ -700,6 +706,7 @@ describe('MobileShell', () => {
           moveDown: vi.fn(),
           insertTrigger: vi.fn(),
           dismissKeyboard: vi.fn(),
+          attachFiles: vi.fn(),
           scrollCaretIntoView: vi.fn(),
         },
       }),


### PR DESCRIPTION
Adds an image button to the mobile keyboard toolbar that opens the iOS photo picker and saves the picks into the graph's `assets/` as `![](…)` at the caret, the same path a paste takes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image and file attachments to the desktop and mobile note editors.
  * Added an image insertion option for selecting multiple images or capturing photos.
  * Attached files are saved and inserted into notes as links.
  * Added support for converting HEIC/HEIF images to JPEG for broader compatibility.
  * Added iOS camera permission messaging for photo capture.

* **Bug Fixes**
  * Improved handling when file selection is cancelled or file saving is declined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->