### PR TITLE
fix: symbolicate native iOS crashes from TestFlight builds

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -102,9 +102,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Resolve build number
+        id: build_number
         run: |
           build_number="$(date -u +%Y%m%d%H%M)"
           echo "BUILD_NUMBER=$build_number" >> "$GITHUB_ENV"
+          echo "value=$build_number" >> "$GITHUB_OUTPUT"
           echo "Using TestFlight CFBundleVersion $build_number"
 
       - name: Build and upload to TestFlight
@@ -124,12 +126,37 @@ jobs:
           fi
           pnpm release:ios "${args[@]}"
 
+      # Xcode Organizer symbolicates a TestFlight crash report from the local
+      # archive, which a CI runner throws away. Keep it so an Apple `.ips` that
+      # arrives weeks later can still be read.
+      - name: Package the Xcode archive
+        if: always()
+        run: |
+          archive="apps/desktop/src-tauri/gen/apple/build/reflect-open_iOS.xcarchive"
+          if [ ! -d "$archive" ]; then
+            echo "::warning::No Xcode archive was produced; skipping symbol packaging"
+            exit 0
+          fi
+          ditto -c -k --sequesterRsrc --keepParent \
+            "$archive" "$RUNNER_TEMP/reflect-ios-xcarchive-$BUILD_NUMBER.zip"
+
       # The exported IPA, kept for post-hoc signing/entitlements inspection —
       # TestFlight builds cannot be downloaded back from App Store Connect.
       - name: Upload IPA artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: reflect-ios-ipa
+          name: reflect-ios-ipa-${{ steps.build_number.outputs.value }}
           path: apps/desktop/src-tauri/gen/apple/build/arm64/*.ipa
           if-no-files-found: ignore
+          retention-days: 90
+
+      - name: Upload Xcode archive artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: reflect-ios-xcarchive-${{ steps.build_number.outputs.value }}
+          path: ${{ runner.temp }}/reflect-ios-xcarchive-${{ steps.build_number.outputs.value }}.zip
+          if-no-files-found: ignore
+          retention-days: 90
+          compression-level: 0

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -60,7 +60,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@sentry/cli": "2.58.6",
+    "@sentry/cli": "3.6.2",
     "@sentry/vite-plugin": "^5.3.0",
     "@sqlite.org/sqlite-wasm": "3.53.0-build1",
     "@tailwindcss/vite": "^4.3.1",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -60,6 +60,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@sentry/cli": "2.58.6",
     "@sentry/vite-plugin": "^5.3.0",
     "@sqlite.org/sqlite-wasm": "3.53.0-build1",
     "@tailwindcss/vite": "^4.3.1",

--- a/apps/desktop/scripts/release-ios.mjs
+++ b/apps/desktop/scripts/release-ios.mjs
@@ -30,6 +30,17 @@ const here = dirname(fileURLToPath(import.meta.url))
 const appDir = join(here, '..')
 const repoRoot = join(here, '..', '..', '..')
 const iosBuildDir = join(appDir, 'src-tauri', 'gen', 'apple', 'build')
+const iosArchive = join(iosBuildDir, 'reflect-open_iOS.xcarchive')
+const iosAppBinary = join(iosArchive, 'Products', 'Applications', 'Reflect.app', 'Reflect')
+const iosDsymBinary = join(
+  iosArchive,
+  'dSYMs',
+  'Reflect.app.dSYM',
+  'Contents',
+  'Resources',
+  'DWARF',
+  'Reflect',
+)
 
 function log(message) {
   console.log(`release-ios: ${message}`)
@@ -71,7 +82,14 @@ export function createTauriIosBuildArgs({
 
 /** Build the environment Tauri's iOS signing layer needs for API-key auth. */
 export function createTauriIosBuildEnv({ apiKeyCredentials = null, baseEnv = process.env } = {}) {
-  return { ...baseEnv, CI: 'true', ...(apiKeyCredentials?.env ?? {}) }
+  return {
+    ...baseEnv,
+    // Rust release builds otherwise omit the line tables Xcode needs when it
+    // creates the app dSYM, leaving native crash addresses unsymbolicated.
+    CARGO_PROFILE_RELEASE_DEBUG: baseEnv.CARGO_PROFILE_RELEASE_DEBUG || 'line-tables-only',
+    CI: 'true',
+    ...(apiKeyCredentials?.env ?? {}),
+  }
 }
 
 /** Build the altool command that uploads an IPA to App Store Connect/TestFlight. */
@@ -105,6 +123,63 @@ export function createAltoolListAppsArgs({ authArgs, bundleIdentifier }) {
     '--output-format',
     'json',
   ]
+}
+
+/** Build the Sentry CLI args for native dSYMs only, without source bundles. */
+export function createSentryDebugFilesUploadArgs(path) {
+  return [
+    'debug-files',
+    'upload',
+    '--org',
+    'reflect-64',
+    '--project',
+    'reflect-open',
+    '--type',
+    'dsym',
+    '--no-sources',
+    '--wait-for',
+    '60',
+    path,
+  ]
+}
+
+/** Accept only the production Reflect Sentry project configured in the clients. */
+export function isProductionSentryDsn(value) {
+  return /^https:\/\/[0-9a-f]{32}@o463484\.ingest\.us\.sentry\.io\/4511705649971200$/.test(
+    value ?? '',
+  )
+}
+
+/** Inspect native symbol-upload credentials without exposing their values. */
+export function inspectNativeSentryConfiguration(env = process.env) {
+  const hasAuthToken = Boolean(env.SENTRY_AUTH_TOKEN)
+  const hasDsn = Boolean(env.VITE_SENTRY_DSN)
+  if (!hasAuthToken && !hasDsn) {
+    return { enabled: false, error: null }
+  }
+  if (!hasAuthToken || !hasDsn) {
+    return {
+      enabled: false,
+      error:
+        'native Sentry configuration is incomplete; set both SENTRY_AUTH_TOKEN and VITE_SENTRY_DSN',
+    }
+  }
+  if (!isProductionSentryDsn(env.VITE_SENTRY_DSN)) {
+    return {
+      enabled: false,
+      error: 'VITE_SENTRY_DSN does not identify the production Reflect Sentry project',
+    }
+  }
+  return { enabled: true, error: null }
+}
+
+/** Parse every Mach-O UUID from `dwarfdump --uuid` output. */
+export function parseDwarfdumpUuids(output) {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.match(/^UUID: ([0-9a-f-]{36}) \(/i)?.[1]?.toUpperCase())
+    .filter((uuid) => uuid !== undefined)
+    .sort()
 }
 
 /** Return the standard App Store Connect API key lookup locations for altool. */
@@ -429,6 +504,60 @@ function assertIpaAppStoreMetadata(ipa) {
   assertIpaAppexEntitlements(ipa)
 }
 
