### PR TITLE
fix(desktop): resync today's date after system sleep

### DIFF
--- a/apps/desktop/src/components/daily-stream.test.tsx
+++ b/apps/desktop/src/components/daily-stream.test.tsx
@@ -137,6 +137,46 @@ describe('DailyStream', () => {
     await view.unmount()
   })
 
+  it('anchors a today arrival to the real day after a slept-through midnight', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 5, 27, 23, 59, 0))
+    let navigateToday: () => void = () => {
+      throw new Error('navigate not ready')
+    }
+    const view = await render(
+      <StreamProviders>
+        <DailyStream target={{ kind: 'today' }} />
+        <NavigateTodayProbe
+          onReady={(run) => {
+            navigateToday = run
+          }}
+        />
+      </StreamProviders>,
+    )
+
+    // Simulated sleep: the wall clock jumps but no timer fires (DOM timers
+    // run on a monotonic clock that pauses while the machine sleeps). The
+    // midnight timeout is now hours away in timer time; the store's
+    // heartbeat is what notices the new date.
+    vi.setSystemTime(new Date(2026, 5, 28, 9, 0, 0))
+    await act(async () => {
+      vi.advanceTimersByTime(60_000)
+    })
+    await act(async () => {
+      navigateToday()
+    })
+
+    const dayWindow = createDayWindow('2026-06-27')
+    const expected = indexOfDate(dayWindow, '2026-06-28') * ESTIMATED_DAY_HEIGHT
+    await vi.waitFor(() =>
+      expect(page.getByTestId('daily-stream').element().scrollTop).toBeGreaterThan(
+        expected - ESTIMATED_DAY_HEIGHT,
+      ),
+    )
+    await expect.element(page.getByText(formatDayLabel('2026-06-28', 'mdy'))).toBeVisible()
+    await view.unmount()
+  })
+
   it('mounts straight at a restored entry’s saved offset, not the anchor', async () => {
     const view = await render(
       <StreamProviders>

--- a/apps/desktop/src/lib/today-store.ts
+++ b/apps/desktop/src/lib/today-store.ts
@@ -51,8 +51,10 @@ function start(): void {
   syncToday()
   scheduleMidnightRollover()
   heartbeat = setInterval(syncToday, 60_000)
-  document.addEventListener('visibilitychange', syncToday)
-  window.addEventListener('focus', syncToday)
+
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', syncToday)
+  }
 }
 
 function stop(): void {
@@ -64,8 +66,10 @@ function stop(): void {
     clearInterval(heartbeat)
     heartbeat = null
   }
-  document.removeEventListener('visibilitychange', syncToday)
-  window.removeEventListener('focus', syncToday)
+
+  if (typeof document !== 'undefined') {
+    document.removeEventListener('visibilitychange', syncToday)
+  }
 }
 
 /** `useSyncExternalStore` subscribe; timers run only while subscribed. */

--- a/apps/desktop/src/lib/today-store.ts
+++ b/apps/desktop/src/lib/today-store.ts
@@ -1,0 +1,88 @@
+import { addDays, startOfDay } from 'date-fns'
+import { todayIso } from './dates'
+
+/**
+ * Today's local calendar date as a module-level external store, shared by
+ * every `useToday()` subscriber: one timer set per window, not one per
+ * mounted hook.
+ *
+ * A lone midnight timeout is not enough: DOM timers fire on a monotonic
+ * clock that pauses while the machine sleeps, so a timeout armed for local
+ * midnight fires hours late after a sleep/wake cycle. The store therefore
+ * re-reads the wall clock from every cheap signal it can get: the midnight
+ * timer (the precise awake-path rollover), visibility/focus changes (the
+ * wake-up path), and a low-frequency heartbeat (a wake with no such event).
+ */
+
+let today = todayIso()
+const listeners = new Set<() => void>()
+let midnightTimer: ReturnType<typeof setTimeout> | null = null
+let heartbeat: ReturnType<typeof setInterval> | null = null
+
+/** Re-read the wall clock; notify subscribers only when the date changed. */
+function syncToday(): void {
+  const next = todayIso()
+  if (next === today) {
+    return
+  }
+  today = next
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+function scheduleMidnightRollover(): void {
+  const now = new Date()
+  const midnight = startOfDay(addDays(now, 1))
+  // The pad absorbs timer drift around the boundary; the heartbeat and the
+  // wake listeners cover this timer being delayed across system sleep.
+  midnightTimer = setTimeout(
+    () => {
+      syncToday()
+      scheduleMidnightRollover()
+    },
+    midnight.getTime() - now.getTime() + 250,
+  )
+}
+
+function start(): void {
+  // The store may have idled across a date boundary while nothing was
+  // subscribed; refresh before the first subscriber reads it.
+  syncToday()
+  scheduleMidnightRollover()
+  heartbeat = setInterval(syncToday, 60_000)
+  document.addEventListener('visibilitychange', syncToday)
+  window.addEventListener('focus', syncToday)
+}
+
+function stop(): void {
+  if (midnightTimer !== null) {
+    clearTimeout(midnightTimer)
+    midnightTimer = null
+  }
+  if (heartbeat !== null) {
+    clearInterval(heartbeat)
+    heartbeat = null
+  }
+  document.removeEventListener('visibilitychange', syncToday)
+  window.removeEventListener('focus', syncToday)
+}
+
+/** `useSyncExternalStore` subscribe; timers run only while subscribed. */
+export function subscribeToday(listener: () => void): () => void {
+  const first = listeners.size === 0
+  listeners.add(listener)
+  if (first) {
+    start()
+  }
+  return () => {
+    listeners.delete(listener)
+    if (listeners.size === 0) {
+      stop()
+    }
+  }
+}
+
+export function getTodaySnapshot(): string {
+  return today
+}

--- a/apps/desktop/src/lib/use-today.test.tsx
+++ b/apps/desktop/src/lib/use-today.test.tsx
@@ -10,10 +10,13 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
+// The backing today store is a module singleton whose timers run only while
+// subscribed, so every test unmounts its hooks: a leaked subscription would
+// keep the store started and later tests would read its stale date.
 describe('useToday', () => {
   it('rolls over when local midnight passes, then keeps rolling', async () => {
     vi.setSystemTime(new Date(2026, 5, 9, 23, 59, 0)) // June 9, 23:59 local
-    const { result } = await renderHook(() => useToday())
+    const { result, unmount } = await renderHook(() => useToday())
     expect(result.current).toBe('2026-06-09')
 
     act(() => {
@@ -25,12 +28,63 @@ describe('useToday', () => {
       vi.advanceTimersByTime(24 * 60 * 60 * 1000) // the timer re-armed
     })
     expect(result.current).toBe('2026-06-11')
+    await unmount()
   })
 
-  it('cleans its timer up on unmount', async () => {
+  it('cleans its timers up on unmount', async () => {
     vi.setSystemTime(new Date(2026, 5, 9, 12, 0, 0))
     const { unmount } = await renderHook(() => useToday())
     await unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('resyncs on visibilitychange after sleeping across midnight', async () => {
+    vi.setSystemTime(new Date(2026, 5, 9, 23, 59, 0))
+    const { result, unmount } = await renderHook(() => useToday())
+    expect(result.current).toBe('2026-06-09')
+
+    // Simulated sleep: the wall clock jumps but no timer fires (DOM timers
+    // run on a monotonic clock that pauses while the machine sleeps).
+    vi.setSystemTime(new Date(2026, 5, 10, 9, 0, 0))
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(result.current).toBe('2026-06-10')
+    await unmount()
+  })
+
+  it('resyncs on window focus after sleeping across midnight', async () => {
+    vi.setSystemTime(new Date(2026, 5, 9, 23, 59, 0))
+    const { result, unmount } = await renderHook(() => useToday())
+
+    vi.setSystemTime(new Date(2026, 5, 10, 9, 0, 0))
+    act(() => {
+      window.dispatchEvent(new Event('focus'))
+    })
+    expect(result.current).toBe('2026-06-10')
+    await unmount()
+  })
+
+  it('the heartbeat catches a slept-through midnight with no wake signal', async () => {
+    vi.setSystemTime(new Date(2026, 5, 9, 23, 59, 0))
+    const { result, unmount } = await renderHook(() => useToday())
+
+    vi.setSystemTime(new Date(2026, 5, 10, 9, 0, 0))
+    act(() => {
+      vi.advanceTimersByTime(60_000) // one heartbeat tick, no wake event at all
+    })
+    expect(result.current).toBe('2026-06-10')
+    await unmount()
+  })
+
+  it('mounted hooks share one timer set', async () => {
+    vi.setSystemTime(new Date(2026, 5, 9, 12, 0, 0))
+    const first = await renderHook(() => useToday())
+    const second = await renderHook(() => useToday())
+    expect(vi.getTimerCount()).toBe(2) // one midnight timeout + one heartbeat
+    await first.unmount()
+    expect(vi.getTimerCount()).toBe(2) // still one subscriber left
+    await second.unmount()
     expect(vi.getTimerCount()).toBe(0)
   })
 })

--- a/apps/desktop/src/lib/use-today.test.tsx
+++ b/apps/desktop/src/lib/use-today.test.tsx
@@ -53,18 +53,6 @@ describe('useToday', () => {
     await unmount()
   })
 
-  it('resyncs on window focus after sleeping across midnight', async () => {
-    vi.setSystemTime(new Date(2026, 5, 9, 23, 59, 0))
-    const { result, unmount } = await renderHook(() => useToday())
-
-    vi.setSystemTime(new Date(2026, 5, 10, 9, 0, 0))
-    act(() => {
-      window.dispatchEvent(new Event('focus'))
-    })
-    expect(result.current).toBe('2026-06-10')
-    await unmount()
-  })
-
   it('the heartbeat catches a slept-through midnight with no wake signal', async () => {
     vi.setSystemTime(new Date(2026, 5, 9, 23, 59, 0))
     const { result, unmount } = await renderHook(() => useToday())

--- a/apps/desktop/src/lib/use-today.ts
+++ b/apps/desktop/src/lib/use-today.ts
@@ -5,5 +5,5 @@ import { getTodaySnapshot, subscribeToday } from './today-store'
  * Today's ISO date as **live** state: re-renders when the local date changes.
  */
 export function useToday(): string {
-  return useSyncExternalStore(subscribeToday, getTodaySnapshot)
+  return useSyncExternalStore(subscribeToday, getTodaySnapshot, getTodaySnapshot)
 }

--- a/apps/desktop/src/lib/use-today.ts
+++ b/apps/desktop/src/lib/use-today.ts
@@ -1,31 +1,9 @@
-import { useEffect, useState } from 'react'
-import { todayIso } from './dates'
+import { useSyncExternalStore } from 'react'
+import { getTodaySnapshot, subscribeToday } from './today-store'
 
 /**
- * Today's ISO date as **live** state: re-renders when local midnight passes
- * (foundations hardening — an app left open overnight previously kept
- * yesterday's "Today" until some unrelated re-render). The timer re-arms each
- * rollover; a small pad absorbs timer drift around the boundary.
+ * Today's ISO date as **live** state: re-renders when the local date changes.
  */
 export function useToday(): string {
-  const [today, setToday] = useState(todayIso)
-  useEffect(() => {
-    let timer: ReturnType<typeof setTimeout>
-    const arm = (): void => {
-      const now = new Date()
-      const midnight = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1)
-      timer = setTimeout(
-        () => {
-          setToday(todayIso())
-          arm()
-        },
-        midnight.getTime() - now.getTime() + 250,
-      )
-    }
-    arm()
-    return () => {
-      clearTimeout(timer)
-    }
-  }, [])
-  return today
+  return useSyncExternalStore(subscribeToday, getTodaySnapshot)
 }


### PR DESCRIPTION
After the machine sleeps across midnight, `⌘D` keeps opening yesterday's daily note for hours because the midnight timeout runs on a monotonic clock that pauses during sleep; `useToday` is now backed by one shared store that also resyncs on visibility, focus, and a heartbeat.