### PR TITLE
docs: explain the benign BRItemCollectionGatherer watch faults from sync-excluded dirs

### DIFF
--- a/docs/icloud-sync.md
+++ b/docs/icloud-sync.md
@@ -82,7 +82,7 @@ delivery, and download/eviction behavior.
 With a graph open, the app process logs CloudDocs errors — a burst while the
 `NSMetadataQuery` watch gathers, then one round per graph write:
 
-```
+```text
 [ERROR] … NSError: NSFileProviderInternalErrorDomain 15 … while gathering
 [CRIT] UNREACHABLE: … BRItemCollectionGatherer - Repeatedly can't watch item …
 ```

--- a/docs/icloud-sync.md
+++ b/docs/icloud-sync.md
@@ -77,6 +77,32 @@ in CI. What *needs a real container* (and the two-device manual matrix in
 the plan doc) is the `NSMetadataQuery` watch, `NSFileVersion` conflict
 delivery, and download/eviction behavior.
 
+## Known log noise: `BRItemCollectionGatherer - Repeatedly can't watch item`
+
+With a graph open, the app process logs CloudDocs errors — a burst while the
+`NSMetadataQuery` watch gathers, then one round per graph write:
+
+```
+[ERROR] … NSError: NSFileProviderInternalErrorDomain 15 … while gathering
+[CRIT] UNREACHABLE: … BRItemCollectionGatherer - Repeatedly can't watch item …
+```
+
+This is Apple's query machinery tripping over the directories Reflect
+deliberately excludes from sync (`.reflect`, and `.git` on desktop — see
+`mark_dir_local_only` in `fs/io.rs`): they exist on disk inside the watched
+root, but carry no identity in the provider database, so the gatherer's
+per-item watch fails, retries, and gives up with the `UNREACHABLE` fault.
+Any FS event under an excluded tree re-attempts once — on desktop that means
+every note save, because the local Git history engine commits into `.git`.
+
+Verified benign (2026-08-02): touching a file inside `.git` reproduces the
+error within milliseconds, the failing watches are exactly the items sync
+must ignore, and the query demonstrably keeps delivering update rounds (and
+the conflict view keeps functioning) after the faults. Don't chase this
+signature; a real watcher failure looks different — `startQuery` returning
+false (logged as `iCloud metadata query failed to start`, surfaced via the
+`icloud:watch-failed` event) or update rounds ceasing entirely.
+
 ## Deliberately not here (yet)
 
 - **AI-assisted resolution** — the ladder already produces the


### PR DESCRIPTION
## Problem

With a graph open, the desktop app process emits scary CloudDocs log entries — a burst during the `NSMetadataQuery` gather and then one per graph write:

```
[ERROR] … NSError: NSFileProviderInternalErrorDomain 15 … while gathering
[CRIT] UNREACHABLE: … BRItemCollectionGatherer - Repeatedly can't watch item …
```

This signature looks like the iCloud watcher silently dying, and it just cost an investigation session to rule that out.

## What the investigation found

- The failing items are exactly the directories Reflect deliberately excludes from sync (`.reflect`, and `.git` on desktop — `mark_dir_local_only` in `fs/io.rs`): present on disk inside the watched root, but with no identity in the provider database, so the gatherer's per-item watch fails, retries, and gives up with the CRIT fault.
- Reproduced live: touching a file inside `.git` (no note change involved) fires the error within milliseconds. On desktop every note save re-triggers one round, because the local Git history engine commits into `.git`.
- Verified benign: the metadata query keeps delivering update rounds after the faults (it reacted to FS events all morning post-CRIT), sync and the conflict view keep functioning, and the unwatchable items are precisely the ones sync must ignore. A real watcher failure looks different (`startQuery` returning false → `icloud:watch-failed`, or rounds ceasing).

## Change

Docs only: a "Known log noise" section in `docs/icloud-sync.md` recording the signature, the cause, the verification, and what a real failure looks like instead.

## Testing

- Live reproduction + liveness verification described above (2026-08-02, macOS 26 / Darwin 25.5.0).
- No code changes; `pnpm check` not applicable to a markdown-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation with no runtime, security, or data-path changes.
> 
> **Overview**
> Adds a **Known log noise** section to `docs/icloud-sync.md` so engineers do not treat recurring CloudDocs `BRItemCollectionGatherer - Repeatedly can't watch item` / `NSFileProviderInternalErrorDomain 15` lines as a broken iCloud watcher.
> 
> The new text ties those faults to sync-excluded trees (`.reflect`, desktop `.git` via `mark_dir_local_only`), notes they can fire on every graph write when Git commits under `.git`, and records 2026-08-02 verification that the metadata query and conflict flow stay healthy. It contrasts this pattern with real failures (`startQuery` false / `icloud:watch-failed`, or update rounds stopping).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6a943f5906286821f7246436b8e08041ff07d2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for interpreting benign CloudDocs sync errors related to excluded `.reflect` and `.git` directories.
  * Documented expected query and update behavior, along with indicators of genuine watcher failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->