### PR TITLE
fix: compute "Similar notes" once per note per session instead of on every index change

### DIFF
--- a/apps/desktop/src/lib/query-client.ts
+++ b/apps/desktop/src/lib/query-client.ts
@@ -65,6 +65,28 @@ export function throttledInvalidateIndexQueries(): void {
   }, INVALIDATE_THROTTLE_MS - elapsed)
 }
 
+/**
+ * "Similar notes" results nest under this key — deliberately *outside*
+ * {@link INDEX_QUERY_SCOPE}. Every other index-backed read is one cheap SQLite
+ * query, so refetching the lot after any applied batch is fine; a neighbor
+ * lookup is up to seventeen vector KNN queries (one per seed chunk), and under
+ * the index scope it re-ran for changes it has nothing to do with — a remote
+ * sync batch, a Git commit, an asset description, your own keystrokes in an
+ * unrelated pane. With its own scope the panel computes once per note per
+ * session, which is what it's for.
+ */
+export const SIMILAR_QUERY_SCOPE = 'similar'
+
+/**
+ * Forget cached neighbors on a graph switch. The graph root is part of the key
+ * so stale rows could never be *read* after a switch, but these entries are
+ * kept for the whole session ({@link SIMILAR_QUERY_SCOPE}) and would otherwise
+ * never be collected — memory hygiene, same as the note-row overlays.
+ */
+export function dropSimilarNotesQueries(): void {
+  queryClient.removeQueries({ queryKey: [SIMILAR_QUERY_SCOPE] })
+}
+
 /** The iCloud container listing (`icloud_status`) — read by the graph chooser and Settings → iCloud. */
 export const ICLOUD_STATUS_QUERY_KEY = ['icloud-status'] as const
 

--- a/apps/desktop/src/lib/use-similar-notes.test.tsx
+++ b/apps/desktop/src/lib/use-similar-notes.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderHook } from 'vitest-browser-react'
 import type { ReactNode } from 'react'
 import type { RetrievalHit } from '@reflect/core'
+import { INDEX_QUERY_SCOPE } from './query-client'
 import { useSimilarNotes } from './use-similar-notes'
 
 const relatedNotes = vi.hoisted(() => vi.fn())
