### PR TITLE
fix(ios): switch Sentry to the dynamic SPM product so TestFlight uploads pass

### DIFF
--- a/apps/desktop/src-tauri/gen/apple/project.yml
+++ b/apps/desktop/src-tauri/gen/apple/project.yml
@@ -175,8 +175,14 @@ targets:
       # + the recording Live Activity; embedded and signed with the app.
       - target: RecordingWidget
         embed: true
+      # Sentry-Dynamic, not Sentry: the default product is a prebuilt STATIC
+      # xcframework, and Xcode 26 links it correctly but then embeds a
+      # synthesized stub Sentry.framework (a 49KB symbol-less dylib whose
+      # install name is a swbuild temp path) into Frameworks/. App Store
+      # Connect rejects that stub with ITMS-90035 "Invalid Signature", killing
+      # every TestFlight upload. The dynamic product embeds the real dylib.
       - package: Sentry
-        product: Sentry
+        product: Sentry-Dynamic
       - framework: libapp.a
         embed: false
       # libgit2 (vendored into libapp.a) needs zlib and iconv at the final

--- a/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0B64041CFADD8313F72A847E /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = C8AADCC30FF3C34B87DA6BCD /* Sentry */; };
+		0B64041CFADD8313F72A847E /* Sentry-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 27BF2501FCD1BD0D24DB4908 /* Sentry-Dynamic */; };
 		14BE6EF4AB511AC099410853 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 57BCB79C0774021318852985 /* main.mm */; };
 		1C8847A7F1C163FBA53373F9 /* ExtensionClass.js in Resources */ = {isa = PBXBuildFile; fileRef = 536E4F5E21B7DCC3C7ECDC1A /* ExtensionClass.js */; };
 		266B3807E809464C8FC14146 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FDC9BB81FAB5AF8D65160799 /* Metal.framework */; };
@@ -75,6 +75,7 @@
 
 /* Begin PBXFileReference section */
 		05ABE058940EC4D96B7CA5D9 /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
+		069F78703991523CA2662E65 /* blocking.rs */ = {isa = PBXFileReference; path = blocking.rs; sourceTree = "<group>"; };
 		088536D8F462855DCFDA7B06 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		08B3817A23175E584BA6FD8D /* error.rs */ = {isa = PBXFileReference; path = error.rs; sourceTree = "<group>"; };
 		11AB73085CB07EA1B7A3533C /* reflect-open_iOS.dev.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "reflect-open_iOS.dev.entitlements"; sourceTree = "<group>"; };
@@ -153,7 +154,6 @@
 		D3691D8F671B7FA21D1E7BD7 /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
 		D7AC6BF821D47F74D41DFAFE /* RecordAudioWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordAudioWidget.swift; sourceTree = "<group>"; };
 		D7DA2E13EA6655A16DFDE015 /* secrets.rs */ = {isa = PBXFileReference; path = secrets.rs; sourceTree = "<group>"; };
-		D8F1F4787BA60FD05FD83FD1 /* spike_mobile.rs */ = {isa = PBXFileReference; path = spike_mobile.rs; sourceTree = "<group>"; };
 		DB54D6D030C08888E9D17442 /* RecordingWidget.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = RecordingWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		DBD22A8C59FD8892E5F139EC /* tests.rs */ = {isa = PBXFileReference; path = tests.rs; sourceTree = "<group>"; };
 		DD5CA5DD1A0A2C6898BF16AE /* tests.rs */ = {isa = PBXFileReference; path = tests.rs; sourceTree = "<group>"; };
@@ -174,7 +174,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0B64041CFADD8313F72A847E /* Sentry in Frameworks */,
+				0B64041CFADD8313F72A847E /* Sentry-Dynamic in Frameworks */,
 				9D7F5A94048CECBFC3D89BBA /* libapp.a in Frameworks */,
 				319EDF8F46AB05DFBA9D674F /* libz.tbd in Frameworks */,
 				E9E7B6C59015E7301EE63308 /* libiconv.tbd in Frameworks */,
@@ -292,6 +292,7 @@
 			isa = PBXGroup;
 			children = (
 				D2398DBC3478C5F96CC89402 /* background_task.rs */,
+				069F78703991523CA2662E65 /* blocking.rs */,
 				772B62ED093A33BDCD1864D8 /* calendar.rs */,
 				2490DACB2171344E8D9A8807 /* capture.rs */,
 				ADB23521181EEB9EF095D4AB /* contacts.rs */,
@@ -310,7 +311,6 @@
 				D7DA2E13EA6655A16DFDE015 /* secrets.rs */,
 				18A732A38CD75FF514E4CF86 /* settings.rs */,
 				2FA419867A84041644CC42E9 /* skill.rs */,
-				D8F1F4787BA60FD05FD83FD1 /* spike_mobile.rs */,
 				F3173A0D7E498896FAC5A43E /* watcher_mobile.rs */,
 				4EE64B671C831953394179E2 /* watcher.rs */,
 				ACE1CDF45CDBB8D7B2446E36 /* windows.rs */,
@@ -482,7 +482,7 @@
 			);
 			name = "reflect-open_iOS";
 			packageProductDependencies = (
-				C8AADCC30FF3C34B87DA6BCD /* Sentry */,
+				27BF2501FCD1BD0D24DB4908 /* Sentry-Dynamic */,
 			);
 			productName = "reflect-open_iOS";
 			productReference = BC3901740F3A40252C3750C7 /* reflect-open_iOS.app */;
