### PR TITLE
ci: add `all-green` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,3 +213,19 @@ jobs:
       # set `tauri ios` builds with.
       - name: Check iOS library
         run: cargo check -p reflect-open --lib --target aarch64-apple-ios --no-default-features
+
+  # A single job for branch protection to require, instead of listing every
+  # job (and every matrix shard) as a required status check.
+  all-green:
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+
+    if: always()
+    needs: [node, chromium, webkit, rust, apple-rust]
+
+    steps:
+      - name: Verify that all jobs succeeded
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: |
+          echo 'Some jobs did not succeed: ${{ toJSON(needs) }}'
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,46 +52,19 @@ jobs:
       - name: Build
         run: pnpm build
 
-  chromium:
+  test:
     strategy:
       fail-fast: false
       matrix:
         shard: ['1/3', '2/3', '3/3']
+        groups:
+          - os: ubuntu-latest
+            browser: chromium
+          - os: macos-latest
+            browser: webkit
 
-    name: test-chromium ${{ matrix.shard }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: Install Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright Chromium
-        run: pnpm --filter @reflect/desktop exec playwright install --with-deps chromium
-
-      - name: Test
-        run: pnpm run test --shard ${{ matrix.shard }}
-
-  webkit:
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
-
-    name: test-webkit ${{ matrix.shard }}
-    runs-on: macos-latest
+    name: test ${{ matrix.groups.browser }} ${{ matrix.shard }}
+    runs-on: ${{ matrix.groups.os }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -110,13 +83,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright WebKit
-        run: pnpm --filter @reflect/desktop exec playwright install webkit
+      - name: Install Playwright
+        run: pnpm --filter @reflect/desktop exec playwright install ${{ matrix.groups.browser }}
 
       - name: Test
         run: pnpm run test --shard ${{ matrix.shard }}
-        env:
-          REFLECT_TEST_BROWSER: webkit
 
   rust:
     name: fmt · clippy · test (Rust)
@@ -218,10 +189,10 @@ jobs:
   # job (and every matrix shard) as a required status check.
   all-green:
     runs-on: ubuntu-slim
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     if: always()
-    needs: [node, chromium, webkit, rust, apple-rust]
+    needs: [node, test, rust, apple-rust]
 
     steps:
       - name: Verify that all jobs succeeded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,14 @@ jobs:
       fail-fast: false
       matrix:
         shard: ['1/3', '2/3', '3/3']
-        groups:
+        config:
           - os: ubuntu-latest
             browser: chromium
           - os: macos-latest
             browser: webkit
 
-    name: test ${{ matrix.groups.browser }} ${{ matrix.shard }}
-    runs-on: ${{ matrix.groups.os }}
+    name: test ${{ matrix.config.browser }} ${{ matrix.shard }}
+    runs-on: ${{ matrix.config.os }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -84,10 +84,12 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright
-        run: pnpm --filter @reflect/desktop exec playwright install ${{ matrix.groups.browser }}
+        run: pnpm --filter @reflect/desktop exec playwright install ${{ matrix.config.browser }}
 
       - name: Test
         run: pnpm run test --shard ${{ matrix.shard }}
+        env:
+          REFLECT_TEST_BROWSER: ${{ matrix.config.browser }}
 
   rust:
     name: fmt · clippy · test (Rust)


### PR DESCRIPTION
Add an `all-green` job that fails if any CI job fails, is cancelled, or is skipped, so branch protection can require a single status check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined automated browser testing across Chromium and WebKit on their respective operating systems.
  * Added consolidated status validation to ensure releases proceed only when all required checks complete successfully.
* **Chores**
  * Improved continuous integration reliability and consistency without introducing any user-facing product changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->