+/**
+ * A dSYM that does not match the shipped executable symbolicates nothing, and
+ * the mismatch is only discoverable once a crash report arrives. Fail here.
+ */
+function assertCurrentArchiveSymbols() {
+  if (!existsSync(iosArchive)) {
+    fail(`tauri build succeeded, but the current Xcode archive is missing: ${iosArchive}`)
+  }
+  if (!existsSync(iosAppBinary)) {
+    fail(`current Xcode archive is missing its main executable: ${iosAppBinary}`)
+  }
+  if (!existsSync(iosDsymBinary)) {
+    fail(`current Xcode archive is missing its main dSYM: ${iosDsymBinary}`)
+  }
+
+  const appUuids = parseDwarfdumpUuids(capture('xcrun', ['dwarfdump', '--uuid', iosAppBinary]))
+  const dsymUuids = parseDwarfdumpUuids(capture('xcrun', ['dwarfdump', '--uuid', iosDsymBinary]))
+  if (
+    appUuids.length === 0 ||
+    dsymUuids.length === 0 ||
+    appUuids.join('\n') !== dsymUuids.join('\n')
+  ) {
+    fail(
+      'current Reflect executable and dSYM UUIDs do not match; refusing to publish a build that cannot be symbolicated',
+    )
+  }
+  log(`archive executable and dSYM UUIDs match: ${appUuids.join(', ')}`)
+}
+
+function uploadNativeDebugFiles() {
+  const configuration = inspectNativeSentryConfiguration()
+  if (configuration.error !== null) {
+    fail(configuration.error)
+  }
+  if (!configuration.enabled) {
+    log('native Sentry upload skipped (SENTRY_AUTH_TOKEN and VITE_SENTRY_DSN are not set)')
+    return
+  }
+
+  log('uploading native dSYM bundles from the current Xcode archive to Sentry…')
+  const result = spawnSync(
+    'pnpm',
+    ['exec', 'sentry-cli', ...createSentryDebugFilesUploadArgs(iosArchive)],
+    {
+      cwd: appDir,
+      stdio: 'inherit',
+      env: process.env,
+    },
+  )
+  if (result.status !== 0) {
+    fail('native Sentry dSYM upload failed; refusing to publish an unsymbolicated build')
+  }
+}
+
 function ensureReleaseTools() {
   ensureMacos()
   ensureTool('xcodebuild', ['-version'], 'Install Xcode and select it with `xcode-select`.')
@@ -436,6 +565,11 @@ function ensureReleaseTools() {
 }
 
 function runTauriIosBuild({ apiKeyCredentials, buildNumber, exportMethod, verbose }) {
+  // Checked before the long build so a bad configuration fails in seconds.
+  const sentryConfiguration = inspectNativeSentryConfiguration()
+  if (sentryConfiguration.error !== null) {
+    fail(sentryConfiguration.error)
+  }
   ensureReleaseTools()
   const args = createTauriIosBuildArgs({
     buildNumber,
@@ -467,6 +601,8 @@ function runTauriIosBuild({ apiKeyCredentials, buildNumber, exportMethod, verbos
   const ipa = newestIpa()
   if (!ipa) fail(`tauri build succeeded, but no .ipa was found under ${iosBuildDir}`)
   assertIpaAppStoreMetadata(ipa)
+  assertCurrentArchiveSymbols()
+  uploadNativeDebugFiles()
   log(`IPA: ${ipa} (${(statSync(ipa).size / (1024 * 1024)).toFixed(1)} MB)`)
   return ipa
 }
@@ -590,6 +726,10 @@ function testflight({ buildNumberFlag, exportMethod, wait, verbose }) {
 }
 
 function preflight({ buildNumberFlag }) {
+  const sentryConfiguration = inspectNativeSentryConfiguration()
+  if (sentryConfiguration.error !== null) {
+    fail(sentryConfiguration.error)
+  }
   ensureReleaseTools()
   resolveBuildNumber(buildNumberFlag, { required: true })
   const apiKeyCredentials = resolveApiKeyCredentials({ requirePrivateKey: false })
@@ -603,6 +743,7 @@ function preflight({ buildNumberFlag }) {
       }`,
     )
     log(`altool upload auth: ${uploadCredentials.source}`)
+    log(`native Sentry: ${sentryConfiguration.enabled ? 'configured' : 'disabled'}`)
     log(`xcodebuild: ${capture('xcodebuild', ['-version']).trim().replace(/\n/g, ' / ')}`)
     verifyAppStoreConnectAppRecord(uploadCredentials)
     log('preflight passed')

--- a/apps/desktop/scripts/release-ios.mjs
+++ b/apps/desktop/scripts/release-ios.mjs
@@ -143,7 +143,14 @@ export function createSentryDebugFilesUploadArgs(path) {
   ]
 }
 
-/** Accept only the production Reflect Sentry project configured in the clients. */
+/**
+ * Accept only the production Reflect Sentry project configured in the clients.
+ *
+ * The org/project identity is asserted in three places that must rotate
+ * together: here, `parseExceptionTelemetryDsn` in
+ * `src/lib/exception-telemetry.ts` (WebView SDK), and `parse_native_dsn` in
+ * `src-tauri/src/native_diagnostics.rs` (iOS native SDK).
+ */
 export function isProductionSentryDsn(value) {
   return /^https:\/\/[0-9a-f]{32}@o463484\.ingest\.us\.sentry\.io\/4511705649971200$/.test(
     value ?? '',

--- a/apps/desktop/scripts/release-ios.test.mjs
+++ b/apps/desktop/scripts/release-ios.test.mjs
@@ -7,13 +7,17 @@ import {
   createAltoolUploadArgs,
   createAltoolValidateArgs,
   createApiKeyAltoolArgs,
+  createSentryDebugFilesUploadArgs,
   createTimestampBuildNumber,
   createTauriIosBuildEnv,
   createTauriIosBuildArgs,
   findIpaAppexPaths,
   findIpaInfoPlistPath,
+  inspectNativeSentryConfiguration,
   isFalsePlistValue,
+  isProductionSentryDsn,
   normalizeApiKeyContent,
+  parseDwarfdumpUuids,
   resolveBuildNumber,
 } from './release-ios.mjs'
 
@@ -93,8 +97,76 @@ test('iOS release builds expose the staged API key path to Tauri signing', () =>
     APPLE_API_ISSUER: 'issuer-uuid',
     APPLE_API_KEY: 'ABC123DEFG',
     APPLE_API_KEY_PATH: '/tmp/AuthKey_ABC123DEFG.p8',
+    CARGO_PROFILE_RELEASE_DEBUG: 'line-tables-only',
     CI: 'true',
   })
+})
+
+test('iOS release builds emit Rust line tables so the app dSYM can symbolicate native frames', () => {
+  expect(createTauriIosBuildEnv({ baseEnv: {} }).CARGO_PROFILE_RELEASE_DEBUG).toBe(
+    'line-tables-only',
+  )
+  expect(
+    createTauriIosBuildEnv({ baseEnv: { CARGO_PROFILE_RELEASE_DEBUG: 'full' } })
+      .CARGO_PROFILE_RELEASE_DEBUG,
+  ).toBe('full')
+})
+
+test('native dSYMs upload without source bundles', () => {
+  expect(createSentryDebugFilesUploadArgs('/build/reflect-open_iOS.xcarchive')).toEqual([
+    'debug-files',
+    'upload',
+    '--org',
+    'reflect-64',
+    '--project',
+    'reflect-open',
+    '--type',
+    'dsym',
+    '--no-sources',
+    '--wait-for',
+    '60',
+    '/build/reflect-open_iOS.xcarchive',
+  ])
+})
+
+test('only the production Reflect Sentry project enables native symbol upload', () => {
+  const dsn =
+    'https://0123456789abcdef0123456789abcdef@o463484.ingest.us.sentry.io/4511705649971200'
+  expect(isProductionSentryDsn(dsn)).toBe(true)
+  expect(isProductionSentryDsn('https://public@example.test/1')).toBe(false)
+  expect(isProductionSentryDsn(undefined)).toBe(false)
+
+  expect(
+    inspectNativeSentryConfiguration({ SENTRY_AUTH_TOKEN: 'token', VITE_SENTRY_DSN: dsn }),
+  ).toEqual({ enabled: true, error: null })
+  expect(inspectNativeSentryConfiguration({})).toEqual({ enabled: false, error: null })
+})
+
+test('partial or foreign native Sentry configuration fails the release instead of shipping blind', () => {
+  const dsn =
+    'https://0123456789abcdef0123456789abcdef@o463484.ingest.us.sentry.io/4511705649971200'
+  expect(inspectNativeSentryConfiguration({ SENTRY_AUTH_TOKEN: 'token' }).error).toMatch(
+    /incomplete/,
+  )
+  expect(inspectNativeSentryConfiguration({ VITE_SENTRY_DSN: dsn }).error).toMatch(/incomplete/)
+  expect(
+    inspectNativeSentryConfiguration({
+      SENTRY_AUTH_TOKEN: 'token',
+      VITE_SENTRY_DSN: 'https://public@example.test/1',
+    }).error,
+  ).toMatch(/production Reflect Sentry project/)
+})
+
+test('dwarfdump UUIDs are parsed per architecture and compared order-independently', () => {
+  expect(
+    parseDwarfdumpUuids(
+      [
+        'UUID: 3fbb0e0d-6cbb-3d0e-9e26-06f2ff1a09f2 (arm64) /build/Reflect.app/Reflect',
+        'warning: no debug map',
+      ].join('\n'),
+    ),
+  ).toEqual(['3FBB0E0D-6CBB-3D0E-9E26-06F2FF1A09F2'])
+  expect(parseDwarfdumpUuids('')).toEqual([])
 })
 
 test('altool upload uses package upload with API key auth and optional processing wait', () => {

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -1,3 +1,6 @@
 fn main() {
+    // `native_diagnostics` bakes the DSN in with `option_env!`, which cargo
+    // does not otherwise track.
+    println!("cargo:rerun-if-env-changed=VITE_SENTRY_DSN");
     tauri_build::build()
 }

--- a/apps/desktop/src-tauri/gen/apple/Sources/reflect-open/NativeDiagnostics.swift
+++ b/apps/desktop/src-tauri/gen/apple/Sources/reflect-open/NativeDiagnostics.swift
@@ -1,0 +1,214 @@
+import Foundation
+import Sentry
+
+/// Native crash/hang reporting for the iOS host process.
+///
+/// The JavaScript layer already reports webview exceptions
+/// (`apps/desktop/src/lib/exception-telemetry.ts`), but a Rust panic, a Swift
+/// crash, an OS watchdog kill, or a WebKit content-process death never reaches
+/// it. Those are exactly the terminations that arrive in TestFlight without a
+/// usable report, so the host starts Sentry Cocoa purely to capture the native
+/// stacks. Everything that could carry note content — messages, breadcrumbs,
+/// file paths, source context, PII — is disabled or scrubbed here; see
+/// `docs/privacy.md`.
+private enum NativeDiagnostics {
+  private static var started = false
+  private static let redacted = "[redacted]"
+
+  /// Device/OS/app context fields that cannot describe a user's notes.
+  private static let safeContextFields: [String: Set<String>] = [
+    "app": [
+      "app_identifier",
+      "app_name",
+      "app_version",
+      "app_build",
+      "app_start_time",
+      "in_foreground",
+    ],
+    "device": [
+      "family",
+      "model",
+      "model_id",
+      "arch",
+      "memory_size",
+      "free_memory",
+      "usable_memory",
+      "storage_size",
+      "free_storage",
+      "simulator",
+      "thermal_state",
+      "orientation",
+      "charging",
+      "battery_level",
+      "online",
+      "processor_count",
+    ],
+    "os": [
+      "name",
+      "version",
+      "build",
+      "kernel_version",
+      "rooted",
+    ],
+  ]
+
+  static func start(dsn: String, version: String) {
+    guard Thread.isMainThread else {
+      DispatchQueue.main.async {
+        start(dsn: dsn, version: version)
+      }
+      return
+    }
+    guard !started else {
+      return
+    }
+    started = true
+
+    let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+
+    SentrySDK.start { options in
+      options.dsn = dsn
+      // Matches the release name the webview SDK reports, so native and
+      // JavaScript events for one build group together.
+      options.releaseName = "reflect@\(version)"
+      options.dist = build
+      options.environment = "production"
+      options.debug = false
+      options.sampleRate = 1
+      options.tracesSampleRate = 0
+
+      options.sendDefaultPii = false
+      options.sendClientReports = false
+      options.enableAutoSessionTracking = false
+      options.maxBreadcrumbs = 0
+      options.beforeBreadcrumb = { _ in nil }
+
+      // The stack-bearing terminations this integration exists for.
+      options.enableCrashHandler = true
+      options.enableAppHangTracking = true
+      options.enableAppHangTrackingV2 = true
+      options.enableReportNonFullyBlockingAppHangs = false
+      options.appHangTimeoutInterval = 2
+      options.enableWatchdogTerminationTracking = true
+      options.enableSigtermReporting = false
+
+      // Everything else the SDK would collect by default.
+      options.attachScreenshot = false
+      options.attachViewHierarchy = false
+      options.enableAutoBreadcrumbTracking = false
+      options.enableNetworkBreadcrumbs = false
+      options.enableCaptureFailedRequests = false
+      options.enableAutoPerformanceTracing = false
+      options.enableUIViewControllerTracing = false
+      options.enableUserInteractionTracing = false
+      options.enableNetworkTracking = false
+      options.enableFileIOTracing = false
+      options.enableCoreDataTracing = false
+
+      if #available(iOS 15.0, *) {
+        options.enableMetricKit = true
+        options.enableMetricKitRawPayload = false
+      }
+
+      options.beforeSend = { event in
+        scrub(event: event)
+      }
+    }
+  }
+
+  /// Drop anything without a stack, then strip every field that is not an
+  /// address, a symbol, or allow-listed device metadata.
+  private static func scrub(event: Event) -> Event? {
+    let hasDiagnosticStack =
+      event.stacktrace != nil || event.exceptions?.isEmpty == false || event.threads?.isEmpty == false
+    guard hasDiagnosticStack else {
+      return nil
+    }
+
+    event.message = nil
+    event.error = nil
+    event.logger = nil
+    event.serverName = nil
+    event.transaction = nil
+    event.user = nil
+    event.request = nil
+    event.extra = nil
+    event.modules = nil
+    event.fingerprint = nil
+    event.breadcrumbs = []
+    event.tags = ["runtime": "tauri-native"]
+    event.context = scrub(context: event.context)
+    // Debug images keep their UUID and address range — that is what Sentry
+    // matches the uploaded dSYMs against — but not their build-machine paths.
+    event.debugMeta?.forEach { image in
+      image.codeFile = image.codeFile.map(basename)
+      image.name = image.name.map(basename)
+    }
+
+    event.exceptions?.forEach { exception in
+      exception.value = redacted
+      exception.type = "NativeCrash"
+      exception.module = nil
+      exception.mechanism?.type = "native"
+      exception.mechanism?.desc = nil
+      exception.mechanism?.data = nil
+      exception.mechanism?.helpLink = nil
+      scrub(stacktrace: exception.stacktrace)
+    }
+    event.threads?.forEach { thread in
+      thread.name = nil
+      scrub(stacktrace: thread.stacktrace)
+    }
+    scrub(stacktrace: event.stacktrace)
+    return event
+  }
+
+  private static func scrub(context: [String: [String: Any]]?) -> [String: [String: Any]]? {
+    guard let context else {
+      return nil
+    }
+    var scrubbed: [String: [String: Any]] = [:]
+    for (name, allowedFields) in safeContextFields {
+      guard let values = context[name] else {
+        continue
+      }
+      let allowedValues = values.filter { allowedFields.contains($0.key) }
+      if !allowedValues.isEmpty {
+        scrubbed[name] = allowedValues
+      }
+    }
+    return scrubbed.isEmpty ? nil : scrubbed
+  }
+
+  private static func scrub(stacktrace: SentryStacktrace?) {
+    stacktrace?.frames.forEach { frame in
+      frame.fileName = nil
+      frame.contextLine = nil
+      frame.preContext = nil
+      frame.postContext = nil
+      frame.vars = nil
+      if let package = frame.package {
+        frame.package = package.split(separator: "/").last.map(String.init)
+      }
+    }
+  }
+
+  private static func basename(_ path: String) -> String {
+    (path as NSString).lastPathComponent
+  }
+}
+
+/// Called once from Rust during Tauri's mobile setup; see `native_diagnostics.rs`.
+@_cdecl("reflect_start_native_diagnostics")
+public func reflectStartNativeDiagnostics(
+  _ dsnPointer: UnsafePointer<CChar>?,
+  _ versionPointer: UnsafePointer<CChar>?
+) {
+  guard let dsnPointer, let versionPointer else {
+    return
+  }
+  NativeDiagnostics.start(
+    dsn: String(cString: dsnPointer),
+    version: String(cString: versionPointer)
+  )
+}

--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -3,6 +3,12 @@ options:
   bundleIdPrefix: app.reflect
   deploymentTarget:
     iOS: 14.0
+packages:
+  # Native crash/hang reporting (NativeDiagnostics.swift). Pinned exactly:
+  # Sentry 9 raises the minimum to iOS 15, above Reflect's deployment target.
+  Sentry:
+    url: https://github.com/getsentry/sentry-cocoa
+    exactVersion: 8.58.4
 fileGroups: [../../src]
 configs:
   debug: debug
@@ -169,6 +175,8 @@ targets:
       # + the recording Live Activity; embedded and signed with the app.
       - target: RecordingWidget
         embed: true
+      - package: Sentry
+        product: Sentry
       - framework: libapp.a
         embed: false
       # libgit2 (vendored into libapp.a) needs zlib and iconv at the final

--- a/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B64041CFADD8313F72A847E /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = C8AADCC30FF3C34B87DA6BCD /* Sentry */; };
 		14BE6EF4AB511AC099410853 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 57BCB79C0774021318852985 /* main.mm */; };
 		1C8847A7F1C163FBA53373F9 /* ExtensionClass.js in Resources */ = {isa = PBXBuildFile; fileRef = 536E4F5E21B7DCC3C7ECDC1A /* ExtensionClass.js */; };
 		266B3807E809464C8FC14146 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FDC9BB81FAB5AF8D65160799 /* Metal.framework */; };
@@ -36,6 +37,7 @@
 		E413DBCB60FF081C8E58468A /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 088536D8F462855DCFDA7B06 /* WebKit.framework */; };
 		E7D75AA83CFA468E0EFBAB21 /* RecordAudioWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AC6BF821D47F74D41DFAFE /* RecordAudioWidget.swift */; };
 		E9E7B6C59015E7301EE63308 /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 44C3B8C21F2D38187423AB2F /* libiconv.tbd */; };
+		ED7E82D99D937F44DF372E66 /* NativeDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A04E7EA62A721AED66B3F2 /* NativeDiagnostics.swift */; };
 		F00F5EAED90E34102F9AE651 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A86D201016958E2276806466 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
@@ -136,11 +138,13 @@
 		ACE1CDF45CDBB8D7B2446E36 /* windows.rs */ = {isa = PBXFileReference; path = windows.rs; sourceTree = "<group>"; };
 		ADB23521181EEB9EF095D4AB /* contacts.rs */ = {isa = PBXFileReference; path = contacts.rs; sourceTree = "<group>"; };
 		B667667E9C6C141128493B00 /* quit.rs */ = {isa = PBXFileReference; path = quit.rs; sourceTree = "<group>"; };
+		B6A04E7EA62A721AED66B3F2 /* NativeDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeDiagnostics.swift; sourceTree = "<group>"; };
 		BC3901740F3A40252C3750C7 /* reflect-open_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "reflect-open_iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C228C4BA95B0BADA424A9E8A /* RecordingActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingActivityAttributes.swift; sourceTree = "<group>"; };
 		C38A6847351881E6D17A1DC2 /* migrations.rs */ = {isa = PBXFileReference; path = migrations.rs; sourceTree = "<group>"; };
 		C7BE8291B337F95D913C6AE9 /* commit_message.rs */ = {isa = PBXFileReference; path = commit_message.rs; sourceTree = "<group>"; };
 		C94374B175075AF3AA7DE586 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		C948CE24FFADAD173A38CFF5 /* menu.rs */ = {isa = PBXFileReference; path = menu.rs; sourceTree = "<group>"; };
 		CF582FB0094C95210BE919F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D05B757D9AB841897576F256 /* merge3.rs */ = {isa = PBXFileReference; path = merge3.rs; sourceTree = "<group>"; };
 		D2398DBC3478C5F96CC89402 /* background_task.rs */ = {isa = PBXFileReference; path = background_task.rs; sourceTree = "<group>"; };
@@ -159,6 +163,7 @@
 		E8031FEC080EBAF422BEE44C /* markers.rs */ = {isa = PBXFileReference; path = markers.rs; sourceTree = "<group>"; };
 		E833A01F2799F6788CDCE53F /* link_preview.rs */ = {isa = PBXFileReference; path = link_preview.rs; sourceTree = "<group>"; };
 		EC45808CD3D13DD431212EAE /* watch.rs */ = {isa = PBXFileReference; path = watch.rs; sourceTree = "<group>"; };
+		ED55B2588FBAE8E128D80472 /* native_diagnostics.rs */ = {isa = PBXFileReference; path = native_diagnostics.rs; sourceTree = "<group>"; };
 		F28F8A628D32337E04C0CBC0 /* libapp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libapp.a; sourceTree = "<group>"; };
 		F3173A0D7E498896FAC5A43E /* watcher_mobile.rs */ = {isa = PBXFileReference; path = watcher_mobile.rs; sourceTree = "<group>"; };
 		FDC9BB81FAB5AF8D65160799 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
@@ -169,6 +174,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0B64041CFADD8313F72A847E /* Sentry in Frameworks */,
 				9D7F5A94048CECBFC3D89BBA /* libapp.a in Frameworks */,
 				319EDF8F46AB05DFBA9D674F /* libz.tbd in Frameworks */,
 				E9E7B6C59015E7301EE63308 /* libiconv.tbd in Frameworks */,
@@ -297,6 +303,8 @@
 				560C7C23BE58D7EA845F1170 /* lib.rs */,
 				E833A01F2799F6788CDCE53F /* link_preview.rs */,
 				37EF719F509C3A532C0E0114 /* main.rs */,
+				C948CE24FFADAD173A38CFF5 /* menu.rs */,
+				ED55B2588FBAE8E128D80472 /* native_diagnostics.rs */,
 				B667667E9C6C141128493B00 /* quit.rs */,
 				8C04E40F02C9B4AE9A24A9A4 /* recents.rs */,
 				D7DA2E13EA6655A16DFDE015 /* secrets.rs */,
@@ -364,6 +372,7 @@
 			isa = PBXGroup;
 			children = (
 				57BCB79C0774021318852985 /* main.mm */,
+				B6A04E7EA62A721AED66B3F2 /* NativeDiagnostics.swift */,
 				D29B88183661F5C1C960E074 /* RecordingIntents.swift */,
 				3613166A0FB6AFF3C3B2F85C /* StopRecordingLiveActivityIntent.swift */,
 				024093CF75026447063ECAFB /* bindings */,
@@ -473,6 +482,7 @@
 			);
 			name = "reflect-open_iOS";
 			packageProductDependencies = (
+				C8AADCC30FF3C34B87DA6BCD /* Sentry */,
 			);
 			productName = "reflect-open_iOS";
 			productReference = BC3901740F3A40252C3750C7 /* reflect-open_iOS.app */;
@@ -510,6 +520,9 @@
 			);
 			mainGroup = 32CAD5F88380EB83D170715E;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				66F54EA13384DC78CB89C8EA /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 085B9B9F8FF6A8514F9F4511 /* Products */;
 			projectDirPath = "";
@@ -633,6 +646,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ED7E82D99D937F44DF372E66 /* NativeDiagnostics.swift in Sources */,
 				6C55CBAB912EC5920CE314DA /* RecordingIntents.swift in Sources */,
 				6C3751B3B175DFE411D97C0F /* StopRecordingLiveActivityIntent.swift in Sources */,
 				14BE6EF4AB511AC099410853 /* main.mm in Sources */,
@@ -970,6 +984,25 @@
 			defaultConfigurationName = debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		66F54EA13384DC78CB89C8EA /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = exactVersion;
+				version = 8.58.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		C8AADCC30FF3C34B87DA6BCD /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 66F54EA13384DC78CB89C8EA /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 5489219F37B2885D5C3112F4 /* Project object */;
 }

--- a/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "a72b37d142139a9f8de021ec1a2d4e7ec2a7ffc9ebc87493f58bac80a85691cb",
+  "pins" : [
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "f196cbb98e0388381d57908f2f5a9bdc385cde68",
+        "version" : "8.58.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/apps/desktop/src-tauri/ios.project.yml
+++ b/apps/desktop/src-tauri/ios.project.yml
@@ -3,6 +3,12 @@ options:
   bundleIdPrefix: app.reflect
   deploymentTarget:
     iOS: 14.0
+packages:
+  # Native crash/hang reporting (NativeDiagnostics.swift). Pinned exactly:
+  # Sentry 9 raises the minimum to iOS 15, above Reflect's deployment target.
+  Sentry:
+    url: https://github.com/getsentry/sentry-cocoa
+    exactVersion: 8.58.4
 fileGroups: [../../src]
 configs:
   debug: debug
@@ -168,6 +174,8 @@ targets:
       # + the recording Live Activity; embedded and signed with the app.
       - target: RecordingWidget
         embed: true
+      - package: Sentry
+        product: Sentry
       - framework: libapp.a
         embed: false
       # libgit2 (vendored into libapp.a) needs zlib and iconv at the final

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -28,6 +28,8 @@ mod graph_gitignore;
 mod icloud;
 mod link_preview;
 mod menu;
+#[cfg(any(target_os = "ios", test))]
+mod native_diagnostics;
 mod quit;
 mod recents;
 mod secrets;
@@ -210,6 +212,11 @@ pub fn run() {
     // line with the spike, but keep the window show.)
     #[cfg(mobile)]
     let builder = builder.setup(|app| {
+        // Before anything else can crash: this is the only reporter that sees
+        // native failures (Rust panics, Swift crashes, main-thread hangs,
+        // watchdog kills), which reach TestFlight with no usable stack.
+        #[cfg(target_os = "ios")]
+        native_diagnostics::start(&app.package_info().version.to_string());
         if let Some(window) = app.get_webview_window(windows::MAIN_WINDOW_LABEL) {
             window.show()?;
         }

--- a/apps/desktop/src-tauri/src/native_diagnostics.rs
+++ b/apps/desktop/src-tauri/src/native_diagnostics.rs
@@ -10,9 +10,13 @@ use std::ffi::{c_char, CString};
 const SENTRY_DSN_PREFIX: &str = "https://";
 const SENTRY_ENDPOINT: &str = "o463484.ingest.us.sentry.io/4511705649971200";
 
-/// Accept only the production Reflect project DSN, mirroring
-/// `parseExceptionTelemetryDsn` in `src/lib/exception-telemetry.ts`. Forks and
-/// local builds without the secret simply never start the native SDK.
+/// Accept only the production Reflect project DSN. Forks and local builds
+/// without the secret simply never start the native SDK.
+///
+/// The org/project identity is asserted in three places that must rotate
+/// together: here, `parseExceptionTelemetryDsn` in
+/// `src/lib/exception-telemetry.ts` (WebView SDK), and `isProductionSentryDsn`
+/// in `scripts/release-ios.mjs` (symbol upload).
 fn parse_native_dsn(value: Option<&str>) -> Option<&str> {
     let value = value?.trim();
     let remainder = value.strip_prefix(SENTRY_DSN_PREFIX)?;

--- a/apps/desktop/src-tauri/src/native_diagnostics.rs
+++ b/apps/desktop/src-tauri/src/native_diagnostics.rs
@@ -1,0 +1,72 @@
+//! Starts native crash/hang reporting for the iOS host process.
+//!
+//! The Swift half lives in
+//! `gen/apple/Sources/reflect-open/NativeDiagnostics.swift`; this module only
+//! validates the compile-time DSN and hands it across the FFI boundary.
+
+#[cfg(target_os = "ios")]
+use std::ffi::{c_char, CString};
+
+const SENTRY_DSN_PREFIX: &str = "https://";
+const SENTRY_ENDPOINT: &str = "o463484.ingest.us.sentry.io/4511705649971200";
+
+/// Accept only the production Reflect project DSN, mirroring
+/// `parseExceptionTelemetryDsn` in `src/lib/exception-telemetry.ts`. Forks and
+/// local builds without the secret simply never start the native SDK.
+fn parse_native_dsn(value: Option<&str>) -> Option<&str> {
+    let value = value?.trim();
+    let remainder = value.strip_prefix(SENTRY_DSN_PREFIX)?;
+    let (public_key, endpoint) = remainder.split_once('@')?;
+    if public_key.len() != 32
+        || !public_key
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        || endpoint != SENTRY_ENDPOINT
+    {
+        return None;
+    }
+    Some(value)
+}
+
+#[cfg(target_os = "ios")]
+extern "C" {
+    fn reflect_start_native_diagnostics(dsn: *const c_char, version: *const c_char);
+}
+
+/// Starts the native SDK when this official build carries the production DSN.
+#[cfg(target_os = "ios")]
+pub fn start(app_version: &str) {
+    let Some(dsn) = parse_native_dsn(option_env!("VITE_SENTRY_DSN")) else {
+        return;
+    };
+    let (Ok(dsn), Ok(app_version)) = (CString::new(dsn), CString::new(app_version)) else {
+        return;
+    };
+    // SAFETY: the Swift function copies these valid, NUL-terminated UTF-8
+    // strings during the call and never retains the pointers.
+    unsafe {
+        reflect_start_native_diagnostics(dsn.as_ptr(), app_version.as_ptr());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_native_dsn;
+
+    #[test]
+    fn accepts_only_the_production_reflect_project() {
+        let valid =
+            "https://0123456789abcdef0123456789abcdef@o463484.ingest.us.sentry.io/4511705649971200";
+        assert_eq!(parse_native_dsn(Some(valid)), Some(valid));
+        assert!(parse_native_dsn(Some("https://public@example.test/1")).is_none());
+        assert!(parse_native_dsn(Some(
+            "https://0123456789abcdef0123456789abcdef@o463484.ingest.us.sentry.io/1"
+        ))
+        .is_none());
+        assert!(parse_native_dsn(Some(
+            "http://0123456789abcdef0123456789abcdef@o463484.ingest.us.sentry.io/4511705649971200"
+        ))
+        .is_none());
+        assert!(parse_native_dsn(None).is_none());
+    }
+}

--- a/docs/ios-testflight.md
+++ b/docs/ios-testflight.md
@@ -63,8 +63,10 @@ for `pnpm release:ios testflight`.
 4. **Sentry exception telemetry credentials.** Set the public `VITE_SENTRY_DSN` and the
    private, build-only `SENTRY_AUTH_TOKEN` for local TestFlight builds. Configure them in
    GitHub as the repository secrets `SENTRY_DSN` and `SENTRY_AUTH_TOKEN`; the TestFlight
-   workflow requires both before building. The token needs release/source-map upload
-   scope only and must never use the `VITE_` prefix or enter the app bundle.
+   workflow requires both before building. The DSN initializes both the WebView and the
+   iOS native SDK. The token must be allowed to upload JavaScript source maps and native
+   debug files to the `reflect-open` project; it must never use the `VITE_` prefix or
+   enter the app bundle.
 
 5. **A monotonically increasing build number.** TestFlight rejects duplicate
    `CFBundleVersion` values for the same marketing version. The GitHub Action
@@ -75,7 +77,7 @@ for `pnpm release:ios testflight`.
    builds: a lower `CFBundleVersion` can upload successfully while TestFlight
    still appears to show the previous timestamp build as the latest.
 
-5. **Xcode on macOS.** The workflow and local script use `xcodebuild`, Tauri's
+6. **Xcode on macOS.** The workflow and local script use `xcodebuild`, Tauri's
    iOS build command, and `xcrun altool`.
 
 ## Commands
@@ -96,7 +98,12 @@ Runs `pnpm tauri ios build --export-method app-store-connect --ci`, using the
 signed-in Xcode account locally or the App Store Connect API key environment
 when the key is configured. The build number is merged into the Tauri config as
 `bundle.iOS.bundleVersion`. The IPA lands under
-`apps/desktop/src-tauri/gen/apple/build/`.
+`apps/desktop/src-tauri/gen/apple/build/`. Release builds retain Rust line
+tables so Xcode can produce a dSYM that symbolicates native frames. When the
+Sentry credentials are set, the helper requires the current archive's main dSYM,
+verifies its UUID against the archived executable, and uploads only that
+archive's native symbols — without source bundles — before returning. Supplying
+only one of the DSN or token is a release error.
 
 ```bash
 pnpm release:ios testflight --wait
@@ -125,7 +132,11 @@ the upload flow.
 
 Use **Actions -> TestFlight -> Run workflow**. The workflow builds on
 `macos-26`, uploads the IPA to App Store Connect, and serializes runs so two
-uploads do not race each other.
+uploads do not race each other. It keeps both the exported IPA and a
+metadata-preserving ZIP of the exact `.xcarchive` for 90 days. The archive holds
+the matching binaries and dSYMs needed to symbolicate an Apple `.ips` report
+that arrives later; the archive is packaged even when the run failed, so the
+evidence survives a release blocker.
 
 Configure these repository secrets:
 
@@ -134,6 +145,8 @@ Configure these repository secrets:
 | `APPLE_API_KEY` | App Store Connect API key ID |
 | `APPLE_API_ISSUER` | App Store Connect issuer UUID |
 | `APPLE_API_KEY_CONTENT` | Contents of `AuthKey_<KEY>.p8` |
+| `SENTRY_DSN` | Public DSN for the production Reflect Sentry project |
+| `SENTRY_AUTH_TOKEN` | Build-only token allowed to upload releases, source maps, and debug files |
 
 The workflow does not accept a build-number input. Each run resolves one UTC
 timestamp build number, logs it, and passes the same value to both `preflight`
@@ -184,3 +197,16 @@ workflow.
 - **Export-compliance prompt appears again**: rebuild from an Xcode project that
   includes `ITSAppUsesNonExemptEncryption=false` in the iOS Info.plist. The
   release helper refuses to upload IPAs that are missing this key.
+- **A TestFlight feedback ZIP has no stack**: expected. Tester feedback carries a
+  screenshot and device metadata, not a crash report, and many `WKWebView`
+  content-process deaths, jetsam kills, and watchdog terminations never produce
+  one. Read the native crash/hang/watchdog events in Sentry instead, or ask for
+  the Apple `.ips` report.
+- **An Apple `.ips` report is unsymbolicated**: download the
+  `reflect-ios-xcarchive-<build>` artifact for that exact TestFlight build,
+  confirm its executable UUID appears in the report, and symbolicate against the
+  archive's dSYM. An IPA alone does not contain one.
+- **Sentry reports "missing debug information"**: check the release helper's
+  `sentry-cli debug-files upload` output. Publication fails when native Sentry is
+  configured but no dSYM exists or the upload is rejected; JavaScript source-map
+  upload does not cover Rust or Swift frames.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -3,8 +3,8 @@
 Reflect is local-first: your notes are markdown files in a folder you chose, the search
 index is SQLite in `.reflect/` beside them, and **no Reflect-hosted server exists in any
 path** — there is no product analytics and no account. Official release builds send
-scrubbed JavaScript exception diagnostics to Sentry. Every network call the app can make
-is listed here, with what it carries.
+scrubbed WebView and native crash diagnostics to Sentry. Every network call the app can
+make is listed here, with what it carries.
 
 The one hard rule sits above all of it: **a note with `private: true` frontmatter never
 has its content sent to any external service.** This is enforced in code at every AI
@@ -101,24 +101,34 @@ disk at call time), and it is covered by tests.
 
 ## Exception diagnostics (on in official release builds)
 
-- **Where:** Sentry, for errors raised in the React/WebView layer. Native process crashes
-  remain covered by the operating system's crash reporting.
-- **What:** an allow-listed diagnostic containing the exception class, sanitized
-  JavaScript stack locations, the app version, and whether the exception was marked
-  handled. A small set of vetted structural error messages that cannot contain document
-  data is kept; all other exception text is redacted. Stack filenames are reduced to
-  bundle basenames. Request
-  data, note content, note titles, graph paths, local filesystem paths, breadcrumbs,
-  console output, session replay, tracing, and user identifiers are not collected. Sentry
-  is also configured not to store the transport IP address with events.
+- **Where:** Sentry. The React/WebView SDK handles JavaScript exceptions; on iOS a
+  native SDK handles host-process crashes, fully blocking main-thread hangs, watchdog
+  terminations, and converted Apple MetricKit diagnostics — the failures that never
+  reach the JavaScript layer, and that arrive in TestFlight with no usable stack.
+- **What:** an allow-listed diagnostic containing the JavaScript exception class (or a
+  fixed native failure category), sanitized stack locations, the app/build version, and
+  whether the exception was marked handled. Native reports also carry non-identifying
+  OS/device model, architecture, memory, storage, battery, and thermal facts, which are
+  what distinguish a resource termination from a code defect. A small set of vetted
+  JavaScript structural error messages that cannot contain document data is kept; every
+  native exception value and all other exception text is redacted. JavaScript filenames
+  and native loaded-image names are reduced to basenames.
+- **Never collected:** request data, note content, note titles, graph paths, local
+  filesystem paths, native source paths, frame variables, source context lines, thread
+  names, breadcrumbs, console or Rust tracing output, session replay, performance
+  traces and profiles, screenshots, view hierarchy, raw MetricKit payloads, and user
+  identifiers. Sentry is also configured not to store the transport IP address with
+  events.
 - **When:** only when an official desktop or iOS release raises an uncaught JavaScript
-  error, an unhandled promise rejection, or a caught/recoverable React error. Development
-  and self-built apps without the release DSN do not initialize Sentry.
+  error, an unhandled promise rejection, or a caught/recoverable React error — and on
+  iOS, the native failure categories above. Development and self-built apps without the
+  release DSN do not initialize either SDK.
 - **Operational safeguards:** Sentry's server-side and default scrubbers are enabled, IP
   address storage and server-side JavaScript source scraping are disabled, and explicit
   sensitive-field rules cover notes, graph paths, requests, and user identifiers. Private
-  source maps are uploaded during official builds for readable stacks, then deleted from
-  the app bundle.
+  JavaScript source maps and native dSYMs are uploaded during official builds so stacks
+  are readable; native symbol uploads exclude sources, and neither kind of symbol file
+  ships as readable source in the app bundle.
 
 ## Housekeeping calls
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -3,8 +3,9 @@
 Reflect is local-first: your notes are markdown files in a folder you chose, the search
 index is SQLite in `.reflect/` beside them, and **no Reflect-hosted server exists in any
 path** — there is no product analytics and no account. Official release builds send
-scrubbed WebView and native crash diagnostics to Sentry. Every network call the app can
-make is listed here, with what it carries.
+scrubbed WebView diagnostics to Sentry, and official iOS release builds also send scrubbed
+native crash diagnostics. Every network call the app can make is listed here, with what it
+carries.
 
 The one hard rule sits above all of it: **a note with `private: true` frontmatter never
 has its content sent to any external service.** This is enforced in code at every AI

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@sentry/cli':
+        specifier: 2.58.6
+        version: 2.58.6(supports-color@7.2.0)
       '@sentry/vite-plugin':
         specifier: ^5.3.0
         version: 5.4.0(supports-color@7.2.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,8 +149,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@sentry/cli':
-        specifier: 2.58.6
-        version: 2.58.6(supports-color@7.2.0)
+        specifier: 3.6.2
+        version: 3.6.2
       '@sentry/vite-plugin':
         specifier: ^5.3.0
         version: 5.4.0(supports-color@7.2.0)
@@ -1690,9 +1690,20 @@ packages:
     engines: {node: '>=10'}
     os: [darwin]
 
+  '@sentry/cli-darwin@3.6.2':
+    resolution: {integrity: sha512-/ZIMLblj6ncwguhOPw5YL9018iaD2RBhxhbHBxjaowy1vrmnzoCurGe4n5Vv7PaS21ldAHtHNqJwNqHJS4XHUw==}
+    engines: {node: '>=18'}
+    os: [darwin]
+
   '@sentry/cli-linux-arm64@2.58.6':
     resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
     engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm64@3.6.2':
+    resolution: {integrity: sha512-KMHW+CIT5H046I1hIYJ6vZmwlbBELZDOTt9Bgue3kqpW5CuvviMeMuuIKXM2oKHr/l4Q1Xnj07oTbVNb1opTsg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux, freebsd, android]
 
@@ -1702,9 +1713,21 @@ packages:
     cpu: [arm]
     os: [linux, freebsd, android]
 
+  '@sentry/cli-linux-arm@3.6.2':
+    resolution: {integrity: sha512-b2M+1ujgf7jHig9r88T2l2HEkg0XR/1Tmo1LCiPg4dsPKtTMC2Rb/f0Mto83//zkVijAA2WDBhznOz9a9Ouo7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
   '@sentry/cli-linux-i686@2.58.6':
     resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
     engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@3.6.2':
+    resolution: {integrity: sha512-tsLTOfJBoUkHfcCjUKxb/w1/WGLU00WJUO5zJztgLHKlebrjGAEiKM+8EPexb2hiW4F/P6UXL+4xXPKANk5JXQ==}
+    engines: {node: '>=18'}
     cpu: [x86, ia32]
     os: [linux, freebsd, android]
 
@@ -1714,9 +1737,21 @@ packages:
     cpu: [x64]
     os: [linux, freebsd, android]
 
+  '@sentry/cli-linux-x64@3.6.2':
+    resolution: {integrity: sha512-CHwfSJYkPe4w96EovIY/iWfxHnf5gvRYh0BGHCPcQ9knhrgWUJqbHqi3lNfEDZmzCxJ76RqPrnLMW6syoSqXow==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
   '@sentry/cli-win32-arm64@2.58.6':
     resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
     engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-arm64@3.6.2':
+    resolution: {integrity: sha512-lTqOPbLexkKnXmuIK8qszv+trpX8fQiZAJoeClVA1+hOerVyrLP9eU2tUqTm/8YW8G/M+mu3ZxAtDvS3OpHvZw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -1726,15 +1761,32 @@ packages:
     cpu: [x86, ia32]
     os: [win32]
 
+  '@sentry/cli-win32-i686@3.6.2':
+    resolution: {integrity: sha512-niUPoxN8p7jWrkvC0ekgpcIYEJNb5YxmuXRjUnOJrArwQs+4OPzRM+3e6JIYRXe7RDoUP63j1voYakEncuxioQ==}
+    engines: {node: '>=18'}
+    cpu: [x86, ia32]
+    os: [win32]
+
   '@sentry/cli-win32-x64@2.58.6':
     resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
+  '@sentry/cli-win32-x64@3.6.2':
+    resolution: {integrity: sha512-Xg6ieuJr/1Ewtdpm9Kudb029lJxnfs3Ae/fLZNAOnvWOie/V4V/X+tgZ+lETC3lU+7yz7Gb0f25gKnU6sPBKVg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@sentry/cli@2.58.6':
     resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
     engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/cli@3.6.2':
+    resolution: {integrity: sha512-/OcDsuz005C1tuauNhTd8/XNBHCfHiy46Wru4hAKBaziywgSA52lMSEznh6mWmHjPe/FoaDLpYt3Zd9qk3G0RA==}
+    engines: {node: '>= 18'}
     hasBin: true
 
   '@sentry/conventions@0.16.0':
@@ -5285,6 +5337,10 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
+
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
@@ -7256,25 +7312,49 @@ snapshots:
   '@sentry/cli-darwin@2.58.6':
     optional: true
 
+  '@sentry/cli-darwin@3.6.2':
+    optional: true
+
   '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@3.6.2':
     optional: true
 
   '@sentry/cli-linux-arm@2.58.6':
     optional: true
 
+  '@sentry/cli-linux-arm@3.6.2':
+    optional: true
+
   '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@3.6.2':
     optional: true
 
   '@sentry/cli-linux-x64@2.58.6':
     optional: true
 
+  '@sentry/cli-linux-x64@3.6.2':
+    optional: true
+
   '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@3.6.2':
     optional: true
 
   '@sentry/cli-win32-i686@2.58.6':
     optional: true
 
+  '@sentry/cli-win32-i686@3.6.2':
+    optional: true
+
   '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@3.6.2':
     optional: true
 
   '@sentry/cli@2.58.6(supports-color@7.2.0)':
@@ -7296,6 +7376,22 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@sentry/cli@3.6.2':
+    dependencies:
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      undici: 6.28.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 3.6.2
+      '@sentry/cli-linux-arm': 3.6.2
+      '@sentry/cli-linux-arm64': 3.6.2
+      '@sentry/cli-linux-i686': 3.6.2
+      '@sentry/cli-linux-x64': 3.6.2
+      '@sentry/cli-win32-arm64': 3.6.2
+      '@sentry/cli-win32-i686': 3.6.2
+      '@sentry/cli-win32-x64': 3.6.2
 
   '@sentry/conventions@0.16.0': {}
 
@@ -11056,6 +11152,8 @@ snapshots:
       layerr: 3.0.0
 
   undici-types@7.18.2: {}
+
+  undici@6.28.0: {}
 
   undici@7.28.0: {}
 


### PR DESCRIPTION
## Problem

TestFlight crash feedback is unreadable today. Tester feedback bundles carry a screenshot and device metadata, not a stack, and the failures that matter most on iOS — Rust panics, Swift crashes, main-thread hangs, watchdog/jetsam kills — never reach the JavaScript exception reporter at all, so nothing else records them either.

Even the Apple `.ips` path is broken for Reflect:

- Xcode Organizer symbolicates from the **local** `.xcarchive`, which a CI runner deletes at the end of the run.
- Rust release builds default to `debug = false`, so the archive's dSYM has no line tables for any Rust frame.

## Approach

This is a smaller, non-user-facing slice of #942 — the native-backtrace half only. It adds no UI, no settings entry, no share sheet, no recovery screen, no local journal, and no startup gating; app behavior is unchanged apart from the SDK start.

## Changes

1. **Native iOS crash reporting.** `NativeDiagnostics.swift` starts Sentry Cocoa (pinned `8.58.4` — Sentry 9 requires iOS 15, above Reflect's iOS 14 target) early in Tauri's mobile setup, and `native_diagnostics.rs` gates that on the compile-time production DSN so forks and local builds never initialize it. Enabled: crashes, fully blocking app hangs, watchdog terminations, converted MetricKit diagnostics. Disabled: sessions, breadcrumbs, tracing, profiling, network/file instrumentation, screenshots, view hierarchy, raw MetricKit payloads, PII. Events without a stack are dropped; exception text is redacted, source paths, context lines, frame variables and thread names are stripped, and loaded-image paths are reduced to basenames while keeping the UUID/address data symbolication needs.

2. **Symbols that survive the build.** `release-ios.mjs` builds Rust with `CARGO_PROFILE_RELEASE_DEBUG=line-tables-only`, requires the current archive's main dSYM, verifies its Mach-O UUID against the archived executable, and uploads that archive's dSYMs with `sentry-cli --no-sources`. Partial or foreign Sentry configuration fails before the long build rather than after it, and a failed symbol upload blocks publication.

3. **Archive retention.** The TestFlight workflow packages the exact `.xcarchive` and keeps it, plus the build-numbered IPA, for 90 days — the fallback for an Apple `.ips` that arrives weeks later. Packaging runs on `always()`, so the evidence survives a failed run.

4. **Docs.** `docs/privacy.md` gets the native allow-list; `docs/ios-testflight.md` documents symbol retention and the "TestFlight feedback has no stack" / "`.ips` is unsymbolicated" cases.

## Tests

- Release-helper tests cover the Rust debug setting (including that an explicit override wins), the `sentry-cli` args, production DSN validation, partial credentials, and `dwarfdump --uuid` parsing.
- Rust unit tests cover production-DSN validation.

## Verification

- `pnpm check` — passed (one pre-existing unrelated warning)
- `pnpm test --run apps/desktop/scripts/release-ios.test.mjs` — 20 passed
- `cargo test -p reflect-open native_diagnostics --lib` — passed
- `cargo fmt --all -- --check`, `cargo clippy -p reflect-open --lib --all-targets -- -D warnings` — passed
- `cargo check -p reflect-open --lib --target aarch64-apple-ios` — passed
- `swiftc -typecheck -target arm64-apple-ios14.0` against Sentry Cocoa 8.58.4 — passed
- `parseDwarfdumpUuids` run against a real local `.xcarchive`: executable and dSYM both resolve to `BE28A389-…`, and the archive/dSYM paths the helper asserts all exist
- Xcode resolved Sentry Cocoa `8.58.4` (`Package.resolved` committed)

## Risk / Rollout

- No schema or migration impact; nothing here can block note startup.
- `SENTRY_DSN` and `SENTRY_AUTH_TOKEN` were already required by the TestFlight workflow, but the token now also needs **debug-file upload** access to `reflect-open`. Without it, TestFlight publication fails loudly rather than shipping an unsymbolicated build.
- Sentry Cocoa is pinned at `8.58.4` while the app supports iOS 14; moving to Sentry 9 is a separate minimum-iOS decision.
- Compile/link/typecheck verified, but no intentional device crash was generated here. After the first TestFlight build, confirm one symbolicated native event in Sentry with readable Rust frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the TestFlight release gate (Sentry token needs debug-file scope) and adds third-party crash SDK at app startup, but startup is not gated on it and misconfiguration fails the build rather than shipping blind.
> 
> **Overview**
> Makes **TestFlight native failures** (Rust/Swift crashes, hangs, watchdog kills) readable by wiring **scrubbed Sentry Cocoa** into the iOS host and hardening the **release symbol pipeline**.
> 
> **Native reporting:** Adds `NativeDiagnostics.swift` (Sentry **8.58.4**) started from Rust during Tauri mobile setup, gated on the compile-time production `VITE_SENTRY_DSN`. Events are stack-only with aggressive redaction; release/dist align with the WebView SDK.
> 
> **Release / CI:** `release-ios.mjs` sets `CARGO_PROFILE_RELEASE_DEBUG=line-tables-only`, verifies executable vs dSYM UUIDs, uploads native dSYMs via `@sentry/cli` (`--no-sources`), and **fails** on partial/wrong Sentry config or failed upload. TestFlight workflow **zips and retains** the `.xcarchive` plus build-numbered IPA artifacts for **90 days**.
> 
> **Docs:** `privacy.md` and `ios-testflight.md` cover native diagnostics, symbol retention, and troubleshooting unsymbolicated `.ips` reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 094272477a1dd98fe57218017bc813585e885b68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native iOS crash diagnostics, including watchdog terminations and MetricKit reports.
  - Added automatic symbol validation and Sentry dSYM uploads for iOS releases.
  - Build artifacts now include resolved build numbers, with archives retained for later symbolication.
  - Added safeguards to verify production diagnostics configuration before reporting native crashes.

- **Documentation**
  - Updated TestFlight setup, troubleshooting, privacy, metadata, and diagnostic data documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->