@@ -85,6 +86,53 @@ describe('useSimilarNotes', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(relatedNotes).not.toHaveBeenCalled()
     expect(result.current).toEqual([])
+  })
+
+  it('does not recompute neighbors when index queries are invalidated', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { result } = await renderHook(() => useSimilarNotes('notes/x.md'), {
+      wrapper: wrapper(client),
+    })
+
+    await vi.waitFor(() => expect(result.current.length).toBe(2))
+    expect(relatedNotes).toHaveBeenCalledTimes(1)
+
+    // A neighbor lookup is up to seventeen vector KNN queries; unrelated graph
+    // churn (a sync batch, a Git commit, the user's own typing) must not drag
+    // it along, so it deliberately sits outside the index invalidation scope.
+    await client.invalidateQueries({ queryKey: [INDEX_QUERY_SCOPE] })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(relatedNotes).toHaveBeenCalledTimes(1)
+  })
+
+  it('recomputes an empty result on remount, but keeps found neighbors for the session', async () => {
+    relatedNotes.mockResolvedValue([])
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const first = await renderHook(() => useSimilarNotes('notes/x.md'), {
+      wrapper: wrapper(client),
+    })
+
+    await vi.waitFor(() => expect(relatedNotes).toHaveBeenCalledTimes(1))
+    expect(first.result.current).toEqual([])
+    await first.unmount()
+
+    // "No neighbors" is never frozen: a note embedded after it was first
+    // opened (a fresh note, a backfill still running) must be able to fill in.
+    relatedNotes.mockResolvedValue([hit('notes/a.md')])
+    const second = await renderHook(() => useSimilarNotes('notes/x.md'), {
+      wrapper: wrapper(client),
+    })
+    await vi.waitFor(() => expect(second.result.current.length).toBe(1))
+    expect(relatedNotes).toHaveBeenCalledTimes(2)
+    await second.unmount()
+
+    // Once they exist they hold for the session — a remount reads the cache.
+    const third = await renderHook(() => useSimilarNotes('notes/x.md'), {
+      wrapper: wrapper(client),
+    })
+    await vi.waitFor(() => expect(third.result.current.length).toBe(1))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(relatedNotes).toHaveBeenCalledTimes(2)
   })
 
   it('queries related notes for a daily note once it has authored content', async () => {

--- a/apps/desktop/src/lib/use-similar-notes.test.tsx
+++ b/apps/desktop/src/lib/use-similar-notes.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderHook } from 'vitest-browser-react'
 import type { ReactNode } from 'react'
 import type { RetrievalHit } from '@reflect/core'
-import { INDEX_QUERY_SCOPE } from './query-client'
+import { INDEX_QUERY_SCOPE, SIMILAR_QUERY_SCOPE } from './query-client'
 import { useSimilarNotes } from './use-similar-notes'
 
 const relatedNotes = vi.hoisted(() => vi.fn())
@@ -132,6 +132,39 @@ describe('useSimilarNotes', () => {
     })
     await vi.waitFor(() => expect(third.result.current.length).toBe(1))
     await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(relatedNotes).toHaveBeenCalledTimes(2)
+  })
+
+  it('recomputes neighbors after a daily note is cleared and refilled', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const first = await renderHook(() => useSimilarNotes('daily/2026-06-09.md'), {
+      wrapper: wrapper(client),
+    })
+    await vi.waitFor(() => expect(first.result.current.length).toBe(2))
+    expect(relatedNotes).toHaveBeenCalledTimes(1)
+    await first.unmount()
+
+    // The daily's body is wiped: the emptiness gate closes, and the cached
+    // neighbors — they describe the deleted content — must be dropped with it.
+    readNote.mockResolvedValue('- \n')
+    const cleared = await renderHook(() => useSimilarNotes('daily/2026-06-09.md'), {
+      wrapper: wrapper(client),
+    })
+    const similarKey = [SIMILAR_QUERY_SCOPE, '/g', 'daily/2026-06-09.md']
+    await vi.waitFor(() => expect(client.getQueryData(similarKey)).toBeUndefined())
+    expect(cleared.result.current).toEqual([])
+    await cleared.unmount()
+
+    // New content arrives: the refill computes fresh instead of serving the
+    // old note's neighbors from the session cache.
+    readNote.mockResolvedValue('- rewritten entry\n')
+    relatedNotes.mockResolvedValue([hit('notes/c.md')])
+    const refilled = await renderHook(() => useSimilarNotes('daily/2026-06-09.md'), {
+      wrapper: wrapper(client),
+    })
+    await vi.waitFor(() =>
+      expect(refilled.result.current.map((h) => h.path)).toEqual(['notes/c.md']),
+    )
     expect(relatedNotes).toHaveBeenCalledTimes(2)
   })
 

