### PR TITLE
fix(ios): stop the brief input freeze right after the app opens

### DIFF
--- a/apps/desktop/src-tauri/src/blocking.rs
+++ b/apps/desktop/src-tauri/src/blocking.rs
@@ -1,0 +1,20 @@
+//! One home for the async-command → blocking-pool hop.
+//!
+//! Sync Tauri commands run on the main thread — on iOS the thread that also
+//! delivers touches — so any command that does real filesystem, SQLite, or
+//! git work is declared `async` and runs its body here instead. The
+//! `JoinError` arm only fires when the closure panics; the panic itself is
+//! the bug, this just keeps it from poisoning the command layer silently.
+
+use crate::error::{AppError, AppResult};
+
+/// Run `task` on the blocking thread pool and await its result.
+pub(crate) async fn run_blocking<T, F>(task: F) -> AppResult<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> AppResult<T> + Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(task)
+        .await
+        .map_err(|err| AppError::io(format!("blocking task panicked: {err}")))?
+}

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -416,10 +416,18 @@ fn shared_inbox_dir() -> Option<PathBuf> {
 /// them. Returns how many envelopes moved; zero without a shared container.
 /// Called by the mobile capture controller on launch and every foreground.
 #[tauri::command]
-pub fn capture_shared_inbox_relay(generation: u64, state: State<GraphState>) -> AppResult<u32> {
+pub async fn capture_shared_inbox_relay(
+    generation: u64,
+    state: State<'_, GraphState>,
+) -> AppResult<u32> {
     let root = root_for_generation(&state, generation)?;
     match shared_inbox_dir() {
-        Some(shared) => relay_shared_spools(&shared, &root),
+        // App Group directory IO belongs on the blocking pool: this fires on
+        // every launch and foreground, on what is the touch-delivery thread
+        // for sync commands on iOS.
+        Some(shared) => {
+            crate::blocking::run_blocking(move || relay_shared_spools(&shared, &root)).await
+        }
         None => Ok(0),
     }
 }

--- a/apps/desktop/src-tauri/src/db/migrations.rs
+++ b/apps/desktop/src-tauri/src/db/migrations.rs
@@ -18,6 +18,12 @@ pub(super) fn open_index_at(root: &Path) -> AppResult<Connection> {
     reflect_index_schema::open_index_at(root).map_err(map_err)
 }
 
+/// Open the same index read-only (the `db_query` reader; see
+/// [`reflect_index_schema::open_index_read_only_at`]).
+pub(super) fn open_index_read_only_at(root: &Path) -> AppResult<Connection> {
+    reflect_index_schema::open_index_read_only_at(root).map_err(map_err)
+}
+
 /// Opens an in-memory connection with sqlite-vec available (used by tests).
 #[cfg(test)]
 pub(super) fn open_in_memory() -> AppResult<Connection> {

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -24,7 +24,7 @@ use std::sync::{Mutex, MutexGuard};
 
 use rusqlite::{params, Connection};
 use serde_json::{Map, Value};
-use tauri::State;
+use tauri::{Manager, State};
 
 use crate::background_task::{self, BackgroundTaskState};
 use crate::error::{AppError, AppResult};
@@ -343,35 +343,42 @@ pub fn index_move<R: tauri::Runtime>(
 /// returns the empty scan — that pass is superseded and its writes would be
 /// dropped anyway, so "nothing to do" is the honest answer.
 #[tauri::command]
-pub fn index_reconcile_scan(
+pub async fn index_reconcile_scan<R: tauri::Runtime>(
     generation: u64,
-    graph: State<GraphState>,
-    index: State<IndexState>,
+    app: tauri::AppHandle<R>,
 ) -> AppResult<scan::ReconcileScan> {
-    let started = std::time::Instant::now();
-    let root = crate::fs::current_root(&graph)?;
-    let walk_started = std::time::Instant::now();
-    let files = crate::fs::note_files(&root);
-    let walk_ms = walk_started.elapsed().as_millis() as u64;
-    let state = lock_state(&index)?;
-    if state.generation != generation {
-        return Ok(scan::ReconcileScan::empty());
-    }
-    let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
-    let now_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|elapsed| elapsed.as_millis() as u64)
-        .unwrap_or(0);
-    let scan = scan::scan_reconcile(conn, &files, now_ms)?;
-    tracing::info!(
-        files = scan.total,
-        candidates = scan.candidates.len(),
-        orphans = scan.orphans.len(),
-        walk_ms,
-        total_ms = started.elapsed().as_millis() as u64,
-        "index_reconcile_scan"
-    );
-    Ok(scan)
+    // Async on purpose: this is one uninterruptible O(graph) walk + table
+    // read, and as a sync command it occupied the iOS main thread — the
+    // post-paint "I can see a note but can't tap it" freeze on every open.
+    crate::blocking::run_blocking(move || {
+        let started = std::time::Instant::now();
+        let graph = app.state::<GraphState>();
+        let root = crate::fs::current_root(&graph)?;
+        let walk_started = std::time::Instant::now();
+        let files = crate::fs::note_files(&root);
+        let walk_ms = walk_started.elapsed().as_millis() as u64;
+        let index = app.state::<IndexState>();
+        let state = lock_state(&index)?;
+        if state.generation != generation {
+            return Ok(scan::ReconcileScan::empty());
+        }
+        let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_millis() as u64)
+            .unwrap_or(0);
+        let scan = scan::scan_reconcile(conn, &files, now_ms)?;
+        tracing::info!(
+            files = scan.total,
+            candidates = scan.candidates.len(),
+            orphans = scan.orphans.len(),
+            walk_ms,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "index_reconcile_scan"
+        );
+        Ok(scan)
+    })
+    .await
 }
 
 /// One `index_touch` entry: re-stamp `path`'s stored mtime to `mtime`
@@ -544,13 +551,22 @@ pub fn embed_remove(
 }
 
 /// Execute a read query (compiled by Kysely on the frontend) and return rows.
+///
+/// Async on purpose: sync commands run on the main thread, which on iOS also
+/// owns touch delivery — a long FTS scan there reads as a frozen app. The
+/// state mutex (not the thread) is what serializes reads against writes, so
+/// hopping to the blocking pool changes nothing about ordering.
 #[tauri::command]
-pub fn db_query(
+pub async fn db_query<R: tauri::Runtime>(
     sql: String,
     params: Vec<Value>,
-    index: State<IndexState>,
+    app: tauri::AppHandle<R>,
 ) -> AppResult<Vec<Map<String, Value>>> {
-    let state = lock_state(&index)?;
-    let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
-    query::run_query(conn, &sql, &params)
+    crate::blocking::run_blocking(move || {
+        let index = app.state::<IndexState>();
+        let state = lock_state(&index)?;
+        let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
+        query::run_query(conn, &sql, &params)
+    })
+    .await
 }

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -43,9 +43,6 @@ pub use write::IndexedNote;
 /// mutate a newly-opened index, regardless of caller timing (needed once the
 /// watcher in Plan 04b indexes outside the serialized open flow).
 ///
-/// The single connection also means reads (`db_query`) and writes (`index_*`)
-/// are serialized — a long FTS scan briefly blocks an apply and vice versa.
-/// Acceptable at first-wave scale; a read-pool / WAL reader split can come later.
 #[derive(Default)]
 struct IndexInner {
     generation: u64,
@@ -60,16 +57,43 @@ struct IndexInner {
     root: Option<std::path::PathBuf>,
 }
 
-/// The active graph's index state (`conn` is `None` until `index_open`).
+/// The `db_query` reader: a second, **read-only** connection under its own
+/// lock. Queries run on the blocking pool now, and the write commands are
+/// still synchronous main-thread calls — if both shared one mutex, a long
+/// FTS scan holding it would make the next `index_apply`/`index_touch` block
+/// the iOS main thread for the read's duration, recreating the exact
+/// touch-delivery stall the async conversion removed. Under WAL the reader
+/// sees the last committed state, so a query after an awaited write still
+/// reads its result; it just never contends with one. Rebound (with its own
+/// generation copy, so the pair swaps atomically for readers of *this* lock)
+/// by `index_open` while the writer lock is held — lock order is always
+/// writer → reader, nothing locks the reverse way.
 #[derive(Default)]
-pub struct IndexState(Mutex<IndexInner>);
+struct ReadInner {
+    generation: u64,
+    conn: Option<Connection>,
+}
+
+/// The active graph's index state (`conn`s are `None` until `index_open`).
+#[derive(Default)]
+pub struct IndexState {
+    inner: Mutex<IndexInner>,
+    read: Mutex<ReadInner>,
+}
 
 fn lock_state<'a>(index: &'a State<IndexState>) -> AppResult<MutexGuard<'a, IndexInner>> {
-    index.0.lock().map_err(|err| {
+    index.inner.lock().map_err(|err| {
         // A poisoned lock means a command panicked while holding it — the panic
         // itself is the bug; this context points at the blast radius.
         tracing::error!(?err, "index state lock poisoned by an earlier panic");
         AppError::io("index state lock poisoned")
+    })
+}
+
+fn lock_read<'a>(index: &'a State<IndexState>) -> AppResult<MutexGuard<'a, ReadInner>> {
+    index.read.lock().map_err(|err| {
+        tracing::error!(?err, "index read lock poisoned by an earlier panic");
+        AppError::io("index read lock poisoned")
     })
 }
 
@@ -132,13 +156,23 @@ pub fn index_open(
         .ok_or_else(AppError::no_graph)?;
     let mut state = lock_state(&index)?;
     state.generation += 1;
-    // Drop the old connection before opening; if the open fails we return with
-    // `conn = None` (reads then error) rather than a stale connection. The
-    // root is rebound with it, under the same lock, so a generation can never
-    // pair with another graph's root (see `IndexInner::root`).
+    // Drop the old connections before opening; if an open fails we return
+    // with `conn = None` (reads then error) rather than a stale connection.
+    // The root is rebound with the writer, under the same lock, so a
+    // generation can never pair with another graph's root (see
+    // `IndexInner::root`). The reader rebinds while the writer lock is still
+    // held (writer → reader lock order), after the writer created/migrated
+    // the file it opens read-only.
     state.conn = None;
     state.root = None;
+    {
+        let mut read = lock_read(&index)?;
+        read.conn = None;
+    }
     state.conn = Some(migrations::open_index_at(&root)?);
+    let mut read = lock_read(&index)?;
+    read.conn = Some(migrations::open_index_read_only_at(&root)?);
+    read.generation = state.generation;
     state.root = Some(root);
     Ok(state.generation)
 }
@@ -575,19 +609,35 @@ pub fn embed_remove(
 /// Execute a read query (compiled by Kysely on the frontend) and return rows.
 ///
 /// Async on purpose: sync commands run on the main thread, which on iOS also
-/// owns touch delivery — a long FTS scan there reads as a frozen app. The
-/// state mutex (not the thread) is what serializes reads against writes, so
-/// hopping to the blocking pool changes nothing about ordering.
+/// owns touch delivery — a long FTS scan there reads as a frozen app. Runs
+/// on the dedicated read-only connection ([`ReadInner`]) so it never holds
+/// the writer lock a sync write command would block the main thread waiting
+/// for.
 #[tauri::command]
 pub async fn db_query<R: tauri::Runtime>(
     sql: String,
     params: Vec<Value>,
     app: tauri::AppHandle<R>,
 ) -> AppResult<Vec<Map<String, Value>>> {
+    // Pin the index session before the hop: with no main-thread FIFO, a
+    // graph switch can rebind the index between invoke and execution, and a
+    // query issued for graph A must not return graph B's rows — the frontend
+    // caches results under root-scoped keys with `staleTime: Infinity`, so
+    // one crossed response would be served as fresh forever. An erroring
+    // superseded query is honest instead: its observers unmounted with the
+    // switch, so nothing retries it against the wrong graph.
+    let requested = {
+        let index = app.state::<IndexState>();
+        let generation = lock_read(&index)?.generation;
+        generation
+    };
     crate::blocking::run_blocking(move || {
         let index = app.state::<IndexState>();
-        let state = lock_state(&index)?;
-        let conn = state.conn.as_ref().ok_or_else(AppError::no_graph)?;
+        let read = lock_read(&index)?;
+        if read.generation != requested {
+            return Err(AppError::io("index reopened during query"));
+        }
+        let conn = read.conn.as_ref().ok_or_else(AppError::no_graph)?;
         query::run_query(conn, &sql, &params)
     })
     .await

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -50,6 +50,14 @@ pub use write::IndexedNote;
 struct IndexInner {
     generation: u64,
     conn: Option<Connection>,
+    /// The graph root this generation's index was opened for. Reconcile
+    /// scans list *this* root, never the graph state's current one: with
+    /// async commands there is no main-thread FIFO ordering scans against
+    /// `graph_open`, so a queued scan could otherwise walk a freshly-swapped
+    /// root and diff another graph's files against this index — in the
+    /// window before the switch's `index_open` bumps the generation, that
+    /// delta would pass the staleness gate and drive cross-graph writes.
+    root: Option<std::path::PathBuf>,
 }
 
 /// The active graph's index state (`conn` is `None` until `index_open`).
@@ -125,9 +133,13 @@ pub fn index_open(
     let mut state = lock_state(&index)?;
     state.generation += 1;
     // Drop the old connection before opening; if the open fails we return with
-    // `conn = None` (reads then error) rather than a stale connection.
+    // `conn = None` (reads then error) rather than a stale connection. The
+    // root is rebound with it, under the same lock, so a generation can never
+    // pair with another graph's root (see `IndexInner::root`).
     state.conn = None;
+    state.root = None;
     state.conn = Some(migrations::open_index_at(&root)?);
+    state.root = Some(root);
     Ok(state.generation)
 }
 
@@ -338,10 +350,11 @@ pub fn index_move<R: tauri::Runtime>(
 
 /// Compute the open-path reconcile delta natively (see [`scan`]): list the
 /// graph's notes, compare against the stored rows, and return only what
-/// needs work. The listing happens **before** the index lock is taken, so
-/// thousands of stats never block concurrent reads. A stale generation
-/// returns the empty scan — that pass is superseded and its writes would be
-/// dropped anyway, so "nothing to do" is the honest answer.
+/// needs work. The walk runs **without** the index lock held, so thousands
+/// of stats never block concurrent reads; the generation is checked again
+/// after it, so a graph switch mid-walk yields the empty scan. A stale
+/// generation returns the empty scan — that pass is superseded and its
+/// writes would be dropped anyway, so "nothing to do" is the honest answer.
 #[tauri::command]
 pub async fn index_reconcile_scan<R: tauri::Runtime>(
     generation: u64,
@@ -352,12 +365,21 @@ pub async fn index_reconcile_scan<R: tauri::Runtime>(
     // post-paint "I can see a note but can't tap it" freeze on every open.
     crate::blocking::run_blocking(move || {
         let started = std::time::Instant::now();
-        let graph = app.state::<GraphState>();
-        let root = crate::fs::current_root(&graph)?;
+        let index = app.state::<IndexState>();
+        // The root comes from the index session, not the graph state: async
+        // commands have no ordering against `graph_open`, and listing a
+        // just-swapped root against this generation's rows would diff two
+        // different graphs (see `IndexInner::root`).
+        let root = {
+            let state = lock_state(&index)?;
+            if state.generation != generation {
+                return Ok(scan::ReconcileScan::empty());
+            }
+            state.root.clone().ok_or_else(AppError::no_graph)?
+        };
         let walk_started = std::time::Instant::now();
         let files = crate::fs::note_files(&root);
         let walk_ms = walk_started.elapsed().as_millis() as u64;
-        let index = app.state::<IndexState>();
         let state = lock_state(&index)?;
         if state.generation != generation {
             return Ok(scan::ReconcileScan::empty());

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -2127,3 +2127,50 @@ fn a_move_restates_the_path_derived_claims() {
     .unwrap();
     assert_eq!(path_key[0]["path_key"], Value::from("notes/new-name.md"));
 }
+
+/// The reconcile scan must list the root its index generation was opened
+/// for. Async commands have no main-thread ordering against `graph_open`,
+/// so a scan queued across a graph switch could otherwise walk the freshly
+/// swapped root and diff another graph's files against this index — in the
+/// window before the switch's `index_open` bumps the generation, that delta
+/// would pass the staleness gate.
+#[test]
+fn reconcile_scan_walks_the_index_sessions_root_not_the_current_graph() {
+    use tauri::Manager;
+    let app = tauri::test::mock_builder()
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .expect("mock app");
+    app.manage(crate::fs::GraphState::default());
+    app.manage(super::IndexState::default());
+    app.manage(crate::background_task::BackgroundTaskState::default());
+
+    let graph_a = tempfile::tempdir().expect("tempdir");
+    let graph_b = tempfile::tempdir().expect("tempdir");
+    std::fs::write(graph_a.path().join("one.md"), "# one\n").unwrap();
+    std::fs::write(graph_b.path().join("two.md"), "# two\n").unwrap();
+    std::fs::write(graph_b.path().join("three.md"), "# three\n").unwrap();
+
+    {
+        let state: tauri::State<crate::fs::GraphState> = app.state();
+        let mut inner = state.0.lock().unwrap();
+        inner.generation = 1;
+        inner.root = Some(graph_a.path().to_path_buf());
+    }
+    let generation = super::index_open(app.state(), app.state(), app.state()).expect("open");
+
+    // The switch's first half: `graph_open` swapped the root, `index_open`
+    // hasn't run yet — the exact window a queued scan can land in.
+    {
+        let state: tauri::State<crate::fs::GraphState> = app.state();
+        let mut inner = state.0.lock().unwrap();
+        inner.generation = 2;
+        inner.root = Some(graph_b.path().to_path_buf());
+    }
+
+    let scan = tauri::async_runtime::block_on(super::index_reconcile_scan(
+        generation,
+        app.handle().clone(),
+    ))
+    .expect("scan");
+    assert_eq!(scan.total, 1, "must list graph A, the index session's root");
+}

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -1187,11 +1187,11 @@ fn stale_generation_writes_are_dropped_end_to_end() {
     }
 
     let count = |label: &str| -> Value {
-        let rows = super::db_query(
+        let rows = tauri::async_runtime::block_on(super::db_query(
             "SELECT count(*) AS n FROM notes".to_string(),
             vec![],
-            app.state(),
-        )
+            app.handle().clone(),
+        ))
         .unwrap_or_else(|err| panic!("{label}: {err:?}"));
         rows[0]["n"].clone()
     };
@@ -1244,11 +1244,11 @@ fn stale_generation_writes_are_dropped_end_to_end() {
     // index_meta_set rides the same gate: stale stamps vanish, fresh ones land
     // (and upsert — the projection-version stamp is written after every rebuild).
     let meta = |label: &str| -> Vec<serde_json::Map<String, Value>> {
-        super::db_query(
+        tauri::async_runtime::block_on(super::db_query(
             "SELECT value FROM index_meta WHERE key = 'k'".to_string(),
             vec![],
-            app.state(),
-        )
+            app.handle().clone(),
+        ))
         .unwrap_or_else(|err| panic!("{label}: {err:?}"))
     };
     super::index_meta_set(

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use serde::Serialize;
-use tauri::{Emitter, State};
+use tauri::{Emitter, Manager, State};
 use tauri_plugin_opener::OpenerExt;
 
 use crate::error::{AppError, AppResult};
@@ -331,15 +331,20 @@ pub fn graph_open(path: String, state: State<GraphState>) -> AppResult<GraphInfo
 
 /// Read a note's markdown by graph-relative path. `generation`, when given,
 /// pins the read to the issuing graph session (see [`root_for`]).
+///
+/// Off the main thread on purpose: this read *does* materialize an evicted
+/// iCloud note (that is its contract — bulk passes use [`note_read_local`]),
+/// and an on-demand download from a sync command would freeze the whole app
+/// for its duration, exactly like the old synchronous asset protocol.
 #[tauri::command]
-pub fn note_read(
+pub async fn note_read(
     path: String,
     generation: Option<u64>,
-    state: State<GraphState>,
+    state: State<'_, GraphState>,
 ) -> AppResult<String> {
     let root = root_for(&state, generation)?;
     let abs = resolve(&root, &path)?;
-    Ok(io::read_note_no_follow(&root, &abs)?)
+    crate::blocking::run_blocking(move || Ok(io::read_note_no_follow(&root, &abs)?)).await
 }
 
 /// How a [`note_read_local`] request found the note on disk.
@@ -378,7 +383,7 @@ pub async fn note_read_local(
     let root = root_for(&state, generation)?;
     let abs = resolve(&root, &path)?;
     let read_root = root;
-    tauri::async_runtime::spawn_blocking(move || {
+    crate::blocking::run_blocking(move || {
         // Best-effort: when the guard refuses to engage, the read keeps a
         // slim stat-then-read race (an eviction landing between the two
         // materializes that one file).
@@ -402,7 +407,6 @@ pub async fn note_read_local(
         }
     })
     .await
-    .map_err(|err| AppError::io(err.to_string()))?
 }
 
 /// Atomically write a note's markdown by graph-relative path. `generation` pins
@@ -822,9 +826,19 @@ fn move_to_graph_trash(root: &Path, abs: &Path) -> AppResult<()> {
 
 /// List eligible Markdown notes anywhere in the vault. `generation`, when
 /// given, pins the listing to the issuing graph session (see [`root_for`]).
+///
+/// Async because a cold catalog is a full-tree walk; the cached case pays
+/// one thread hop, which is noise next to the IPC round-trip itself.
 #[tauri::command]
-pub fn list_files(generation: Option<u64>, state: State<GraphState>) -> AppResult<Vec<FileMeta>> {
-    Ok(file_catalog(&state, generation)?.notes)
+pub async fn list_files<R: tauri::Runtime>(
+    generation: Option<u64>,
+    app: tauri::AppHandle<R>,
+) -> AppResult<Vec<FileMeta>> {
+    crate::blocking::run_blocking(move || {
+        let state = app.state::<GraphState>();
+        Ok(file_catalog(&state, generation)?.notes)
+    })
+    .await
 }
 
 /// List supported local attachments from the same cached catalog as

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -834,9 +834,21 @@ pub async fn list_files<R: tauri::Runtime>(
     generation: Option<u64>,
     app: tauri::AppHandle<R>,
 ) -> AppResult<Vec<FileMeta>> {
+    // Pin the graph session before the hop, like `note_read` and `db_query`:
+    // an unpinned call resolved inside the closure could list a root swapped
+    // in after the invoke (the rebuild path calls this without a
+    // generation). A pinned call the switch superseded fails the
+    // `file_catalog` generation check instead of listing the wrong graph.
+    let generation = match generation {
+        Some(generation) => generation,
+        None => {
+            let state = app.state::<GraphState>();
+            current_graph_info(&state)?.generation
+        }
+    };
     crate::blocking::run_blocking(move || {
         let state = app.state::<GraphState>();
-        Ok(file_catalog(&state, generation)?.notes)
+        Ok(file_catalog(&state, Some(generation))?.notes)
     })
     .await
 }

--- a/apps/desktop/src-tauri/src/git/mod.rs
+++ b/apps/desktop/src-tauri/src/git/mod.rs
@@ -28,7 +28,9 @@ use std::path::Path;
 use serde::Serialize;
 use tauri::State;
 
-use crate::error::{AppError, AppResult};
+use crate::blocking::run_blocking;
+
+use crate::error::AppResult;
 use crate::fs::GraphState;
 
 use self::commit::CommitOutcome;
@@ -114,16 +116,6 @@ fn setup(root: &Path, remote_url: Option<String>, branch: Option<String>) -> App
     }
     drop(repo);
     status(root)
-}
-
-async fn run_blocking<T, F>(task: F) -> AppResult<T>
-where
-    T: Send + 'static,
-    F: FnOnce() -> AppResult<T> + Send + 'static,
-{
-    tauri::async_runtime::spawn_blocking(task)
-        .await
-        .map_err(|err| AppError::io(format!("git task panicked: {err}")))?
 }
 
 /// Snapshot the backup repository (cheap, no network).

--- a/apps/desktop/src-tauri/src/icloud/sweep.rs
+++ b/apps/desktop/src-tauri/src/icloud/sweep.rs
@@ -85,11 +85,10 @@ pub async fn icloud_conflicts_scan(
     let started = std::time::Instant::now();
     let root = crate::fs::root_for_generation(&state, generation)?;
     let sweep_root = root.clone();
-    let outcome = tauri::async_runtime::spawn_blocking(move || {
+    let outcome = crate::blocking::run_blocking(move || {
         run_sweep(&sweep_root, &skip_paths, &ingested_paths, record_baseline)
     })
-    .await
-    .map_err(|err| AppError::io(err.to_string()))?;
+    .await;
     if let Ok(outcome) = &outcome {
         tracing::info!(
             changed = outcome.changed.len(),

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@
 //! [`error`] (the shared error contract).
 
 mod background_task;
+mod blocking;
 mod calendar;
 mod capture;
 mod conflict;

--- a/crates/index-schema/src/lib.rs
+++ b/crates/index-schema/src/lib.rs
@@ -171,6 +171,24 @@ mod schema {
         Ok(conn)
     }
 
+    /// Open `<root>/.reflect/index.sqlite` **read-only** (no create, no
+    /// migrate) — a second connection for query traffic, so a long read never
+    /// holds the writer's lock. WAL readers see the last committed state, and
+    /// the writer connection (opened first via [`open_index_at`]) owns the
+    /// file's existence and schema.
+    pub fn open_index_read_only_at(root: &Path) -> Result<Connection, SchemaError> {
+        register_sqlite_vec()?;
+        let path = root.join(super::REFLECT_DIR).join(super::INDEX_FILE);
+        let conn = Connection::open_with_flags(
+            path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
+                | rusqlite::OpenFlags::SQLITE_OPEN_URI
+                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        conn.busy_timeout(std::time::Duration::from_secs(5))?;
+        Ok(conn)
+    }
+
     /// Check the migration set itself (each `up` parses and applies in order).
     pub fn validate() -> Result<(), SchemaError> {
         // Validation replays the migrations on its own connection; vec0 must be
@@ -205,5 +223,6 @@ mod schema {
 
 #[cfg(feature = "vec")]
 pub use schema::{
-    migrate, migrate_to, open_in_memory, open_index_at, register_sqlite_vec, validate, SchemaError,
+    migrate, migrate_to, open_in_memory, open_index_at, open_index_read_only_at,
+    register_sqlite_vec, validate, SchemaError,
 };


### PR DESCRIPTION
Stacked on #1008. Second leg of the startup-perf investigation: the iOS report — "the UI boots and I can see a note, but for 500ms–1s it's frozen."

## Problem

Sync Tauri commands execute on the app's main thread. On iOS that thread also owns UIKit hit-testing and touch delivery, while the WKWebView renders in a separate process — so the UI paints normally while taps go nowhere. The repo already knew this pattern: the asset protocol was made asynchronous for exactly this reason, and `background_task.rs` documents the main-thread synchrony. The post-paint boot burst — one uninterruptible O(graph) `index_reconcile_scan` (directory walk + full `notes`-table read, slower still on an iCloud container), plus a volley of `db_query` and `note_read` calls from the three mounted day panes — all ran there. Resume was worse: the reconcile fires twice (index lifecycle + iCloud refresh, coalesced into one pass but always a full one).

## What changed

`index_reconcile_scan`, `db_query`, `note_read`, `list_files`, and `capture_shared_inbox_relay` become `async` commands running their bodies on the blocking pool — the pattern `note_read_local`, the asset protocol, and the git/iCloud commands already use. The hop itself is now one shared helper (`blocking::run_blocking`, hoisted from `git/mod.rs`), used by all of these plus the pre-existing `note_read_local` and sweep sites. Commands needing managed state inside the closure take `AppHandle<R>` and resolve it there; the others resolve the root before hopping. No frontend changes: `invoke` was already async.

Ordering is unchanged by design: the `IndexState` mutex — not the main thread — is what serializes reads against index writes (its doc comment states this as the contract), and every boot-path call site awaits sequentially.

## Deliberately excluded (wave 2)

`index_open` and the index **write** commands stay sync. They hold `ScopedBackgroundTask` assertions whose expiration safety currently depends on main-thread synchrony — UIKit delivers the expiration handler on that thread, so it cannot fire mid-command today. Moving them off-main first needs the expiration→cancel signal that `background_task.rs`'s comment demands, otherwise iOS could suspend the app mid-write while it holds a SQLite lock. That design is a tracked follow-up.

## Testing

- `cargo test -p reflect-open` — 341 passed (the two direct `db_query` test call sites now `block_on`).
- `cargo check -p reflect-open --target aarch64-apple-ios` — clean, covering the iOS-only relay half. `cargo clippy` clean.
- No TS changes; the dev bridge's command surface is name/payload-compatible.
- Real-device acceptance (tap responsiveness in the first second after paint on a large graph) still owed — same device pass the earlier iOS perf PRs are waiting on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches iOS main-thread IPC, index concurrency/graph-switch semantics, and release-time native symbol upload—any mistake can cause wrong-graph data, boot regressions, or unsymbolicated production crashes.
> 
> **Overview**
> **Fixes the post-paint “frozen for ~1s” window on iOS** by turning filesystem/SQLite-heavy commands (`index_reconcile_scan`, `db_query`, `note_read`, `list_files`, `capture_shared_inbox_relay`) into async handlers that run on a shared `blocking::run_blocking` pool instead of the touch-delivery main thread. `db_query` now uses a **read-only SQLite connection** so long FTS work does not contend with sync index writes. Reconcile scans pin the **index session’s graph root** (not live `graph_open` state) and generation checks guard async races; a new test covers cross-graph misuse.
> 
> **Makes TestFlight native crashes readable in Sentry:** Sentry Cocoa (`NativeDiagnostics.swift`) starts from Rust with a production-only DSN, heavy scrubbing, and crash/hang/watchdog capture. Release builds set `CARGO_PROFILE_RELEASE_DEBUG=line-tables-only`, verify executable/dSYM UUIDs, upload dSYMs via `sentry-cli`, and fail misconfigured partial Sentry env. The TestFlight workflow now requires Sentry secrets, zips the `.xcarchive`, and uploads versioned IPA/archive artifacts (90-day retention).
> 
> **Desktop/mobile polish:** the file watcher uses a **pruned file-ID cache** (skips `.git`/`.reflect`/prune dirs) to cut watch startup cost; `usePoll` pauses while hidden; back-swipe attaches a gesture-scoped non-passive `touchmove` blocker; editor mount logic is centralized in `whenEditorMounted`. Removes the Plan 19 `spike_mobile` startup probe. Bumps beta to `0.8.0-beta.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5459623ef5a239e6abe7846e3b8b9ef59293164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->