### PR TITLE
refactor: gate native-shell features on `isNativeShell`

### DIFF
--- a/apps/desktop/src/components/context-sidebar/daily-events-section.test.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-events-section.test.tsx
@@ -9,7 +9,7 @@ import { DailyEventsSection } from './daily-events-section'
 
 // The calendar queries only run in the macOS desktop webview; the test
 // browser is not it either, so the platform check is mocked on.
-vi.mock('@/lib/platform', () => ({ isMacosDesktop: true }))
+vi.mock('@/lib/platform', () => ({ isMacosDesktop: true, isNativeShell: () => true }))
 
 // The add-meeting dialog reads the write generation from the graph provider.
 vi.mock('@/providers/graph-provider', () => ({

--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -42,6 +42,11 @@ vi.mock('@/providers/sync-provider', () => ({
     backUpNow: async () => {},
   }),
 }))
+// The update field gates on the native shell, which the test browser is not.
+vi.mock('@/lib/platform', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/platform')>()),
+  isNativeShell: () => true,
+}))
 // The Import section only hands the picked zip to the workspace-level V1
 // import controller, which these screen tests don't mount.
 vi.mock('@/providers/v1-import-provider', () => ({

--- a/apps/desktop/src/components/settings/agents-section-non-macos.test.tsx
+++ b/apps/desktop/src/components/settings/agents-section-non-macos.test.tsx
@@ -7,7 +7,7 @@ import { AgentsSection } from './agents-section'
 // A browser-mode module mock materializes value exports once, so the
 // off-macOS behavior needs its own file with the flag statically false
 // (see `agents-section.test.tsx` for the macOS suite).
-vi.mock('@/lib/platform', () => ({ isMacosDesktop: false }))
+vi.mock('@/lib/platform', () => ({ isMacosDesktop: false, isNativeShell: () => false }))
 
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: { root: '/graphs/Personal', name: 'Personal', generation: 7 } }),

--- a/apps/desktop/src/components/settings/agents-section.test.tsx
+++ b/apps/desktop/src/components/settings/agents-section.test.tsx
@@ -8,7 +8,7 @@ import { AgentsSection } from './agents-section'
 // A browser-mode module mock materializes value exports once, so this file
 // keeps the flag statically true; the off-macOS test lives in
 // `agents-section-non-macos.test.tsx`.
-vi.mock('@/lib/platform', () => ({ isMacosDesktop: true }))
+vi.mock('@/lib/platform', () => ({ isMacosDesktop: true, isNativeShell: () => true }))
 
 const GRAPH = { root: '/graphs/Personal', name: 'Personal', generation: 7 }
 vi.mock('@/providers/graph-provider', () => ({

--- a/apps/desktop/src/components/settings/calendar-integration-field.test.tsx
+++ b/apps/desktop/src/components/settings/calendar-integration-field.test.tsx
@@ -7,7 +7,7 @@ import { SettingsProvider } from '@/providers/settings-provider'
 import { CalendarIntegrationField } from './calendar-integration-field'
 
 // The section renders only in the macOS desktop webview; jsdom is neither.
-vi.mock('@/lib/platform', () => ({ isMacosDesktop: true }))
+vi.mock('@/lib/platform', () => ({ isMacosDesktop: true, isNativeShell: () => true }))
 
 const openUrl = vi.hoisted(() => vi.fn<(url: string) => Promise<void>>(async () => {}))
 vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl }))

--- a/apps/desktop/src/components/settings/connect-github-dialog.test.tsx
+++ b/apps/desktop/src/components/settings/connect-github-dialog.test.tsx
@@ -13,6 +13,10 @@ const sync = vi.hoisted(() => ({
 }))
 vi.mock('@/providers/sync-provider', () => ({ useSync: () => sync }))
 vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }))
+vi.mock('@/lib/platform', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/platform')>()),
+  isNativeShell: () => true,
+}))
 vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn() }))
 const httpFetch = vi.mocked(tauriFetch)
 const openedUrls = vi.mocked(openUrl)

--- a/apps/desktop/src/components/settings/github-auth-step.test.tsx
+++ b/apps/desktop/src/components/settings/github-auth-step.test.tsx
@@ -16,6 +16,10 @@ import { GithubAuthStep } from './github-auth-step'
 // code-handoff view.
 
 vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }))