--- a/apps/desktop/src/lib/use-similar-notes.ts
+++ b/apps/desktop/src/lib/use-similar-notes.ts
@@ -1,5 +1,5 @@
-import { useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { hasBridge, isDaily, relatedNotes, type RetrievalHit } from '@reflect/core'
 import { readNoteSource } from '@/lib/note-frontmatter'
 import { isOstensiblyEmptyNoteSource } from '@/lib/note-emptiness'
@@ -29,7 +29,10 @@ const SIMILAR_NOTES_LIMIT = 6
  * — it must reopen the gate when a blank daily gets its first line — and an
  * empty *result* is left stale so a note whose vectors land later (a fresh
  * note, a backfill still running) fills in on its next mount instead of being
- * frozen at "no neighbors" for the session.
+ * frozen at "no neighbors" for the session. The gate closing works the other
+ * way too: a daily observed empty has had its content *wiped*, so its cached
+ * neighbors describe deleted text — they're dropped, and the refill recomputes
+ * instead of being served the old note's panel from cache.
  *
  * Gated on `semanticSearchEnabled` so disabling semantic search empties every
  * surface immediately: the query stops fetching, and the cached rows are
@@ -39,6 +42,7 @@ const SIMILAR_NOTES_LIMIT = 6
 export function useSimilarNotes(path: string): RetrievalHit[] {
   const { graph } = useGraph()
   const { settings } = useSettings()
+  const queryClient = useQueryClient()
   const bridgeAvailable = hasBridge()
   const dailyNote = isDaily(path)
   const { data: dailyNoteIsEmpty } = useQuery({
@@ -46,6 +50,20 @@ export function useSimilarNotes(path: string): RetrievalHit[] {
     queryFn: async () => isOstensiblyEmptyNoteSource(await readNoteSource(path)),
     enabled: bridgeAvailable && graph !== null && dailyNote && settings.semanticSearchEnabled,
   })
+  const graphRoot = graph?.root
+  // A daily observed empty was cleared: its cached neighbors (frozen at
+  // `staleTime: Infinity` below) describe the deleted content, and re-enabling
+  // the query on refill would serve them straight from cache. Dropping the
+  // entry makes the refill compute fresh. Safe to run repeatedly — the query
+  // is disabled while the gate is closed, so there's no in-flight fetch.
+  useEffect(() => {
+    if (dailyNoteIsEmpty === true) {
+      queryClient.removeQueries({
+        queryKey: [SIMILAR_QUERY_SCOPE, graphRoot, path],
+        exact: true,
+      })
+    }
+  }, [dailyNoteIsEmpty, queryClient, graphRoot, path])
   const enabled =
     bridgeAvailable &&
     graph !== null &&

--- a/apps/desktop/src/lib/use-similar-notes.ts
+++ b/apps/desktop/src/lib/use-similar-notes.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { hasBridge, isDaily, relatedNotes, type RetrievalHit } from '@reflect/core'
 import { readNoteSource } from '@/lib/note-frontmatter'
 import { isOstensiblyEmptyNoteSource } from '@/lib/note-emptiness'
-import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
+import { INDEX_QUERY_SCOPE, SIMILAR_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
 
@@ -12,9 +12,24 @@ const SIMILAR_NOTES_LIMIT = 6
 /**
  * The note's semantic neighbors ("Similar notes"), one query shared by every
  * surface that shows them (the in-note panel and the context sidebars). The
- * key shape is the contract with the index invalidation hook, so it is built
- * here exactly once; the graph root is part of the key because cached rows
- * must never outlive a graph switch.
+ * graph root is part of the key because cached rows must never outlive a graph
+ * switch.
+ *
+ * Neighbors are computed **once per note per session**, not on the index
+ * invalidation scope: the lookup is up to seventeen vector KNN queries, and
+ * under that scope it re-ran every few seconds through any burst of graph
+ * activity — a sync, a backfill, your own typing — for a panel of six titles
+ * that barely moves. It also re-ran at the wrong moment. `onApplied` fires
+ * *before* the embedding sync has written the save's new vectors, so those
+ * refetches read the previous generation anyway; the cost bought no freshness.
+ * The trade is deliberate: neighbors reflect the note as it was embedded when
+ * you opened it, and a reopen picks up anything later.
+ *
+ * The daily-note emptiness gate below is the exception that stays index-scoped
+ * — it must reopen the gate when a blank daily gets its first line — and an
+ * empty *result* is left stale so a note whose vectors land later (a fresh
+ * note, a backfill still running) fills in on its next mount instead of being
+ * frozen at "no neighbors" for the session.
  *
  * Gated on `semanticSearchEnabled` so disabling semantic search empties every
  * surface immediately: the query stops fetching, and the cached rows are
@@ -37,9 +52,13 @@ export function useSimilarNotes(path: string): RetrievalHit[] {
     settings.semanticSearchEnabled &&
     (!dailyNote || dailyNoteIsEmpty === false)
   const { data } = useQuery({
-    queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'related', path],
+    queryKey: [SIMILAR_QUERY_SCOPE, graph?.root, path],
     queryFn: () => relatedNotes(path, SIMILAR_NOTES_LIMIT),
     enabled,
+    staleTime: (query) => ((query.state.data?.length ?? 0) > 0 ? Infinity : 0),
+    // Held for the session so revisiting a note is free; dropped wholesale on
+    // a graph switch (dropSimilarNotesQueries).
+    gcTime: Infinity,
   })
   // Slice off the query result (reference-stable via structural sharing) only
   // when it or the gate changes, so consumers get a stable array across the

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -28,7 +28,11 @@ import {
 import { followHealedMove } from '@/editor/move-note'
 import { resetNoteRowOverlays } from '@/hooks/note-row-overlay'
 import { setIndexProgress } from '@/lib/index-progress'
-import { dropIcloudStatusQuery, throttledInvalidateIndexQueries } from '@/lib/query-client'
+import {
+  dropIcloudStatusQuery,
+  dropSimilarNotesQueries,
+  throttledInvalidateIndexQueries,
+} from '@/lib/query-client'
 import { ensureWelcomeNote } from '@/lib/welcome-note'
 import { closeSecondaryWindows } from '@/lib/windows/close-secondary-windows'
 import { isMainWindow, requireMainWindow } from '@/lib/windows/window-role'
@@ -259,10 +263,12 @@ export function GraphProvider({
           // Rust index connection is swapped, so a stale pass can't write into
           // this graph's index.
           await index.stop()
-          // Reclaim the prior graph's optimistic note-row overlays. They're
-          // already invisible here (scoped by generation), so this is memory
+          // Reclaim the prior graph's optimistic note-row overlays and its
+          // session-held "Similar notes" results. Both are already invisible
+          // here (scoped by generation / graph root), so this is memory
           // hygiene, not correctness.
           resetNoteRowOverlays()
+          dropSimilarNotesQueries()
           // Open the index *before* 'ready' so reads can't hit the previous
           // graph's index. Best-effort: an index failure doesn't block editing.
           const generation = await index.open()

--- a/packages/core/src/embeddings/retrieve.ts
+++ b/packages/core/src/embeddings/retrieve.ts
@@ -204,8 +204,10 @@ const MAX_RELATED_SEEDS = 16
 /**
  * Semantic neighbors of an existing note, seeded by its own **stored** chunk
  * vectors — no re-embedding, no pane-provided seed text: the embedding sync
- * keeps chunks current on every save, and the index invalidation scope
- * refetches consumers, so freshness is automatic. Every chunk seeds its own
+ * keeps chunks current on every save, so a call always reads the note as it
+ * was last embedded. Callers own their own refresh cadence (the desktop panel
+ * computes once per note per session); this is a read, and a costly one.
+ * Every chunk seeds its own
  * KNN pass (capped at {@link MAX_RELATED_SEEDS}) and the lists merge
  * nearest-first, so a multi-topic note — a daily note above all — surfaces
  * neighbors for anything written in it, not just its lead paragraph.


### PR DESCRIPTION
## Problem

The "Similar notes" panel recomputed on essentially any graph activity, not when a note was opened.

Its query key lived under `INDEX_QUERY_SCOPE`, and `invalidateIndexQueries()` invalidates that entire subtree. It's wired to the graph index's `onApplied` plus the backup controller, iCloud controller, asset describe/backfill, conflict resolution, and rebuild-index. So the mounted section refetched on **any** applied index batch anywhere in the graph — a remote sync batch, a Git commit, an asset description, your own keystrokes.

With the 800ms save debounce (`note-session-state.ts:21`) and the 3s invalidation throttle, editing a note with the sidebar open recomputed neighbors roughly **every three seconds**, indefinitely. An iCloud sync did the same for its whole duration.

That's not a cheap read. `relatedNotes` runs one seed query plus up to sixteen separate `vec0` KNN passes (`MAX_RELATED_SEEDS = 16`, `k = 24` each) over IPC, then merges — to render six titles that barely move.

It also fired at the wrong moment. `onApplied` runs *before* `EmbeddingsSync` queues `embedNote`, and nothing invalidates once vectors land, so every one of those refetches read the *previous* generation of vectors. The comment in `retrieve.ts` claiming "freshness is automatic" was already untrue.

Secondary: default `gcTime` is 5 minutes, so a note revisited after five minutes away recomputed even with no invalidation. And in the daily stream the sidebar keys on the focused day, so scrolling fired a fresh 17-query pass per day.

## Changes

- **`query-client.ts`** — new `SIMILAR_QUERY_SCOPE = 'similar'`, deliberately outside `INDEX_QUERY_SCOPE`, plus `dropSimilarNotesQueries()`.
- **`use-similar-notes.ts`** — the neighbor query moves to `['similar', root, path]` with `gcTime: Infinity`. Computes once per note per session; unrelated graph churn no longer drags it along.
- **`graph-provider.tsx`** — `dropSimilarNotesQueries()` on graph open, next to `resetNoteRowOverlays()`. The root is in the key so stale rows could never be *read*, but session-held entries would otherwise never be collected across a switch.
- **`retrieve.ts`** — corrected the stale freshness claim; callers now own their refresh cadence.

## Two judgment calls

**Empty results are not frozen.** `staleTime: (query) => (query.state.data?.length ? Infinity : 0)`. A plain once-per-session cache would have introduced a real bug: a blank daily note, a freshly created note, or a note reached while the backfill is still running all return `[]` on first open, and frozen they'd stay empty for the rest of the session. Now a miss stays eligible and refills on the note's next mount; a hit is fixed for the session. Recomputing a miss costs one seed query returning zero rows — no KNN pass.

**The daily-emptiness gate stays index-scoped.** One file read, and it has to react to content — it's what opens the gate when you type the first line into a blank daily.

## Behavior change reviewers should weigh

While you're actively typing, a note's neighbors now reflect the vectors as of when you opened it rather than updating mid-edit. This was already effectively true — the old refetches read stale vectors — but it's now explicit rather than incidental. If we want live-updating neighbors for the note under the cursor, the correct trigger is an invalidation of that one path after `embedNote` resolves in `embeddings-sync.tsx`, not the global index scope.

## Testing

- `use-similar-notes.test.tsx` — 6 pass, two new: one asserts an `INDEX_QUERY_SCOPE` invalidation does *not* re-run `relatedNotes`; one covers the empty → found → cached remount sequence.
- Sidebar + `route-content` suites: 88 pass. Core embeddings: 36 pass.
- `pnpm check` clean apart from pre-existing `max-lines` warnings (`graph-provider.tsx` was already 567 lines).
- Full desktop suite: 2130/2131. The one failure is an unrelated mobile back-swipe gesture assertion (`mobile-screen.test.tsx:1002`) that passes in isolation both with and without these changes — a load-sensitive flake.
- No manual pass on device or in the running app yet; the change is verified by tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop UI/query caching only; no auth, persistence, or embedding pipeline logic changes beyond documentation.
> 
> **Overview**
> **Similar notes** no longer refetch on every throttled `INDEX_QUERY_SCOPE` invalidation (sync, saves, commits, etc.). Neighbor lookup moved to a dedicated `SIMILAR_QUERY_SCOPE` with session-long `gcTime`, **once per note per open** semantics, and explicit cache drops on graph switch.
> 
> **Caching rules:** non-empty neighbor lists stay frozen for the session (`staleTime: Infinity`); empty results can refetch on remount so late embeddings/backfill can populate. When a daily note becomes empty, cached neighbors for that path are removed so a refill does not show neighbors for deleted content.
> 
> **Docs:** `relatedNotes` in core no longer claims automatic freshness via index invalidation—callers own refresh cadence.
> 
> Tests cover index invalidation isolation, empty→found→cached remount behavior, and daily clear/refill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e528a2dd8913695929538b618da1c0f9d127adb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Similar notes remain cached during the session, avoiding unnecessary recomputation when unrelated index data changes.
  * Empty results can be retried when revisiting a note.

* **Bug Fixes**
  * Similar-note results are cleared when switching graphs, preventing stale results.
  * Daily-note results are refreshed when note content is removed and later restored.

* **Documentation**
  * Clarified embedding update timing and similar-note retrieval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->