### PR TITLE
fix(ios): stop `nm` dSYM output from overflowing `execFileSync` maxBuffer

### DIFF
--- a/apps/desktop/scripts/release-ios.mjs
+++ b/apps/desktop/scripts/release-ios.mjs
@@ -56,7 +56,9 @@ function run(command, args) {
 }
 
 function capture(command, args) {
-  return execFileSync(command, args, { encoding: 'utf8' })
+  // `nm` on the dSYM emits megabytes; Node's default 1 MiB maxBuffer would
+  // kill the spawn with ENOBUFS.
+  return execFileSync(command, args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
 }
 
 /** Build the altool authentication args for an App Store Connect API key. */
@@ -536,7 +538,7 @@ function assertCurrentArchiveSymbols() {
  * executable.
  */
 function assertNativeDiagnosticsLinkedIn() {
-  const symbols = capture('xcrun', ['nm', '-Uj', iosDsymBinary])
+  const symbols = capture('xcrun', ['nm', '-gUj', iosDsymBinary])
   if (!symbols.includes('_reflect_start_native_diagnostics')) {
     fail('the app binary does not contain the native diagnostics entry point')
   }


### PR DESCRIPTION
`nm -Uj` on the dSYM emits megabytes of local symbols, so `capture` died with `spawnSync xcrun ENOBUFS`; list only defined global symbols (`-gUj`, the entry point is external) and raise `maxBuffer` to 64 MiB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved iOS release diagnostics when processing applications with large native symbol data.
  - Prevented release processing from failing unexpectedly in cases involving extensive diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->