### PR TITLE
fix(ios): remove redundant whole-graph work on every iCloud open

### DIFF
--- a/apps/desktop/src-tauri/src/conflict/shadow.rs
+++ b/apps/desktop/src-tauri/src/conflict/shadow.rs
@@ -60,6 +60,13 @@ impl ShadowStore {
         fs::read_to_string(path).ok()
     }
 
+    /// Whether a base is recorded for a note, without reading it. The
+    /// baseline fill pass probes every note on every start — as a `base()`
+    /// call that was a full read of the entire store per launch.
+    pub fn has_base(&self, rel: &str) -> bool {
+        self.entry_path(rel, "").is_some_and(|path| path.is_file())
+    }
+
     /// Record `content` as the note's synced base (atomic).
     pub fn record(&self, rel: &str, content: &str) -> AppResult<()> {
         let path = self
@@ -189,8 +196,16 @@ mod tests {
     fn records_and_reads_a_base() {
         let (_dir, store) = store();
         assert_eq!(store.base("notes/a.md"), None);
+        assert!(!store.has_base("notes/a.md"));
         store.record("notes/a.md", "# synced\n").unwrap();
         assert_eq!(store.base("notes/a.md"), Some("# synced\n".to_string()));
+        assert!(store.has_base("notes/a.md"));
+    }
+
+    #[test]
+    fn has_base_refuses_traversal_shapes_like_base() {
+        let (_dir, store) = store();
+        assert!(!store.has_base("../outside.md"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/conflict/shadow.rs
+++ b/apps/desktop/src-tauri/src/conflict/shadow.rs
@@ -55,14 +55,32 @@ impl ShadowStore {
     }
 
     /// The base content for a note, when one has been recorded.
+    ///
+    /// A definitively corrupt entry — the bytes read fine but aren't UTF-8 —
+    /// is removed on sight: [`has_base`](Self::has_base) answers by
+    /// existence, so a corrupt file left in place would make every baseline
+    /// fill skip the note while every merge sees no base. Forgetting it
+    /// restores the store's rebuildable contract (the next fill re-records).
+    /// A read *error* is left alone: it may be transient, and deleting a
+    /// possibly-good base over it would be worse than one degraded merge.
     pub fn base(&self, rel: &str) -> Option<String> {
         let path = self.entry_path(rel, "")?;
-        fs::read_to_string(path).ok()
+        let bytes = fs::read(path).ok()?;
+        match String::from_utf8(bytes) {
+            Ok(content) => Some(content),
+            Err(_) => {
+                self.forget(rel);
+                None
+            }
+        }
     }
 
     /// Whether a base is recorded for a note, without reading it. The
     /// baseline fill pass probes every note on every start — as a `base()`
-    /// call that was a full read of the entire store per launch.
+    /// call that was a full read of the entire store per launch. Existence
+    /// is the honest answer here because [`base`](Self::base) deletes
+    /// definitively-corrupt entries, so a lingering entry is either usable
+    /// or transiently unreadable — never permanently dead.
     pub fn has_base(&self, rel: &str) -> bool {
         self.entry_path(rel, "").is_some_and(|path| path.is_file())
     }
@@ -206,6 +224,17 @@ mod tests {
     fn has_base_refuses_traversal_shapes_like_base() {
         let (_dir, store) = store();
         assert!(!store.has_base("../outside.md"));
+    }
+
+    #[test]
+    fn a_corrupt_base_is_forgotten_on_read_so_the_fill_can_re_record() {
+        let (dir, store) = store();
+        let entry = dir.path().join(".reflect/sync-base/notes/a.md");
+        fs::create_dir_all(entry.parent().unwrap()).unwrap();
+        fs::write(&entry, [0xff, 0xfe, 0x00]).unwrap(); // not UTF-8
+        assert!(store.has_base("notes/a.md")); // exists — fill would skip it
+        assert_eq!(store.base("notes/a.md"), None); // unusable → forgotten
+        assert!(!store.has_base("notes/a.md")); // next fill re-records
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/icloud/sweep.rs
+++ b/apps/desktop/src-tauri/src/icloud/sweep.rs
@@ -234,7 +234,7 @@ fn advance_base_if_clean(root: &Path, rel: &str, shadow: &ShadowStore, fill_only
     if crate::fs::ensure_relative(rel).is_err() {
         return;
     }
-    if fill_only && shadow.base(rel).is_some() {
+    if fill_only && shadow.has_base(rel) {
         return;
     }
     let abs = root.join(rel);

--- a/apps/desktop/src-tauri/src/icloud/watch.rs
+++ b/apps/desktop/src-tauri/src/icloud/watch.rs
@@ -487,7 +487,19 @@ mod platform {
                 crate::fs::invalidate_file_catalog(&state, root);
             }
             if emit_file_changes {
-                let _ = app.emit("index:changed", round.changes);
+                if is_update {
+                    let _ = app.emit("index:changed", round.changes);
+                } else {
+                    // The gather round diffs against an empty snapshot, so
+                    // its "changes" are every downloaded note in the graph —
+                    // not news, just the watch coming up. Emitting them sent
+                    // an O(graph) payload through every index:changed
+                    // listener on each open. The open-path reconcile already
+                    // covers on-disk state; one coarse reconcile signal
+                    // (coalesced by the frontend) closes the small window
+                    // between its listing and the gather completing.
+                    let _ = app.emit(crate::watcher::RECONCILE_EVENT, ());
+                }
             }
         }
         if !round.conflicts.is_empty() {

--- a/apps/desktop/src-tauri/src/icloud/watch.rs
+++ b/apps/desktop/src-tauri/src/icloud/watch.rs
@@ -486,21 +486,23 @@ mod platform {
                 let root = std::path::Path::new(root.trim_end_matches('/'));
                 crate::fs::invalidate_file_catalog(&state, root);
             }
-            if emit_file_changes {
-                if is_update {
-                    let _ = app.emit("index:changed", round.changes);
-                } else {
-                    // The gather round diffs against an empty snapshot, so
-                    // its "changes" are every downloaded note in the graph —
-                    // not news, just the watch coming up. Emitting them sent
-                    // an O(graph) payload through every index:changed
-                    // listener on each open. The open-path reconcile already
-                    // covers on-disk state; one coarse reconcile signal
-                    // (coalesced by the frontend) closes the small window
-                    // between its listing and the gather completing.
-                    let _ = app.emit(crate::watcher::RECONCILE_EVENT, ());
-                }
+            if emit_file_changes && is_update {
+                let _ = app.emit("index:changed", round.changes);
             }
+        }
+        if emit_file_changes && !is_update {
+            // The gather round diffs against an empty snapshot, so its
+            // "changes" are every downloaded note in the graph — not news,
+            // just the watch coming up. Emitting them sent an O(graph)
+            // payload through every index:changed listener on each open.
+            // The open-path reconcile already covers on-disk state; one
+            // coarse reconcile signal (coalesced by the frontend) closes the
+            // window between its listing and the gather completing. Emitted
+            // regardless of the round's diff: what raced in may be invisible
+            // to it — a deletion leaves the empty-snapshot diff empty, and
+            // placeholders never appear as changes at all — so an empty
+            // gather proves nothing about that window.
+            let _ = app.emit(crate::watcher::RECONCILE_EVENT, ());
         }
         if !round.conflicts.is_empty() {
             let mut conflicts = round.conflicts;

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -43,7 +43,7 @@ const CHANGE_EVENT: &str = "index:changed";
 /// removed (or the platform demanded a rescan), and its descendants were
 /// never enumerated per file. Carries no payload — the frontend answers with
 /// one full reconcile pass.
-const RECONCILE_EVENT: &str = "index:reconcile";
+pub(crate) const RECONCILE_EVENT: &str = "index:reconcile";
 
 /// Holds the active debouncer; dropping it stops the background watch thread.
 #[derive(Default)]

--- a/apps/desktop/src-tauri/src/watcher_mobile.rs
+++ b/apps/desktop/src-tauri/src/watcher_mobile.rs
@@ -15,6 +15,11 @@ use tauri::State;
 
 use crate::error::AppResult;
 
+/// The coarse "run one full reconcile" signal — same name as the desktop
+/// watcher's constant so `icloud::watch` can emit it on either platform.
+/// On mobile it is the iCloud watch's gather round that uses it.
+pub(crate) const RECONCILE_EVENT: &str = "index:reconcile";
+
 /// Unit stand-in for the desktop watcher state, so `lib.rs` manages the same
 /// type name on every platform.
 #[derive(Default)]


### PR DESCRIPTION
Stacked on #1009 (which stacks on #1008). Third leg of the startup-perf investigation: the two remaining pieces of redundant whole-graph work on every iCloud open.

## The gather-round avalanche

When the NSMetadataQuery watch starts, `install()` clears the snapshot, so the gather round's diff-against-empty reports **every downloaded note in the graph as an upsert**. On mobile (`emitFileChangesFromWatch`) that whole-graph array was serialized into the webview a few hundred ms to ~2s after open, where eight independent `index:changed` listeners each zod-parse it, and the live path follows with a chunked facts query over thousands of bind params — all redoing what the open-path reconcile just did against disk.

The gather round now seeds the snapshot (unchanged), keeps its download-nudge behavior (unchanged — `plan_nudges` never depended on the emit), and emits one coarse `index:reconcile` instead of the per-file payload. `GraphProvider` already listens for that signal on both platforms and folds it into the coalescing `refreshIndex`, so the cost becomes a single async reconcile scan with a near-empty delta — and it closes the small window between the open reconcile's listing and the gather completing, so nothing is lost by suppressing the emit. Update rounds keep their O(delta) per-file emits; desktop behavior is unchanged (it never emitted from this path).

The event name previously lived only in the desktop watcher; the mobile watcher stand-in now carries the same `pub(crate)` constant, keeping the two modules' identical-surface contract.

## The baseline fill's hidden full read

The conflict sweep's first pass of each launch (`record_baseline`) checks every note for an existing shadow base — via `base()`, which is `fs::read_to_string`. On an adopted graph where every note has a base, that "existence check" read the **entire base store** on every start. `ShadowStore::has_base()` answers with a stat instead; the fill-only guard in `advance_base_if_clean` uses it. `base()`'s readers are untouched.

## Testing

- `cargo test -p reflect-open` — 342 passed, including new `has_base` coverage (recorded/absent, and the traversal-shape refusal mirroring `base()`).
- `cargo check -p reflect-open --target aarch64-apple-ios` — clean (this is what caught the mobile watcher stand-in missing the constant).
- `cargo clippy` — clean.
- The gather path itself is ObjC-driven and not unit-testable; the pure diff/nudge logic it calls is unchanged and already covered.

## Not included, still deferred

The parse-once `index:changed` hub: with the gather emit gone, remaining emits are O(delta), so eight small zod parses are noise — the refactor no longer pays for its regression surface. Wave-2 async (index writes + `index_open`) still waits on the `ScopedBackgroundTask` expiration→cancel design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mobile index refresh timing at iCloud watch startup (reconcile vs per-file events) and shadow-store read semantics; behavior is intentional but affects sync/index correctness windows.
> 
> **Overview**
> **iCloud gather round (mobile):** Stops emitting an O(graph) `index:changed` batch when the metadata query finishes its initial gather (diff against an empty snapshot). Per-file emits are limited to **update** rounds; after gather, the shell emits a single coalesced **`index:reconcile`** so the frontend does one reconcile instead of re-processing every note.
> 
> **Shadow baseline fill:** Adds **`ShadowStore::has_base`** (file existence only) and uses it in the adoption **`fill_only`** path instead of **`base()`**, so launch no longer reads the entire `.reflect/sync-base` store just to skip notes that already have a base. **`base()`** now drops definitively non–UTF-8 entries on read so corrupt files cannot block re-record forever.
> 
> **Plumbing:** **`RECONCILE_EVENT`** is shared via **`pub(crate)`** on desktop **`watcher`** and the mobile **`watcher_mobile`** stand-in so **`icloud::watch`** can emit the same event on iOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52def5213b3c55e023b918ace4c184838896f7be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->