### PR TITLE
test: wait for Base UI's focus trap to settle in the dialog Tab test

### DIFF
--- a/apps/desktop/src/components/settings/ai-providers-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-providers-section.test.tsx
@@ -355,10 +355,15 @@ describe('AiProvidersSection', () => {
     await userEvent.keyboard('{Tab}')
 
     // From the last control, Tab wraps to the first instead of escaping
-    // into the settings page behind the modal.
-    expect(document.activeElement).toBe(
-      dialog.getByLabelText('Provider', { exact: true }).element(),
-    )
+    // into the settings page behind the modal. Base UI traps by letting Tab
+    // land on a sentinel guard span for a beat, then teleporting focus to
+    // the wrap target — poll for the settled state, not the interim one
+    // (WebKit reliably exposes the interim beat).
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(
+        dialog.getByLabelText('Provider', { exact: true }).element(),
+      )
+    })
   })
 
   it('falls back to the first entry when the default id dangles', async () => {

--- a/apps/desktop/src/editor/when-editor-mounted.ts
+++ b/apps/desktop/src/editor/when-editor-mounted.ts
@@ -15,7 +15,10 @@ const MOUNT_RETRY_FRAMES = 30
  * Returns a cancel function for effect cleanup; canceling after `run` has
  * fired (or after the budget lapsed) is a no-op.
  */
-export function whenEditorMounted(editor: { readonly mounted: boolean }, run: () => void): () => void {
+export function whenEditorMounted(
+  editor: { readonly mounted: boolean },
+  run: () => void,
+): () => void {
   let frame: number | null = null
   let attempts = 0
   const check = (): void => {


### PR DESCRIPTION
`test-webkit` shards on unrelated PRs (seen on #1008/#1009) started failing on 2026-08-01 in `ai-providers-section.test.tsx > traps Tab inside the dialog`, reproducibly on clean master.

## Diagnosis

Since the Radix → Base UI migration (#994), the dialog's focus trap is Base UI's `FloatingFocusManager`, which traps Tab differently: the keypress first lands on a sentinel guard span (`<span data-type="inside">`), and the manager then teleports focus to the wrap target. The test focused the last control, pressed Tab, and asserted `document.activeElement` synchronously — a race against that forwarding. It happened to win the race until yesterday; WebKit now reliably exposes the interim beat (fails locally and on CI, four attempts per run).

The trap itself works: focus does settle on the first control (the Provider select trigger), verified by the fixed test passing under both WebKit and Chromium.

## Change

Poll for the settled focus with `vi.waitFor` instead of asserting the transient state. The test's intent — Tab must wrap inside the modal, never escape to the page behind it — is unchanged.

Other `document.activeElement` assertions in the suite are direct focus/blur cases with no guard traversal, so they're left alone.

## Testing

- `REFLECT_TEST_BROWSER=webkit pnpm --filter @reflect/desktop test --run src/components/settings/ai-providers-section.test.tsx` — 14/14 (failed 1/14 before).
- Same file under the default Chromium project — 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change plus cosmetic formatting; no production logic affected.
> 
> **Overview**
> Fixes flaky **WebKit** failures in `ai-providers-section.test.tsx` for **“traps Tab inside the dialog”** after the Radix → Base UI dialog migration.
> 
> The test still checks that Tab from the last control wraps to the first field instead of escaping the modal. It now uses **`vi.waitFor`** on `document.activeElement` because Base UI’s focus trap briefly lands on a sentinel guard span before moving focus to the wrap target—WebKit exposes that interim state, so a synchronous assertion was racing.
> 
> `when-editor-mounted.ts` only has a **signature line-break** formatting tweak; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9fc270abdb770f02af39fdc763a1c5fd35cdef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the settings dialog focus-navigation test to account for focus settling on the Provider field after Tab navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->