### PR TITLE
fix(ios): check the native diagnostics entry point in the dSYM

### DIFF
--- a/apps/desktop/scripts/release-ios.mjs
+++ b/apps/desktop/scripts/release-ios.mjs
@@ -530,10 +530,13 @@ function assertCurrentArchiveSymbols() {
 
 /**
  * The native reporter once shipped compiled-out for months without anyone
- * noticing; fail the release if the Swift entry point is missing.
+ * noticing; fail the release if the Swift entry point is missing. The archive
+ * step strips the app executable's symbol table, so look for the symbol in the
+ * dSYM, which `assertCurrentArchiveSymbols` has already UUID-matched to the
+ * executable.
  */
 function assertNativeDiagnosticsLinkedIn() {
-  const symbols = capture('xcrun', ['nm', '-Uj', iosAppBinary])
+  const symbols = capture('xcrun', ['nm', '-Uj', iosDsymBinary])
   if (!symbols.includes('_reflect_start_native_diagnostics')) {
     fail('the app binary does not contain the native diagnostics entry point')
   }


### PR DESCRIPTION
`xcodebuild archive` strips the app executable's symbol table, so `assertNativeDiagnosticsLinkedIn` could never find `_reflect_start_native_diagnostics` there; check the UUID-matched dSYM instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS release validation to verify native diagnostics symbols from the correct archive.
  * Releases still fail validation when required native diagnostics are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->