### PR TITLE
feat: copy an AI chat reply to the clipboard

### DIFF
--- a/apps/desktop/src/components/chat/chat-copy-button.tsx
+++ b/apps/desktop/src/components/chat/chat-copy-button.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState, type ReactElement } from 'react'
+import { Check, Copy } from 'lucide-react'
+import { errorMessage } from '@reflect/core'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { startOperation } from '@/lib/operations'
+
+interface ChatCopyButtonProps {
+  /** The markdown put on the clipboard when the button is pressed. */
+  text: string
+}
+
+const COPY_RESET_MS = 1400
+
+/**
+ * Copies one assistant reply to the clipboard. The check mark is the whole
+ * confirmation — a toast per copy would be noise — so only a failed write
+ * raises an operation, where it would otherwise be silent.
+ */
+export function ChatCopyButton({ text }: ChatCopyButtonProps): ReactElement {
+  const [isCopied, setIsCopied] = useState(false)
+
+  // Reset the check mark whenever the reply changes underneath it.
+  const [appliedText, setAppliedText] = useState(text)
+  if (appliedText !== text) {
+    setAppliedText(text)
+    setIsCopied(false)
+  }
+
+  useEffect(() => {
+    if (!isCopied) {
+      return
+    }
+    const timeout = window.setTimeout(() => setIsCopied(false), COPY_RESET_MS)
+    return () => window.clearTimeout(timeout)
+  }, [isCopied])
+
+  const copyReply = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setIsCopied(true)
+    } catch (cause) {
+      startOperation('Copying the reply').fail(errorMessage(cause))
+    }
+  }
+
+  const Icon = isCopied ? Check : Copy
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Copy reply"
+            onClick={() => void copyReply()}
+            className="text-text-muted hover:text-text"
+          >
+            <Icon aria-hidden className="size-3.5" />
+          </Button>
+        }
+      />
+      <TooltipContent>{isCopied ? 'Copied' : 'Copy reply'}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -263,6 +263,26 @@ describe('ChatScreen', () => {
     expect(options?.messages.at(-1)).toEqual({ role: 'user', content: 'when does atlas ship?' })
   })
 