@@ -701,7 +701,7 @@
 				CODE_SIGN_ENTITLEMENTS = "reflect-open_iOS/reflect-open_iOS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 789ULN5MZB;
+				DEVELOPMENT_TEAM = "789ULN5MZB";
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -716,7 +716,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios;
-				PRODUCT_NAME = Reflect;
+				PRODUCT_NAME = "Reflect";
 				REFLECT_DISPLAY_NAME = Reflect;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -864,7 +864,7 @@
 				CODE_SIGN_ENTITLEMENTS = "reflect-open_iOS/reflect-open_iOS.dev.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 789ULN5MZB;
+				DEVELOPMENT_TEAM = "789ULN5MZB";
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -878,8 +878,8 @@
 				);
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
-				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios.dev;
-				PRODUCT_NAME = Reflect;
+				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios;
+				PRODUCT_NAME = "Reflect";
 				REFLECT_DISPLAY_NAME = "Reflect Dev";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -997,10 +997,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		C8AADCC30FF3C34B87DA6BCD /* Sentry */ = {
+		27BF2501FCD1BD0D24DB4908 /* Sentry-Dynamic */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 66F54EA13384DC78CB89C8EA /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
-			productName = Sentry;
+			productName = "Sentry-Dynamic";
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
+++ b/apps/desktop/src-tauri/gen/apple/reflect-open.xcodeproj/project.pbxproj
@@ -701,7 +701,7 @@
 				CODE_SIGN_ENTITLEMENTS = "reflect-open_iOS/reflect-open_iOS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "789ULN5MZB";
+				DEVELOPMENT_TEAM = 789ULN5MZB;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -716,7 +716,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios;
-				PRODUCT_NAME = "Reflect";
+				PRODUCT_NAME = Reflect;
 				REFLECT_DISPLAY_NAME = Reflect;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -864,7 +864,7 @@
 				CODE_SIGN_ENTITLEMENTS = "reflect-open_iOS/reflect-open_iOS.dev.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "789ULN5MZB";
+				DEVELOPMENT_TEAM = 789ULN5MZB;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -878,8 +878,8 @@
 				);
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
-				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios;
-				PRODUCT_NAME = "Reflect";
+				PRODUCT_BUNDLE_IDENTIFIER = app.reflect.ios.dev;
+				PRODUCT_NAME = Reflect;
 				REFLECT_DISPLAY_NAME = "Reflect Dev";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;

--- a/apps/desktop/src-tauri/ios.project.yml
+++ b/apps/desktop/src-tauri/ios.project.yml
@@ -174,8 +174,14 @@ targets:
       # + the recording Live Activity; embedded and signed with the app.
       - target: RecordingWidget
         embed: true
+      # Sentry-Dynamic, not Sentry: the default product is a prebuilt STATIC
+      # xcframework, and Xcode 26 links it correctly but then embeds a
+      # synthesized stub Sentry.framework (a 49KB symbol-less dylib whose
+      # install name is a swbuild temp path) into Frameworks/. App Store
+      # Connect rejects that stub with ITMS-90035 "Invalid Signature", killing
+      # every TestFlight upload. The dynamic product embeds the real dylib.
       - package: Sentry
-        product: Sentry
+        product: Sentry-Dynamic
       - framework: libapp.a
         embed: false
       # libgit2 (vendored into libapp.a) needs zlib and iconv at the final

--- a/docs/ios-testflight.md
+++ b/docs/ios-testflight.md
@@ -206,6 +206,14 @@ workflow.
   `reflect-ios-xcarchive-<build>` artifact for that exact TestFlight build,
   confirm its executable UUID appears in the report, and symbolicate against the
   archive's dSYM. An IPA alone does not contain one.
+- **`Invalid Signature … Reflect.app/Frameworks/Sentry.framework/Sentry is not
+  properly signed` (ITMS-90035)**: the Sentry SPM dependency is pointing at the
+  default `Sentry` product again. That product is a prebuilt *static*
+  xcframework; Xcode 26 links it into the app binary correctly but then embeds
+  a synthesized stub `Sentry.framework` (a tiny symbol-less dylib with a
+  `swbuild` temp-path install name) that App Store Connect rejects. Keep the
+  dependency on `Sentry-Dynamic` in `ios.project.yml` and
+  `gen/apple/project.yml`, and regenerate the Xcode project with `xcodegen`.
 - **Sentry reports "missing debug information"**: check the release helper's
   `sentry-cli debug-files upload` output. Publication fails when native Sentry is
   configured but no dSYM exists or the upload is rejected; JavaScript source-map