+vi.mock('@/lib/platform', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/platform')>()),
+  isNativeShell: () => true,
+}))
 vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn(async () => {}) }))
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),

--- a/apps/desktop/src/components/settings/integrations-section-macos.test.tsx
+++ b/apps/desktop/src/components/settings/integrations-section-macos.test.tsx
@@ -8,7 +8,7 @@ import { IntegrationsSection } from './integrations-section'
 // A browser-mode module mock materializes value exports once, so the macOS
 // behavior needs its own file with the flag statically true
 // (see `integrations-section.test.tsx` for the rest of the suite).
-vi.mock('@/lib/platform', () => ({ isMacosDesktop: true }))
+vi.mock('@/lib/platform', () => ({ isMacosDesktop: true, isNativeShell: () => true }))
 
 vi.mock('./calendar-integration-field', () => ({
   CalendarIntegrationField: () => <div>Calendar events</div>,

--- a/apps/desktop/src/components/settings/integrations-section.test.tsx
+++ b/apps/desktop/src/components/settings/integrations-section.test.tsx
@@ -11,7 +11,7 @@ vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl }))
 // A browser-mode module mock materializes value exports once, so this file
 // keeps the flag statically false; the macOS-specific test lives in
 // `integrations-section-macos.test.tsx`.
-vi.mock('@/lib/platform', () => ({ isMacosDesktop: false }))
+vi.mock('@/lib/platform', () => ({ isMacosDesktop: false, isNativeShell: () => true }))
 
 vi.mock('./calendar-integration-field', () => ({
   CalendarIntegrationField: () => <div>Calendar events</div>,

--- a/apps/desktop/src/components/settings/sync-section-non-macos.test.tsx
+++ b/apps/desktop/src/components/settings/sync-section-non-macos.test.tsx
@@ -9,7 +9,7 @@ import { SyncSection } from './sync-section'
 // A browser-mode module mock materializes value exports once, so the
 // platform-hidden behavior needs its own file with the flag statically false
 // (see `sync-section.test.tsx` for the macOS suite).
-vi.mock('@/lib/platform', () => ({ isMacosDesktop: false }))
+vi.mock('@/lib/platform', () => ({ isMacosDesktop: false, isNativeShell: () => true }))
 
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),

--- a/apps/desktop/src/components/settings/sync-section.test.tsx
+++ b/apps/desktop/src/components/settings/sync-section.test.tsx
@@ -45,7 +45,7 @@ vi.mock('@reflect/core', async (importOriginal) => ({
 // A browser-mode module mock materializes value exports once, so this file
 // keeps the flag statically true; the platform-hidden test lives in
 // `sync-section-non-macos.test.tsx`.
-vi.mock('@/lib/platform', () => ({ isMacosDesktop: true }))
+vi.mock('@/lib/platform', () => ({ isMacosDesktop: true, isNativeShell: () => true }))
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({ graph: graph.current, openRecent: graph.openRecent }),
 }))

--- a/apps/desktop/src/desktop-root.tsx
+++ b/apps/desktop/src/desktop-root.tsx
@@ -9,6 +9,7 @@ import { WindowDragRegion } from '@/components/window-drag-region'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { useMainWindowEffect } from '@/hooks/use-main-window-effect'
 import { startDeepLinkListener } from '@/lib/deep-links/intake'
+import { isNativeShell } from '@/lib/platform'
 import { trackSubscriptions } from '@/lib/subscriptions'
 import { GraphProvider } from '@/providers/graph-provider'
 import { SidebarWidthEffect } from '@/providers/sidebar-width'
@@ -28,7 +29,7 @@ export function DesktopRoot(): ReactElement {
   // (in-note `reflect://` clicks still work — `dispatchDeepLink` and the
   // handler are per-webview state).
   useMainWindowEffect(() => {
-    if (!hasBridge()) {
+    if (!isNativeShell()) {
       return
     }
     startDeepLinkListener().catch((cause: unknown) => {

--- a/apps/desktop/src/lib/backup-controller.test.tsx
+++ b/apps/desktop/src/lib/backup-controller.test.tsx
@@ -13,6 +13,10 @@ import { createBackupController, type BackupState } from './backup-controller'
 // providerFetch routes GitHub API calls through the Tauri HTTP plugin
 // whenever a bridge is set — which it is in every test here.
 vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }))
+vi.mock('@/lib/platform', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/platform')>()),
+  isNativeShell: () => true,
+}))
 const httpFetch = vi.mocked(tauriFetch)
 
 afterEach(() => {

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -19,7 +19,7 @@ const runCopyDeepLink = vi.hoisted(() => vi.fn(async () => undefined))
 const runCopyNotePath = vi.hoisted(() => vi.fn(async () => undefined))
 const getNote = vi.hoisted(() => vi.fn<() => Promise<NoteRow | undefined>>(async () => undefined))
 const getPinnedNotes = vi.hoisted(() => vi.fn<() => Promise<PinnedNote[]>>(async () => []))
-const hasBridge = vi.hoisted(() => vi.fn(() => true))
+const isNativeShell = vi.hoisted(() => vi.fn(() => true))
 const toggleDevtools = vi.hoisted(() => vi.fn(async () => undefined))
 const openRouteInNewWindow = vi.hoisted(() => vi.fn<() => Promise<boolean>>())
 const operationFail = vi.hoisted(() => vi.fn())
@@ -34,6 +34,10 @@ vi.mock('@/lib/note-pin', () => ({ toggleNotePinned }))
 vi.mock('@/lib/note-private', () => ({ toggleNotePrivate }))
 vi.mock('@/lib/note-deep-link', () => ({ runCopyDeepLink }))
 vi.mock('@/lib/note-copy-path', () => ({ runCopyNotePath }))
+vi.mock('@/lib/platform', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/platform')>()),
+  isNativeShell,
+}))
 vi.mock('@/lib/windows/open-in-new-window', () => ({ openRouteInNewWindow }))
 vi.mock('@/lib/operations', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/operations')>()),
@@ -46,7 +50,6 @@ vi.mock('@reflect/core', async (importOriginal) => ({
   embedStatus,
   getNote,
   getPinnedNotes,
-  hasBridge,
   toggleDevtools,
 }))
 
@@ -402,7 +405,7 @@ describe('app commands', () => {
   })
 
   it('dev.toggleDevtools toggles the inspector through the native shell', async () => {
-    hasBridge.mockReturnValue(true)
+    isNativeShell.mockReturnValue(true)
     toggleDevtools.mockClear()
     const { context } = fakeContext()
     await command('dev.toggleDevtools').run(context)
@@ -410,12 +413,12 @@ describe('app commands', () => {
   })
 
   it('dev.toggleDevtools no-ops without a native shell (plain-browser dev)', async () => {
-    hasBridge.mockReturnValue(false)
+    isNativeShell.mockReturnValue(false)
     toggleDevtools.mockClear()
     const { context } = fakeContext()
     await expect(command('dev.toggleDevtools').run(context)).resolves.toBeUndefined()
     expect(toggleDevtools).not.toHaveBeenCalled()
-    hasBridge.mockReturnValue(true)
+    isNativeShell.mockReturnValue(true)
   })
 
   it('semantic.enable persists the opt-in through the context capability', async () => {

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -2,7 +2,6 @@ import {
   errorMessage,
   getNote,
   getPinnedNotes,
-  hasBridge,
   randomNotePath,
   toggleDevtools,
   untitledNotePath,
@@ -14,6 +13,7 @@ import { runGistPublish } from '@/lib/note-gist'
 import { toggleNotePinned } from '@/lib/note-pin'
 import { toggleNotePrivate } from '@/lib/note-private'
 import { startOperation } from '@/lib/operations'
+import { isNativeShell } from '@/lib/platform'
 import { rebuildIndexVisibly } from '@/lib/rebuild-index'
 import { openRouteInNewWindow } from '@/lib/windows/open-in-new-window'
 import { routeForPath, type Route } from '@/routing/route'
@@ -386,7 +386,7 @@ const APP_COMMANDS: AppCommand[] = [
     // bridge. Errors are swallowed: a debug affordance never interrupts the user.
     keybinding: 'Mod-Shift-i',
     run: async () => {
-      if (!hasBridge()) {
+      if (!isNativeShell()) {
         return
       }
       try {

--- a/apps/desktop/src/lib/github-account.test.ts
+++ b/apps/desktop/src/lib/github-account.test.ts
@@ -4,6 +4,10 @@ import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
 import { fetchSignedInUser } from './github-account'
 
 vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }))
+vi.mock('@/lib/platform', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/platform')>()),
+  isNativeShell: () => true,
+}))
 const httpFetch = vi.mocked(tauriFetch)
 
 function fakeKeychain(initial: Record<string, string> = {}): Map<string, string> {

--- a/apps/desktop/src/lib/platform.ts
+++ b/apps/desktop/src/lib/platform.ts
@@ -1,6 +1,17 @@
 import { isTauri } from '@tauri-apps/api/core'
 
 /**
+ * True in a real Tauri webview — plugins, custom URL schemes, and real OS
+ * windows are reachable. NOT satisfied by the in-browser dev bridge, which
+ * answers IPC commands (`hasBridge()`) without any of those. Gates that mean
+ * "the native shell exists" use this; gates that mean "commands can be
+ * answered" use `hasBridge()`.
+ */
+export function isNativeShell(): boolean {
+  return isTauri()
+}
+
+/**
  * True in the macOS desktop webview — the platform gate for macOS-only
  * capabilities (EventKit calendar access). Plain-browser dev and other
  * desktop platforms are excluded by the Tauri check; iPadOS — whose user

--- a/apps/desktop/src/lib/provider-fetch.test.ts
+++ b/apps/desktop/src/lib/provider-fetch.test.ts
@@ -1,24 +1,24 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { setBridge } from '@reflect/core'
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
 import { providerFetch } from './provider-fetch'
 
 vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }))
+const isNativeShell = vi.hoisted(() => vi.fn(() => false))
+vi.mock('@/lib/platform', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/platform')>()),
+  isNativeShell,
+}))
 const httpFetch = vi.mocked(tauriFetch)
 
 afterEach(() => {
-  setBridge(null)
+  isNativeShell.mockReturnValue(false)
   httpFetch.mockReset()
   vi.unstubAllGlobals()
 })
 
-function installBridge(): void {
-  setBridge({ invoke: async () => null, listen: async () => () => {} })
-}
-
 describe('providerFetch', () => {
   it('sends an explicit empty Origin so the plugin drops the header', async () => {
-    installBridge()
+    isNativeShell.mockReturnValue(true)
     httpFetch.mockResolvedValue(new Response(null, { status: 200 }))
 
     await providerFetch('https://api.anthropic.com/v1/models', {
@@ -32,7 +32,7 @@ describe('providerFetch', () => {
   })
 
   it('leaves a caller-set Origin alone', async () => {
-    installBridge()
+    isNativeShell.mockReturnValue(true)
     httpFetch.mockResolvedValue(new Response(null, { status: 200 }))
 
     await providerFetch('https://api.anthropic.com/v1/models', {
@@ -43,7 +43,7 @@ describe('providerFetch', () => {
     expect(new Headers(init?.headers).get('Origin')).toBe('https://reflect.example')
   })
 
-  it('falls back to the global fetch (untouched init) without a bridge', async () => {
+  it('falls back to the global fetch (untouched init) outside the native shell', async () => {
     const globalFetch = vi.fn(async () => new Response(null, { status: 200 }))
     vi.stubGlobal('fetch', globalFetch)
 

--- a/apps/desktop/src/lib/provider-fetch.ts
+++ b/apps/desktop/src/lib/provider-fetch.ts
@@ -1,5 +1,5 @@
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
-import { hasBridge } from '@reflect/core'
+import { isNativeShell } from '@/lib/platform'
 
 /**
  * The transport for direct app → AI-provider calls (BYOK, Plan 10). Inside
@@ -21,7 +21,7 @@ import { hasBridge } from '@reflect/core'
  * empty value an explicit removal).
  */
 export function providerFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-  if (!hasBridge()) {
+  if (!isNativeShell()) {
     return fetch(input, init)
   }
   const headers = new Headers(init?.headers)

--- a/apps/desktop/src/lib/quit-flush-non-macos.test.tsx
+++ b/apps/desktop/src/lib/quit-flush-non-macos.test.tsx
@@ -36,7 +36,6 @@ vi.mock('@tauri-apps/api/window', () => ({
 
 vi.mock('@reflect/core', () => ({
   confirmQuit: core.confirmQuit,
-  hasBridge: () => true,
   subscribeQuitRequested: async (handler: () => void) => {
     core.quitRequested = handler
     return core.unlisten
@@ -46,7 +45,7 @@ vi.mock('@reflect/core', () => ({
 vi.mock('@/editor/open-documents', () => ({ flushOpenDocuments }))
 vi.mock('@/lib/backup-flush', () => ({ flushBackup }))
 vi.mock('@/lib/settings-flush', () => ({ flushSettings }))
-vi.mock('@/lib/platform', () => ({ isMacosDesktop: false }))
+vi.mock('@/lib/platform', () => ({ isMacosDesktop: false, isNativeShell: () => true }))
 vi.mock('@/lib/windows/window-role', () => ({
   isMainWindow: () => true,
 }))

--- a/apps/desktop/src/lib/quit-flush.test.tsx
+++ b/apps/desktop/src/lib/quit-flush.test.tsx
@@ -33,7 +33,6 @@ vi.mock('@tauri-apps/api/window', () => ({
 
 vi.mock('@reflect/core', () => ({
   confirmQuit: core.confirmQuit,
-  hasBridge: () => true,
   subscribeQuitRequested: async (handler: () => void) => {
     core.quitRequested = handler
     return core.unlisten
@@ -43,7 +42,7 @@ vi.mock('@reflect/core', () => ({
 vi.mock('@/editor/open-documents', () => ({ flushOpenDocuments }))
 vi.mock('@/lib/backup-flush', () => ({ flushBackup }))
 vi.mock('@/lib/settings-flush', () => ({ flushSettings }))
-vi.mock('@/lib/platform', () => ({ isMacosDesktop: true }))
+vi.mock('@/lib/platform', () => ({ isMacosDesktop: true, isNativeShell: () => true }))
 vi.mock('@/lib/windows/window-role', () => ({
   isMainWindow: () => windowRole.isMainWindow,
 }))

--- a/apps/desktop/src/lib/quit-flush.ts
+++ b/apps/desktop/src/lib/quit-flush.ts
@@ -1,8 +1,8 @@
 import { getCurrentWindow } from '@tauri-apps/api/window'
-import { confirmQuit, hasBridge, subscribeQuitRequested } from '@reflect/core'
+import { confirmQuit, subscribeQuitRequested } from '@reflect/core'
 import { flushOpenDocuments } from '@/editor/open-documents'
 import { flushBackup } from '@/lib/backup-flush'
-import { isMacosDesktop } from '@/lib/platform'
+import { isMacosDesktop, isNativeShell } from '@/lib/platform'
 import { flushSettings } from '@/lib/settings-flush'
 import { trackSubscriptions } from '@/lib/subscriptions'
 import { isMainWindow } from '@/lib/windows/window-role'
@@ -28,9 +28,9 @@ import { isMainWindow } from '@/lib/windows/window-role'
  * sequence lives in `background-flush.ts` (Plan 19, decision 6).
  */
 export function installQuitFlush(): () => void {
-  // No bridge → no native shell (plain-browser dev): nothing can quit-flush.
-  // getCurrentWindow below is safe to reach only inside a Tauri webview.
-  if (!hasBridge()) {
+  // No native shell (browser dev): nothing can quit-flush. getCurrentWindow
+  // below is safe to reach only inside a Tauri webview.
+  if (!isNativeShell()) {
     return () => {}
   }
 

--- a/apps/desktop/src/lib/windows/close-secondary-windows.ts
+++ b/apps/desktop/src/lib/windows/close-secondary-windows.ts
@@ -1,10 +1,5 @@
-import {
-  closeNoteWindows,
-  errorMessage,
-  hasBridge,
-  isMobilePlatform,
-  type AppPlatform,
-} from '@reflect/core'
+import { closeNoteWindows, errorMessage, isMobilePlatform, type AppPlatform } from '@reflect/core'
+import { isNativeShell } from '@/lib/platform'
 
 /**
  * Close every note window before a graph switch or delete replaces the
@@ -16,7 +11,7 @@ import {
  * browser dev, where secondary windows don't exist.
  */
 export async function closeSecondaryWindows(platform: AppPlatform): Promise<void> {
-  if (isMobilePlatform(platform) || !hasBridge()) {
+  if (isMobilePlatform(platform) || !isNativeShell()) {
     return
   }
   try {

--- a/apps/desktop/src/lib/windows/open-in-new-window.test.tsx
+++ b/apps/desktop/src/lib/windows/open-in-new-window.test.tsx
@@ -1,13 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const hasBridge = vi.hoisted(() => vi.fn(() => true))
+const isNativeShell = vi.hoisted(() => vi.fn(() => true))
 const openNoteWindow = vi.hoisted(() => vi.fn<(link: string) => Promise<void>>())
 const isMobileSurface = vi.hoisted(() => vi.fn(() => false))
 
 vi.mock('@reflect/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@reflect/core')>()),
-  hasBridge,
   openNoteWindow,
+}))
+vi.mock('@/lib/platform', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/platform')>()),
+  isNativeShell,
 }))
 vi.mock('@/lib/platform-surface', () => ({ isMobileSurface }))
 
@@ -19,7 +22,7 @@ import {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  hasBridge.mockReturnValue(true)
+  isNativeShell.mockReturnValue(true)
   isMobileSurface.mockReturnValue(false)
   openNoteWindow.mockResolvedValue(undefined)
 })
@@ -73,9 +76,9 @@ describe('openRouteInNewWindow', () => {
   })
 
   it('declines without a native shell and on mobile', async () => {
-    hasBridge.mockReturnValue(false)
+    isNativeShell.mockReturnValue(false)
     await expect(openRouteInNewWindow({ kind: 'note', path: 'notes/foo.md' })).resolves.toBe(false)
-    hasBridge.mockReturnValue(true)
+    isNativeShell.mockReturnValue(true)
     isMobileSurface.mockReturnValue(true)
     await expect(openRouteInNewWindow({ kind: 'note', path: 'notes/foo.md' })).resolves.toBe(false)
     expect(openNoteWindow).not.toHaveBeenCalled()

--- a/apps/desktop/src/lib/windows/open-in-new-window.ts
+++ b/apps/desktop/src/lib/windows/open-in-new-window.ts
@@ -1,6 +1,7 @@
-import { errorMessage, hasBridge, openNoteWindow } from '@reflect/core'
+import { errorMessage, openNoteWindow } from '@reflect/core'
 import { deepLinkForRoute } from '@/lib/deep-links/format'
 import { parseDeepLink } from '@/lib/deep-links/parse'
+import { isNativeShell } from '@/lib/platform'
 import { isMobileSurface } from '@/lib/platform-surface'
 import type { Route } from '@/routing/route'
 
@@ -42,7 +43,7 @@ export function isNewWindowClick(event: NewWindowClickEvent | undefined): boolea
  * so the gesture degrades to a plain click instead of doing nothing.
  */
 export async function openRouteInNewWindow(route: Route): Promise<boolean> {
-  if (!hasBridge() || isMobileSurface()) {
+  if (!isNativeShell() || isMobileSurface()) {
     return false
   }
   const link = deepLinkForRoute(route)
@@ -59,7 +60,7 @@ export async function openRouteInNewWindow(route: Route): Promise<boolean> {
  * Same false-not-throw contract as {@link openRouteInNewWindow}.
  */
 export async function openDeepLinkInNewWindow(href: string): Promise<boolean> {
-  if (!hasBridge() || isMobileSurface()) {
+  if (!isNativeShell() || isMobileSurface()) {
     return false
   }
   const link = parseDeepLink(href)

--- a/apps/desktop/src/lib/windows/window-role.ts
+++ b/apps/desktop/src/lib/windows/window-role.ts
@@ -1,5 +1,5 @@
 import { getCurrentWindow } from '@tauri-apps/api/window'
-import { hasBridge } from '@reflect/core'
+import { isNativeShell } from '@/lib/platform'
 
 /**
  * Which window this webview is: the main window (the config-declared `main`
@@ -13,17 +13,16 @@ import { hasBridge } from '@reflect/core'
  * through this predicate so the ownership rule lives in one place.
  */
 export function isMainWindow(): boolean {
-  if (!hasBridge()) {
-    return true // plain-browser dev: one window, no native shell
+  if (!isNativeShell()) {
+    return true // no Tauri window metadata (browser dev, tests): one window
   }
   try {
     return getCurrentWindow().label === 'main'
   } catch (cause) {
-    // A bridge without Tauri window metadata: the jsdom test harness and the
-    // ?platform=ios browser harness. Both are single-window — main. In a real
-    // Tauri webview the internals are injected before any script runs, so
-    // this can't fire there; warn loudly in case that assumption ever breaks
-    // (a misclassified note window would boot the main-window singletons).
+    // In a real Tauri webview the internals are injected before any script
+    // runs, so this can't fire; warn loudly in case that assumption ever
+    // breaks (a misclassified note window would boot the main-window
+    // singletons).
     console.warn('window label unavailable; assuming the main window:', cause)
     return true
   }

--- a/apps/desktop/src/lib/windows/window-title.ts
+++ b/apps/desktop/src/lib/windows/window-title.ts
@@ -1,5 +1,5 @@
 import { getCurrentWindow } from '@tauri-apps/api/window'
-import { hasBridge } from '@reflect/core'
+import { isNativeShell } from '@/lib/platform'
 
 /**
  * Set this webview's OS window title. Best-effort and shell-only: browser
@@ -8,7 +8,7 @@ import { hasBridge } from '@reflect/core'
  * ⌘-backtick cycling can tell N note windows apart.
  */
 export function setWindowTitle(title: string): void {
-  if (!hasBridge()) {
+  if (!isNativeShell()) {
     return
   }
   try {

--- a/apps/desktop/src/mobile/audio-memo-provider.test.tsx
+++ b/apps/desktop/src/mobile/audio-memo-provider.test.tsx
@@ -89,6 +89,8 @@ vi.mock('@tauri-apps/api/core', () => ({
   ),
 }))
 
+vi.mock('@/lib/platform', () => ({ isMacosDesktop: false, isNativeShell: () => true }))
+
 vi.mock('@/lib/transcription-reconciler', () => ({
   createTranscriptionReconciler,
 }))

--- a/apps/desktop/src/mobile/audio-memo-provider.tsx
+++ b/apps/desktop/src/mobile/audio-memo-provider.tsx
@@ -8,8 +8,9 @@ import {
   type ReactElement,
   type ReactNode,
 } from 'react'
-import { errorMessage, hasBridge, type GraphInfo } from '@reflect/core'
+import { errorMessage, type GraphInfo } from '@reflect/core'
 import { useAudioMemoPipeline, type PendingAudioCapture } from '@/hooks/use-audio-memo-pipeline'
+import { isNativeShell } from '@/lib/platform'
 import type { AudioMemoPhase } from '@/providers/audio-memo-provider'
 import { hapticImpactLight } from '@/mobile/haptics'
 import {
@@ -57,7 +58,7 @@ interface MobileAudioMemoContextValue {
   level: number
   /** Recordings committed but not yet written to the graph. */
   pendingCount: number
-  /** False without the native bridge. */
+  /** False without the native shell (the recorder is a native plugin). */
   available: boolean
   /** False when no OpenAI/Gemini model is configured; the drawer then guides key setup. */
   hasTranscriptionConfig: boolean
@@ -164,7 +165,7 @@ export function MobileAudioMemoProvider({
   const stopRecorder = recorder.stop
   const cancelRecorder = recorder.cancel
 
-  const available = hasBridge()
+  const available = isNativeShell()
 
   const start = useCallback(async (): Promise<void> => {
     if (!available) {

--- a/apps/desktop/src/mobile/connect-github-drawer.test.tsx
+++ b/apps/desktop/src/mobile/connect-github-drawer.test.tsx
@@ -29,6 +29,10 @@ const sync = vi.hoisted(() => ({
 }))
 vi.mock('@/providers/sync-provider', () => ({ useSync: () => sync }))
 vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }))
+vi.mock('@/lib/platform', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/platform')>()),
+  isNativeShell: () => true,
+}))
 vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn() }))
 const httpFetch = vi.mocked(tauriFetch)
 

--- a/apps/desktop/src/mobile/use-native-record-action.ts
+++ b/apps/desktop/src/mobile/use-native-record-action.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { addPluginListener, invoke } from '@tauri-apps/api/core'
-import { hasBridge } from '@reflect/core'
 import { z } from 'zod'
+import { isNativeShell } from '@/lib/platform'
 import { nativeRecordingStatus, stopActiveRecording } from '@/mobile/use-native-audio-recorder'
 import type { StagedRecordingInput } from '@/mobile/use-staged-recording-ingest'
 
@@ -48,7 +48,7 @@ export function useNativeRecordAction(options: UseNativeRecordActionOptions): vo
   })
 
   useEffect(() => {
-    if (!hasBridge()) {
+    if (!isNativeShell()) {
       return
     }
     let disposed = false

--- a/apps/desktop/src/mobile/use-staged-recording-ingest.ts
+++ b/apps/desktop/src/mobile/use-staged-recording-ingest.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { invoke } from '@tauri-apps/api/core'
-import { hasBridge } from '@reflect/core'
 import { z } from 'zod'
+import { isNativeShell } from '@/lib/platform'
 import {
   claimStagedPath,
   isStagedPathClaimed,
@@ -38,7 +38,7 @@ export function useStagedRecordingIngest(
 ): void {
   const scanningRef = useRef(false)
   useEffect(() => {
-    if (!hasBridge()) {
+    if (!isNativeShell()) {
       return
     }
     let disposed = false

--- a/apps/desktop/src/providers/graph-provider.test.tsx
+++ b/apps/desktop/src/providers/graph-provider.test.tsx
@@ -9,6 +9,10 @@ import { SettingsProvider } from './settings-provider'
 import { ICLOUD_STATUS_QUERY_KEY, queryClient as appQueryClient } from '@/lib/query-client'
 
 vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }))
+vi.mock('@/lib/platform', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/platform')>()),
+  isNativeShell: () => true,
+}))
 
 /**
  * Exercises the provider's open-ordering guards: overlapping opens are

--- a/apps/desktop/src/providers/update-provider.tsx
+++ b/apps/desktop/src/providers/update-provider.tsx
@@ -7,8 +7,8 @@ import {
   type ReactElement,
   type ReactNode,
 } from 'react'
-import { hasBridge } from '@reflect/core'
 import { useMainWindowEffect } from '@/hooks/use-main-window-effect'
+import { isNativeShell } from '@/lib/platform'
 import {
   createUpdateController,
   type UpdateController,
@@ -49,7 +49,7 @@ interface UpdateProviderProps {
  * any graph is open.
  */
 export function UpdateProvider({ children, autoCheck }: UpdateProviderProps): ReactElement {
-  const supported = hasBridge()
+  const supported = isNativeShell()
   const resolvedAutoCheck = autoCheck ?? (supported && !import.meta.env.DEV)
   const [controller, setController] = useState<UpdateController | null>(null)
 

--- a/apps/desktop/src/routing/app-shortcuts-macos.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts-macos.test.tsx
@@ -19,7 +19,7 @@ const openNoteFindForPath = vi.hoisted(() => vi.fn(() => true))
 const findNextInNote = vi.hoisted(() => vi.fn())
 const findPreviousInNote = vi.hoisted(() => vi.fn())
 
-vi.mock('@/lib/platform', () => ({ isMacosDesktop: true }))
+vi.mock('@/lib/platform', () => ({ isMacosDesktop: true, isNativeShell: () => false }))
 vi.mock('@/providers/note-find-provider', () => ({
   useNoteFindActions: () => ({
     openForPath: openNoteFindForPath,

--- a/apps/desktop/src/routing/app-shortcuts.test.tsx
+++ b/apps/desktop/src/routing/app-shortcuts.test.tsx
@@ -33,7 +33,7 @@ vi.mock('@/lib/native-menu/menu', () => ({
 // macOS-only shortcut behavior lives in app-shortcuts-macos.test.tsx: a
 // browser-mode module mock materializes value exports once, so the flag
 // cannot flip per test.
-vi.mock('@/lib/platform', () => ({ isMacosDesktop: false }))
+vi.mock('@/lib/platform', () => ({ isMacosDesktop: false, isNativeShell: () => false }))
 
 vi.mock('@/providers/graph-provider', () => ({
   useGraph: () => ({


### PR DESCRIPTION
Distinguish "a real Tauri webview with plugins and windows" (`isNativeShell()`) from "IPC commands can be answered" (`hasBridge()`), and switch the gates that call plugins, window APIs, or the native lifecycle to the new predicate, so a future in-browser dev bridge can install without turning those features on.