### PR TITLE
fix: clear the new-template name between dialog openings

### DIFF
--- a/apps/desktop/src/components/templates/template-create-dialog.test.tsx
+++ b/apps/desktop/src/components/templates/template-create-dialog.test.tsx
@@ -1,0 +1,104 @@
+import { render } from 'vitest-browser-react'
+import { page, userEvent } from 'vitest/browser'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactElement } from 'react'
+import { Button } from '@/components/ui/button'
+import type { CommandContext } from '@/lib/commands/types'
+import { NoteTemplatesProvider, useNoteTemplates } from '@/providers/note-templates-provider'
+import { TemplateCreateDialog } from './template-create-dialog'
+
+const createTemplate = vi.hoisted(() =>
+  vi.fn<(name: string, generation: number) => Promise<string>>(),
+)
+
+vi.mock('@/lib/note-templates', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/note-templates')>()),
+  createTemplate,
+}))
+
+function OpenTemplateCreate(): ReactElement {
+  const { openTemplateCreate } = useNoteTemplates()
+  return <Button onClick={openTemplateCreate}>New template</Button>
+}
+
+function renderDialog(context?: Partial<CommandContext>) {
+  const navigate = vi.fn()
+  const fullContext: CommandContext = {
+    navigate,
+    route: () => ({ kind: 'today' }),
+    notePath: () => null,
+    back: vi.fn(),
+    forward: vi.fn(),
+    clearScrollState: vi.fn(),
+    toggleTheme: vi.fn(),
+    toggleSidebar: vi.fn(),
+    newChat: vi.fn(),
+    openNoteFind: vi.fn(),
+    findNextInNote: vi.fn(),
+    findPreviousInNote: vi.fn(),
+    switchGraph: vi.fn(),
+    toggleAudioMemo: vi.fn(),
+    generation: () => 1,
+    openPalette: vi.fn(),
+    openShortcuts: vi.fn(),
+    openTemplatePicker: vi.fn(),
+    openTemplateCreate: vi.fn(),
+    enableSemanticSearch: vi.fn(),
+    ...context,
+  }
+  return render(
+    <NoteTemplatesProvider>
+      <OpenTemplateCreate />
+      <TemplateCreateDialog context={fullContext} />
+    </NoteTemplatesProvider>,
+  )
+}
+
+beforeEach(() => {
+  createTemplate.mockReset().mockResolvedValue('templates/weekly-review.md')
+})
+
+describe('TemplateCreateDialog', () => {
+  it('opens each time with an empty name, not the last one created', async () => {
+    await renderDialog()
+
+    await userEvent.click(page.getByRole('button', { name: 'New template' }))
+    await userEvent.fill(page.getByPlaceholder('Template name'), 'Weekly review')
+    await userEvent.click(page.getByRole('button', { name: 'Create' }))
+
+    await vi.waitFor(() => expect(createTemplate).toHaveBeenCalledWith('Weekly review', 1))
+
+    await userEvent.click(page.getByRole('button', { name: 'New template' }))
+
+    await expect.element(page.getByPlaceholder('Template name')).toHaveValue('')
+  })
+
+  it('opens each time with an empty name after a cancelled draft', async () => {
+    await renderDialog()
+
+    await userEvent.click(page.getByRole('button', { name: 'New template' }))
+    await userEvent.fill(page.getByPlaceholder('Template name'), 'Abandoned')
+    await userEvent.click(page.getByRole('button', { name: 'Cancel' }))
+
+    await userEvent.click(page.getByRole('button', { name: 'New template' }))
+
+    await expect.element(page.getByPlaceholder('Template name')).toHaveValue('')
+    expect(createTemplate).not.toHaveBeenCalled()
+  })
+
+  it('drops the previous attempt error when reopened', async () => {
+    createTemplate.mockRejectedValue(new Error('Disk is full'))
+    await renderDialog()
+
+    await userEvent.click(page.getByRole('button', { name: 'New template' }))
+    await userEvent.fill(page.getByPlaceholder('Template name'), 'Weekly review')
+    await userEvent.click(page.getByRole('button', { name: 'Create' }))
+
+    await expect.element(page.getByText('Disk is full')).toBeInTheDocument()
+
+    await userEvent.click(page.getByRole('button', { name: 'Cancel' }))
+    await userEvent.click(page.getByRole('button', { name: 'New template' }))
+
+    expect(page.getByText('Disk is full').query()).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/templates/template-create-dialog.test.tsx
+++ b/apps/desktop/src/components/templates/template-create-dialog.test.tsx
@@ -67,6 +67,9 @@ describe('TemplateCreateDialog', () => {
     await userEvent.click(page.getByRole('button', { name: 'Create' }))
 
     await vi.waitFor(() => expect(createTemplate).toHaveBeenCalledWith('Weekly review', 1))
+    // The creation await resolves after the assertion above, so wait for the
+    // close it triggers — reopening is only a remount once the form is gone.
+    await expect.element(page.getByPlaceholder('Template name')).not.toBeInTheDocument()
 
     await userEvent.click(page.getByRole('button', { name: 'New template' }))
 

--- a/apps/desktop/src/components/templates/template-create-dialog.tsx
+++ b/apps/desktop/src/components/templates/template-create-dialog.tsx
@@ -31,16 +31,27 @@ interface TemplateCreateForm {
   name: string
 }
 
+/**
+ * The dialog lives for the workspace's lifetime, so the form only mounts while
+ * it is open: every "New template" starts from an empty name and no stale
+ * error, rather than the last name this workspace typed.
+ */
 export function TemplateCreateDialog({ context }: TemplateCreateDialogProps): ReactElement | null {
-  const { createOpen, closeTemplateCreate } = useNoteTemplates()
-  const { register, handleSubmit, formState } = useForm<TemplateCreateForm>({
-    defaultValues: { name: '' },
-  })
-  const [submitError, setSubmitError] = useState<string | null>(null)
+  const { createOpen } = useNoteTemplates()
 
   if (!createOpen) {
     return null
   }
+
+  return <TemplateCreateDialogContent context={context} />
+}
+
+function TemplateCreateDialogContent({ context }: TemplateCreateDialogProps): ReactElement {
+  const { closeTemplateCreate } = useNoteTemplates()
+  const { register, handleSubmit, formState } = useForm<TemplateCreateForm>({
+    defaultValues: { name: '' },
+  })
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
   const submit = handleSubmit(async (values) => {
     setSubmitError(null)


### PR DESCRIPTION
The "New template" dialog is mounted for the workspace's lifetime and only rendered away while closed, so its react-hook-form state (and any submit error) outlived a close: reopening it pre-filled the name with whatever was last typed there.

Mount the form only while the dialog is open so each opening starts empty.

Fixes #1024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Template creation dialogs now open with a clean form and no errors from previous attempts.
  * Closing and reopening the dialog resets the template name and submission state.

* **Tests**
  * Added coverage for template creation, cancellation, form reset behavior, and error clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->