### PR DESCRIPTION
## Problem

Every TestFlight upload since #1012 landed fails App Store Connect validation with **ITMS-90035**:

> Invalid Signature. Code failed to satisfy specified code requirement(s). The file at path "Reflect.app/Frameworks/Sentry.framework/Sentry" is not properly signed.

Both release uploads today hit it (`0.8.0-beta.4`, `0.8.0-beta.5` — [failed job](https://github.com/team-reflect/reflect-open/actions/runs/30694807531/job/91355789620)), so the desktop beta shipped but no matching TestFlight build exists. These were the first CI TestFlight builds to include Sentry Cocoa.

## Diagnosis

Inspecting the `reflect-ios-ipa-202608011000` artifact from the failed run:

- The sentry-cocoa `Sentry` SPM product is a prebuilt **static** xcframework. Its code links into the main `Reflect` binary correctly (Sentry ObjC classes are present there).
- Xcode 26.6 nonetheless embeds a synthesized stub `Sentry.framework` into `Frameworks/`: a 49KB dylib with **no exported symbols** whose `LC_ID_DYLIB` is a leftover build temp path (`/private/var/folders/.../swbuild.tmp.../arm64-apple`).
- The stub is present in the `.xcarchive` too, so the build (not the export) produces it.
- It is signed with the correct Apple Distribution cert and passes `codesign --verify --deep --strict` locally — but App Store Connect rejects it.

## Fix

Depend on **`Sentry-Dynamic`** instead: the prebuilt dynamic framework gets embedded as a real dylib. This is also Sentry's documented workaround for App Store upload failures with the static product (getsentry/sentry-cocoa#7236).

- `import Sentry` is unchanged — the framework/module inside `Sentry-Dynamic.xcframework` is still named `Sentry`.
- The release helper's checks are unaffected: the main-executable dSYM UUID gate, `sentry-cli debug-files upload`, and the IPA assertions don't assume static linking.
- Tradeoff: Sentry's own SDK frames no longer carry dSYMs in our archive (prebuilt binary); app/Rust frames symbolicate exactly as before.
- The regenerated pbxproj also picks up two file-list normalizations the checked-in project had lagged (`blocking.rs` added, `spike_mobile.rs` removed).
- Adds a troubleshooting entry to `docs/ios-testflight.md` so the product doesn't get flipped back.

## Verification

- [x] Failed IPA + xcarchive artifacts inspected (stub confirmed as root cause)
- [x] Local `pnpm release:ios build` with this change (same Xcode 26.6 as CI): the archived `Frameworks/Sentry.framework` is now the real dylib — 9.85MB, 3,836 exported symbols, install name `@rpath/Sentry.framework/Sentry` — and the `Reflect` binary dynamically links it. The 49KB swbuild stub is gone.
- [ ] App Store Connect server-side validation. Blocked locally: the export step fails with `No Accounts` (no signing account/API key on this machine), so no signed IPA to run `pnpm release:ios validate` on. The definitive check is a **TestFlight workflow run** (`workflow_dispatch`) — either on this branch before merge, or the automatic run on the next release. Note that both paths upload a real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging/signing fix for a third-party SDK with no app logic changes; main tradeoff is Sentry’s own frames may lack dSYMs, as noted in the PR.
> 
> **Overview**
> **Unblocks TestFlight** by changing the iOS Sentry Swift package product from the default static `Sentry` xcframework to **`Sentry-Dynamic`**, in both `ios.project.yml` and the generated `gen/apple/project.yml` / `project.pbxproj`. Xcode 26 was embedding a bogus stub `Sentry.framework` that App Store Connect rejects with **ITMS-90035**; the dynamic product ships a properly signed real dylib instead. Inline comments in the YAML explain why not to revert to `Sentry`.
> 
> The xcodegen refresh also syncs the Rust source file list in the Xcode project (`blocking.rs` in, `spike_mobile.rs` out).
> 
> `docs/ios-testflight.md` adds a troubleshooting entry for this signature failure and points maintainers at **`Sentry-Dynamic`** plus `xcodegen` if it regresses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0b7021f94f6d9b65a637951cc464a798ddd1bd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS builds by linking the dynamic Sentry package, helping prevent framework signature errors during TestFlight submission.

* **Documentation**
  * Added troubleshooting guidance for resolving invalid-signature errors involving `Sentry.framework`.
  * Documented the required configuration before regenerating the iOS project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
