### PR TITLE
fix: an arrival to the already-anchored day could drop its editor focus intent

### DIFF
--- a/apps/desktop/src/components/daily-stream.focus.test.tsx
+++ b/apps/desktop/src/components/daily-stream.focus.test.tsx
@@ -98,17 +98,27 @@ beforeEach(() => {
 
 type Navigate = (route: Route, options?: NavigateOptions) => void
 
-function NavigateProbe({ onReady }: { onReady: (navigate: Navigate) => void }): null {
-  const { navigate } = useRouter()
+interface RouterHandles {
+  navigate: Navigate
+  back: () => void
+}
+
+function NavigateProbe({ onReady }: { onReady: (handles: RouterHandles) => void }): null {
+  const { navigate, back } = useRouter()
   useEffect(() => {
-    onReady(navigate)
-  }, [navigate, onReady])
+    onReady({ navigate, back })
+  }, [navigate, back, onReady])
   return null
 }
 
 async function renderStream() {
-  let navigate: Navigate = () => {
-    throw new Error('navigate not ready')
+  let handles: RouterHandles = {
+    navigate: () => {
+      throw new Error('navigate not ready')
+    },
+    back: () => {
+      throw new Error('back not ready')
+    },
   }
   const view = await render(
     <div style={{ height: 800 }}>
@@ -116,7 +126,7 @@ async function renderStream() {
         <DailyStream target={{ kind: 'today' }} />
         <NavigateProbe
           onReady={(run) => {
-            navigate = run
+            handles = run
           }}
         />
       </RouterProvider>
@@ -125,7 +135,8 @@ async function renderStream() {
   const paneFor = (date: string) => page.locate(`[data-testid="pane-probe"][data-date="${date}"]`)
   return {
     view,
-    navigate: (route: Route, options?: NavigateOptions) => navigate(route, options),
+    navigate: (route: Route, options?: NavigateOptions) => handles.navigate(route, options),
+    back: () => handles.back(),
     anchored: (date: string) => expect.element(paneFor(date)).toBeInTheDocument(),
     paneFor,
   }
@@ -198,6 +209,33 @@ describe('DailyStream arrival focus', () => {
     const pane = paneFor(today)
     await expect.element(pane).toHaveAttribute('data-autofocus', 'true')
     await expect.element(pane).toHaveAttribute('data-selection', 'start')
+    await view.unmount()
+  })
+
+  it('a back-restored arrival un-renders a still-pending focus assignment', async () => {
+    const today = todayIso()
+    const { view, navigate, back, anchored, paneFor } = await renderStream()
+    await anchored(today)
+    await expect.element(paneFor(today)).toHaveAttribute('data-autofocus', 'true')
+
+    // Let virtua's anchor scroll and row measurement settle, then record the
+    // settled offset on this entry (the stream saves scroll per scroll event;
+    // fire one explicitly rather than racing the anchor scroll's async
+    // events). The second entry anchors to the same day, so from here on
+    // nothing scrolls and nothing re-renders the rows incidentally: the
+    // restored arrival's own re-render must be what clears the assignment.
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    fireEvent.scroll(page.locate('[data-testid="daily-stream"]'))
+
+    await act(() => navigate({ kind: 'daily', date: today }))
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    // The probe never consumed the arrival's focus, mirroring a day whose
+    // lazy editor has not mounted yet; a row that kept rendering `autoFocus`
+    // through the return would steal focus when that editor mounts.
+    await act(() => back())
+
+    await expect.element(paneFor(today)).toHaveAttribute('data-autofocus', 'false')
     await view.unmount()
   })
 })

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -201,17 +201,20 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
       focusPending.current = null
       pendingFocusRef.current = null
       virtualizerRef.current?.scrollTo(restored)
-      return
+    } else {
+      const target = targetDateRef.current
+      pendingFocusRef.current = null
+      focusPending.current = {
+        date: target,
+        selection: arrivalFocusEditorRef.current ? 'end' : 'start',
+      }
+      virtualizerRef.current?.scrollToIndex(indexOfDate(dayWindow, target), { align: 'start' })
     }
-    const target = targetDateRef.current
-    pendingFocusRef.current = null
-    focusPending.current = {
-      date: target,
-      selection: arrivalFocusEditorRef.current ? 'end' : 'start',
-    }
-    virtualizerRef.current?.scrollToIndex(indexOfDate(dayWindow, target), { align: 'start' })
     // One bounded pre-paint render per arrival, not a cascade: the bumped
-    // render changes none of this effect's dependencies.
+    // render changes none of this effect's dependencies. The restored branch
+    // needs it too: a row still rendering an earlier arrival's `autoFocus`
+    // would otherwise keep it past the cancellation above and steal focus
+    // when its lazy editor mounts.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     republishFocusPending((seq) => seq + 1)
   }, [arrivalSeq, entryId, dayWindow, savedScroll])

--- a/apps/desktop/src/components/daily-stream.tsx
+++ b/apps/desktop/src/components/daily-stream.tsx
@@ -89,6 +89,13 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
   const consumeFocus = useCallback(() => {
     focusPending.current = null
   }, [])
+  // Rows read `focusPending` during render, but the anchor effect below fills
+  // it *after* the arrival's render pass, so the rendered focus props are one
+  // arrival behind until the rows render again. The anchor scroll usually
+  // forces that, but an arrival that lands where the stream already sits (a
+  // re-navigation while anchored on today) scrolls nothing, so the effect
+  // bumps this state to guarantee a pre-paint re-read of the slot.
+  const [, republishFocusPending] = useState(0)
 
   // Report the day the user is editing to the context sidebar: the route stays
   // on the day navigated to, but focus moves freely between stream rows, and the
@@ -203,6 +210,10 @@ export function DailyStream({ target }: DailyStreamProps): ReactElement {
       selection: arrivalFocusEditorRef.current ? 'end' : 'start',
     }
     virtualizerRef.current?.scrollToIndex(indexOfDate(dayWindow, target), { align: 'start' })
+    // One bounded pre-paint render per arrival, not a cascade: the bumped
+    // render changes none of this effect's dependencies.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    republishFocusPending((seq) => seq + 1)
   }, [arrivalSeq, entryId, dayWindow, savedScroll])
 
   const onScrollOffset = useCallback((offset: number) => {


### PR DESCRIPTION
A same-position arrival (e.g. re-navigating to today while the stream is already anchored there) writes the pending focus slot after the render pass and triggers no scroll, so the rows never re-read it; the stream now forces one pre-paint re-render per arrival, which also stabilizes the flaky webkit run of `daily-stream.focus.test.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where pending focus information might not appear after navigating in the daily stream.
  * Focused rows now refresh reliably, even when navigation does not change the scroll position.
  * Prevented stale autofocus from being applied when returning to the daily stream through navigation history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->