+  it('copies a settled reply as the markdown the model wrote', async () => {
+    configureModel()
+    scriptTurn([
+      { type: 'text-delta', text: 'It ships in June. [[Atlas]]' },
+      {
+        type: 'complete',
+        messages: [{ role: 'assistant', content: 'It ships in June. [[Atlas]]' }],
+      },
+    ])
+    const writeText = vi.fn(async () => {})
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+    const view = await renderChat()
+
+    await userEvent.type(view.getByLabelText('Chat message'), 'when does atlas ship?{Enter}')
+    await view.getByRole('button', { name: 'Copy reply' }).click()
+
+    // The wiki link survives the copy, so a pasted reply still links.
+    expect(writeText).toHaveBeenCalledWith('It ships in June. [[Atlas]]')
+  })
+
   it('opens ⌘-clicked tool-result and read-note links in new windows', async () => {
     configureModel()
     scriptTurn([
@@ -541,6 +561,8 @@ describe('ChatScreen', () => {
     // Visible immediately as plain text — never re-parsed per delta.
     await expect.element(view.getByText('Streaming **markdown**')).toBeInTheDocument()
     expect(view.getByTestId('markdown-preview').query()).toBeNull()
+    // Nothing to copy until the reply is whole.
+    expect(view.getByRole('button', { name: 'Copy reply' }).query()).toBeNull()
   })
 
   it('rejects a second send fired before the first one has rendered', async () => {

--- a/apps/desktop/src/components/chat/chat-turn.tsx
+++ b/apps/desktop/src/components/chat/chat-turn.tsx
@@ -2,9 +2,11 @@ import type { ReactElement } from 'react'
 import type { ChatTurn as ChatTurnModel } from '@reflect/core'
 import { Bubble, BubbleContent } from '@/components/ui/bubble'
 import { Marker, MarkerContent } from '@/components/ui/marker'
-import { Message, MessageContent, MessageGroup } from '@/components/ui/message'
+import { Message, MessageContent, MessageFooter, MessageGroup } from '@/components/ui/message'
 import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
+import { assistantReplyMarkdown } from '@/lib/chat-copy'
 import { ChatAssistantPart } from './chat-assistant-part'
+import { ChatCopyButton } from './chat-copy-button'
 import { ChatUserAttachments } from './chat-user-attachments'
 
 interface ChatTurnProps {
@@ -24,10 +26,15 @@ interface ChatTurnProps {
  *
  * Wiki navigation passes a null generation deliberately: a clicked citation
  * that doesn't resolve must never *create* a note the model hallucinated.
+ *
+ * A settled turn that produced answer text gets a hover-revealed copy button
+ * under it; a turn that only ran tools or errored has nothing to copy, so it
+ * gets none.
  */
 export function ChatTurn({ turn }: ChatTurnProps): ReactElement {
   const navigateWikiLink = useWikiLinkNavigation(null)
   const lastIndex = turn.parts.length - 1
+  const replyMarkdown = turn.status === 'done' ? assistantReplyMarkdown(turn) : null
 
   return (
     <MessageGroup className="gap-6">
@@ -61,6 +68,11 @@ export function ChatTurn({ turn }: ChatTurnProps): ReactElement {
               onWikiLinkClick={navigateWikiLink}
             />
           ))}
+          {replyMarkdown !== null ? (
+            <MessageFooter className="-mt-1 opacity-0 transition-opacity group-hover/message:opacity-100 focus-within:opacity-100">
+              <ChatCopyButton text={replyMarkdown} />
+            </MessageFooter>
+          ) : null}
         </MessageContent>
       </Message>
     </MessageGroup>

--- a/apps/desktop/src/lib/chat-copy.test.ts
+++ b/apps/desktop/src/lib/chat-copy.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import type { ChatTurn } from '@reflect/core'
+import { assistantReplyMarkdown } from './chat-copy'
+
+function turnWith(parts: ChatTurn['parts']): ChatTurn {
+  return {
+    id: 'turn-1',
+    userText: 'hi',
+    attachments: [],
+    parts,
+    responseMessages: [],
+    status: 'done',
+  }
+}
+
+describe('assistantReplyMarkdown', () => {
+  it('joins the answer text around tool activity, leaving the chrome behind', () => {
+    const turn = turnWith([
+      { kind: 'text', text: 'Looking it up.' },
+      {
+        kind: 'tool',
+        call: { tool: 'search', toolCallId: 'tool-1', query: 'atlas' },
+        result: { tool: 'search', toolCallId: 'tool-1', query: 'atlas', hits: [] },
+        error: null,
+      },
+      { kind: 'text', text: 'It ships in June. [[Atlas]]\n' },
+      { kind: 'notice', tone: 'info', text: 'Stopped.' },
+    ])
+
+    expect(assistantReplyMarkdown(turn)).toBe('Looking it up.\n\nIt ships in June. [[Atlas]]')
+  })
+
+  it('has nothing to copy when the turn produced no answer text', () => {
+    const turn = turnWith([
+      { kind: 'text', text: '   ' },
+      { kind: 'notice', tone: 'error', text: 'The provider refused the request.' },
+    ])
+
+    expect(assistantReplyMarkdown(turn)).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/chat-copy.ts
+++ b/apps/desktop/src/lib/chat-copy.ts
@@ -1,0 +1,24 @@
+import type { ChatTurn } from '@reflect/core'
+
+/**
+ * The assistant's answer for one turn as markdown, ready for the clipboard:
+ * the turn's text parts joined by blank lines, exactly as the model wrote them
+ * (`[[wiki links]]` included, so a pasted reply still links inside a note).
+ *
+ * Tool activity and notices are chrome around the answer rather than part of
+ * it, so they never reach the clipboard. Returns `null` when the turn carries
+ * no answer text — the caller renders no copy affordance at all.
+ */
+export function assistantReplyMarkdown(turn: ChatTurn): string | null {
+  const chunks: string[] = []
+  for (const part of turn.parts) {
+    if (part.kind !== 'text') {
+      continue
+    }
+    const text = part.text.trim()
+    if (text !== '') {
+      chunks.push(text)
+    }
+  }
+  return chunks.length === 0 ? null : chunks.join('\n\n')
+}


### PR DESCRIPTION
## Problem

Chat replies were read-only in practice: getting an answer into a note meant selecting the rendered text by hand, which loses the markdown (`**bold**`, list structure) and mangles `[[wiki links]]` into plain words.

## Changes

- **`lib/chat-copy.ts`** — `assistantReplyMarkdown(turn)` joins a turn's text parts with blank lines and returns `null` when there is no answer text. Tool activity and notices are chrome around the answer, so they never reach the clipboard; the copy is exactly what the model wrote, wiki links intact.
- **`components/chat/chat-copy-button.tsx`** — icon button + tooltip following the published-URL copy affordance: the check mark is the whole confirmation (1.4s), and only a failed clipboard write raises an operation, where it would otherwise be silent.
- **`components/chat/chat-turn.tsx`** — renders the button in a `MessageFooter` under the assistant message, revealed on hover or keyboard focus. Only for settled turns with answer text: nothing appears mid-stream, or on a turn that only ran tools or errored.

## Testing

- `pnpm test --run apps/desktop/src/lib/chat-copy.test.ts` — extraction across tool/notice parts, and the empty-reply case.
- `pnpm test --run apps/desktop/src/components/chat/chat-screen.test.tsx` (22 passed) — clicking Copy writes the model's markdown including `[[Atlas]]`; no copy button while streaming.
- `pnpm check` — clean (pre-existing warnings only).
- Manual pass in a temporary browser scaffold (reverted before commit): hover reveals the button, tooltip reads "Copy reply", the clipboard receives the exact markdown, the icon flips to a check and back, and focusing the button by keyboard reveals it.

## Risks

Presentational and additive; no data or IPC paths touched. Worst case is a chat reply that doesn't offer a copy button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only, additive clipboard affordance with no data, IPC, or auth changes; worst case is a missing or incorrect copy button.
> 
> **Overview**
> Adds **copy-to-clipboard** for settled AI chat replies so users get the model’s markdown (including `[[wiki links]]`) instead of manually selecting rendered text.
> 
> **`assistantReplyMarkdown`** joins a turn’s text parts with blank lines and omits tool/notices; returns `null` when there’s no answer text. **`ChatCopyButton`** writes that string via the clipboard API, shows a brief check icon (no success toast), and surfaces failures through `startOperation`. **`ChatTurn`** shows the control in a hover/focus-revealed `MessageFooter` only when `status === 'done'` and markdown exists—hidden while streaming or on tool-only/error turns.
> 
> Tests cover extraction logic and screen behavior (copy includes `[[Atlas]]`; no button during streaming).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf9938fd4936644be305e54a9c04ea0b3e201655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->