### PR TITLE
refactor: boot the desktop tree in browser during development

### DIFF
--- a/apps/desktop/src/components/all-notes/all-notes-screen.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { isDaily, listNotes, listNoteTags } from '@reflect/core'
 import { Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { useNoteLinkNavigation } from '@/hooks/use-note-link-navigation'
 import { allNotesQueryKey, allNotesTagsQueryKey } from '@/lib/notes/all-notes-query'
 import type { NewWindowClickEvent } from '@/lib/windows/open-in-new-window'
@@ -53,7 +53,7 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
   // The surface, so the keyboard shortcuts can scope to it (and focus it on mount).
   const rootRef = useRef<HTMLDivElement>(null)
 
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const enabled = bridgeReady && graph !== null
 
   const { data: notes } = useQuery({

--- a/apps/desktop/src/components/all-notes/all-notes-screen.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { hasBridge, isDaily, listNotes, listNoteTags } from '@reflect/core'
+import { isDaily, listNotes, listNoteTags } from '@reflect/core'
 import { Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { useNoteLinkNavigation } from '@/hooks/use-note-link-navigation'
 import { allNotesQueryKey, allNotesTagsQueryKey } from '@/lib/notes/all-notes-query'
 import type { NewWindowClickEvent } from '@/lib/windows/open-in-new-window'
@@ -52,8 +53,8 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
   // The surface, so the keyboard shortcuts can scope to it (and focus it on mount).
   const rootRef = useRef<HTMLDivElement>(null)
 
-  // REVIEW: DO NOT CALL hasBridge() directly in this and in any React component. add a new hook useHasBridge() that returns a boolean and call that instead. useHasBridge should call useSyncExternalStore to subscribe to changes in the bridge state. This will ensure that the component re-renders when the bridge state changes.
-  const enabled = hasBridge() && graph !== null
+  const bridgeReady = useHasBridge()
+  const enabled = bridgeReady && graph !== null
 
   const { data: notes } = useQuery({
     queryKey: allNotesQueryKey(graph?.root, tag),

--- a/apps/desktop/src/components/all-notes/all-notes-screen.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.tsx
@@ -51,6 +51,8 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null)
   // The surface, so the keyboard shortcuts can scope to it (and focus it on mount).
   const rootRef = useRef<HTMLDivElement>(null)
+
+  // REVIEW: DO NOT CALL hasBridge() directly in this and in any React component. add a new hook useHasBridge() that returns a boolean and call that instead. useHasBridge should call useSyncExternalStore to subscribe to changes in the bridge state. This will ensure that the component re-renders when the bridge state changes.
   const enabled = hasBridge() && graph !== null
 
   const { data: notes } = useQuery({

--- a/apps/desktop/src/components/chat/chat-history-menu.tsx
+++ b/apps/desktop/src/components/chat/chat-history-menu.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
-import { hasBridge, listChatConversations } from '@reflect/core'
+import { listChatConversations } from '@reflect/core'
 import { Check, History, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -10,6 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { CHAT_QUERY_SCOPE } from '@/lib/query-client'
 import { useChatSession } from '@/providers/chat-provider'
 import { useGraph } from '@/providers/graph-provider'
@@ -24,7 +25,8 @@ export function ChatHistoryMenu(): ReactElement | null {
   const { graph, indexGeneration } = useGraph()
   const { activeConversationId, openConversation, deleteConversation } = useChatSession()
 
-  const enabled = hasBridge() && indexGeneration !== null
+  const bridgeReady = useHasBridge()
+  const enabled = bridgeReady && indexGeneration !== null
   const { data: conversations } = useQuery({
     // The graph root is part of the key: conversations belong to one graph,
     // and a graph switch must never serve the previous graph's cached list.

--- a/apps/desktop/src/components/chat/chat-history-menu.tsx
+++ b/apps/desktop/src/components/chat/chat-history-menu.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { CHAT_QUERY_SCOPE } from '@/lib/query-client'
 import { useChatSession } from '@/providers/chat-provider'
 import { useGraph } from '@/providers/graph-provider'
@@ -25,7 +25,7 @@ export function ChatHistoryMenu(): ReactElement | null {
   const { graph, indexGeneration } = useGraph()
   const { activeConversationId, openConversation, deleteConversation } = useChatSession()
 
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const enabled = bridgeReady && indexGeneration !== null
   const { data: conversations } = useQuery({
     // The graph root is part of the key: conversations belong to one graph,

--- a/apps/desktop/src/components/command-palette/use-palette-results.ts
+++ b/apps/desktop/src/components/command-palette/use-palette-results.ts
@@ -6,7 +6,7 @@ import {
   searchWithFilters,
   suggestWikiTargets,
 } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { listCommands } from '@/lib/commands/registry'
 import { todayIso } from '@/lib/dates'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
@@ -49,7 +49,7 @@ export function usePaletteResults(open: boolean, query: string): PaletteResults 
   // switch the search into constrained mode (Plan 08b); plain text is the same
   // query with empty filters — one search path.
   const parsed = useMemo(() => parseSearchQuery(trimmed), [trimmed])
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const searching = open && bridgeReady && graph !== null && !trimmed.startsWith('>')
   // The generated date suggestions are relative to today, so the calendar day is
   // part of the cache identity — without it a palette cached before midnight

--- a/apps/desktop/src/components/command-palette/use-palette-results.ts
+++ b/apps/desktop/src/components/command-palette/use-palette-results.ts
@@ -1,11 +1,6 @@
 import { useDeferredValue, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import {
-  parseSearchQuery,
-  retrieve,
-  searchWithFilters,
-  suggestWikiTargets,
-} from '@reflect/core'
+import { parseSearchQuery, retrieve, searchWithFilters, suggestWikiTargets } from '@reflect/core'
 import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { listCommands } from '@/lib/commands/registry'
 import { todayIso } from '@/lib/dates'

--- a/apps/desktop/src/components/command-palette/use-palette-results.ts
+++ b/apps/desktop/src/components/command-palette/use-palette-results.ts
@@ -1,12 +1,12 @@
 import { useDeferredValue, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import {
-  hasBridge,
   parseSearchQuery,
   retrieve,
   searchWithFilters,
   suggestWikiTargets,
 } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { listCommands } from '@/lib/commands/registry'
 import { todayIso } from '@/lib/dates'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
@@ -49,7 +49,8 @@ export function usePaletteResults(open: boolean, query: string): PaletteResults 
   // switch the search into constrained mode (Plan 08b); plain text is the same
   // query with empty filters — one search path.
   const parsed = useMemo(() => parseSearchQuery(trimmed), [trimmed])
-  const searching = open && hasBridge() && graph !== null && !trimmed.startsWith('>')
+  const bridgeReady = useHasBridge()
+  const searching = open && bridgeReady && graph !== null && !trimmed.startsWith('>')
   // The generated date suggestions are relative to today, so the calendar day is
   // part of the cache identity — without it a palette cached before midnight
   // would serve a stale "Tomorrow" afterwards. Computed once so the key and the

--- a/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
+++ b/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
@@ -16,8 +16,8 @@ import {
   buildAutocompleteEntries,
   type AutocompleteEntry,
 } from '@/editor/wiki-autocomplete-entries'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { useContactsAuthorization } from '@/hooks/use-contacts-authorization'
-import { useHasBridge } from '@/hooks/use-has-bridge'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
@@ -82,7 +82,7 @@ export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): R
   const anchorRef = useRef<HTMLInputElement>(null)
   const deferredQuery = useDeferredValue(query)
   const searchTerm = deferredQuery.trim()
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
 
   const {
     data: fetched,

--- a/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
+++ b/apps/desktop/src/components/context-sidebar/attendee-combobox.tsx
@@ -4,7 +4,6 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import {
   contactLinkSuggestions,
   foldKey,
-  hasBridge,
   isContactsReadable,
   suggestWikiTargets,
   type MeetingAttendee,
@@ -18,6 +17,7 @@ import {
   type AutocompleteEntry,
 } from '@/editor/wiki-autocomplete-entries'
 import { useContactsAuthorization } from '@/hooks/use-contacts-authorization'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 import { useSettings } from '@/providers/settings-provider'
@@ -82,6 +82,7 @@ export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): R
   const anchorRef = useRef<HTMLInputElement>(null)
   const deferredQuery = useDeferredValue(query)
   const searchTerm = deferredQuery.trim()
+  const bridgeReady = useHasBridge()
 
   const {
     data: fetched,
@@ -114,7 +115,7 @@ export function AttendeeCombobox({ attendees, onAdd }: AttendeeComboboxProps): R
         },
       )
     },
-    enabled: hasBridge() && graph !== null && searchTerm !== '',
+    enabled: bridgeReady && graph !== null && searchTerm !== '',
     // Typing re-keys the query as the deferred value settles; holding the
     // previous rows avoids the list flashing closed between keystrokes.
     placeholderData: keepPreviousData,

--- a/apps/desktop/src/components/context-sidebar/day-calendar.tsx
+++ b/apps/desktop/src/components/context-sidebar/day-calendar.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { dailyDatesInRange, hasBridge, type WeekStartDay } from '@reflect/core'
+import { dailyDatesInRange, type WeekStartDay } from '@reflect/core'
 import { CalendarIcon } from '@/components/icons/calendar-icon'
 import { ChevronLeftIcon } from '@/components/icons/chevron-left-icon'
 import { ChevronRightIcon } from '@/components/icons/chevron-right-icon'
 import { ShortcutKeys } from '@/components/shortcut-keys'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { useNoteLinkNavigation } from '@/hooks/use-note-link-navigation'
 import { keybindingFor } from '@/lib/commands/app-commands'
 import { formatDayLabel } from '@/lib/dates'
@@ -60,10 +61,11 @@ export function DayCalendar({ selectedDate, today }: DayCalendarProps): ReactEle
   }
 
   const grid = buildMonthGrid(month, weekStartsOn)
+  const bridgeReady = useHasBridge()
   const { data: notedDates } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'dailyDates', grid.start, grid.end],
     queryFn: () => dailyDatesInRange(grid.start, grid.end),
-    enabled: hasBridge() && graph !== null,
+    enabled: bridgeReady && graph !== null,
   })
   // The sidebar re-renders as the focused day scrolls through the stream; with
   // the query result reference-stable (structural sharing), rebuild the lookup

--- a/apps/desktop/src/components/context-sidebar/day-calendar.tsx
+++ b/apps/desktop/src/components/context-sidebar/day-calendar.tsx
@@ -6,7 +6,7 @@ import { ChevronLeftIcon } from '@/components/icons/chevron-left-icon'
 import { ChevronRightIcon } from '@/components/icons/chevron-right-icon'
 import { ShortcutKeys } from '@/components/shortcut-keys'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { useNoteLinkNavigation } from '@/hooks/use-note-link-navigation'
 import { keybindingFor } from '@/lib/commands/app-commands'
 import { formatDayLabel } from '@/lib/dates'
@@ -61,7 +61,7 @@ export function DayCalendar({ selectedDate, today }: DayCalendarProps): ReactEle
   }
 
   const grid = buildMonthGrid(month, weekStartsOn)
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const { data: notedDates } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'dailyDates', grid.start, grid.end],
     queryFn: () => dailyDatesInRange(grid.start, grid.end),

--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -8,8 +8,8 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { useGraphColors } from '@/hooks/use-graph-colors'
-import { useHasBridge } from '@/hooks/use-has-bridge'
 import { cleanGraphName, graphNameFromRoot, isGraphNameTaken } from '@/lib/graph-names'
 import { ICLOUD_STATUS_QUERY_KEY } from '@/lib/query-client'
 import { graphColorCss } from '@/lib/graph-colors'
@@ -202,7 +202,7 @@ function IcloudCard({
   const [typedName, setTypedName] = useState<string | null>(null)
   const [busy, setBusy] = useState<IcloudBusy>(null)
   const nameId = useId()
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const { data: status } = useQuery({
     queryKey: ICLOUD_STATUS_QUERY_KEY,
     queryFn: icloudStatus,

--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -1,6 +1,6 @@
 import { useId, useState, type ReactElement, type ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { hasBridge, icloudStatus } from '@reflect/core'
+import { icloudStatus } from '@reflect/core'
 import { Cloud, Folder, FolderPlus } from 'lucide-react'
 import { getIsComposing } from '@meowdown/core'
 import { InlineAlert } from '@/components/inline-alert'
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
 import { useGraphColors } from '@/hooks/use-graph-colors'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { cleanGraphName, graphNameFromRoot, isGraphNameTaken } from '@/lib/graph-names'
 import { ICLOUD_STATUS_QUERY_KEY } from '@/lib/query-client'
 import { graphColorCss } from '@/lib/graph-colors'
@@ -201,10 +202,11 @@ function IcloudCard({
   const [typedName, setTypedName] = useState<string | null>(null)
   const [busy, setBusy] = useState<IcloudBusy>(null)
   const nameId = useId()
+  const bridgeReady = useHasBridge()
   const { data: status } = useQuery({
     queryKey: ICLOUD_STATUS_QUERY_KEY,
     queryFn: icloudStatus,
-    enabled: hasBridge(),
+    enabled: bridgeReady,
   })
 
   const pending = busy !== null

--- a/apps/desktop/src/components/settings/agents-section.tsx
+++ b/apps/desktop/src/components/settings/agents-section.tsx
@@ -6,12 +6,12 @@ import {
   agentSkillStatus,
   agentSkillUninstall,
   errorMessage,
-  hasBridge,
   type AgentSkillStatus,
 } from '@reflect/core'
 import { SettingsField } from '@/components/settings/field'
 import { SettingsSection } from '@/components/settings/section'
 import { Button } from '@/components/ui/button'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { isMacosDesktop } from '@/lib/platform'
 import { useGraph } from '@/providers/graph-provider'
 
@@ -28,10 +28,11 @@ export function AgentsSection(): ReactElement | null {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const queryKey = ['agent-skill', graph?.root]
+  const bridgeReady = useHasBridge()
   const { data: status } = useQuery({
     queryKey,
     queryFn: agentSkillStatus,
-    enabled: hasBridge() && isMacosDesktop && graph !== null,
+    enabled: bridgeReady && isMacosDesktop && graph !== null,
   })
 
   if (!isMacosDesktop || graph === null) {

--- a/apps/desktop/src/components/settings/agents-section.tsx
+++ b/apps/desktop/src/components/settings/agents-section.tsx
@@ -11,7 +11,7 @@ import {
 import { SettingsField } from '@/components/settings/field'
 import { SettingsSection } from '@/components/settings/section'
 import { Button } from '@/components/ui/button'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { isMacosDesktop } from '@/lib/platform'
 import { useGraph } from '@/providers/graph-provider'
 
@@ -28,7 +28,7 @@ export function AgentsSection(): ReactElement | null {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const queryKey = ['agent-skill', graph?.root]
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const { data: status } = useQuery({
     queryKey,
     queryFn: agentSkillStatus,

--- a/apps/desktop/src/components/settings/backup-section.tsx
+++ b/apps/desktop/src/components/settings/backup-section.tsx
@@ -10,8 +10,8 @@ import { GithubSignOutRow } from '@/components/settings/github-sign-out-row'
 import { SyncForkNotice } from '@/components/settings/sync-fork-notice'
 import { Button } from '@/components/ui/button'
 import { useAsyncAction } from '@/hooks/use-async-action'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { useGithubConnected } from '@/hooks/use-github-connected'
-import { useHasBridge } from '@/hooks/use-has-bridge'
 import { suggestRepoName } from '@/lib/github-repos'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
@@ -55,7 +55,7 @@ export function BackupSettingsField(): ReactElement {
   const openRepoAttempt = useRef(0)
   const action = useAsyncAction()
 
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const conflicted = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, 'conflicted-notes', graph?.root],
     queryFn: () => getConflictedNotes(),

--- a/apps/desktop/src/components/settings/backup-section.tsx
+++ b/apps/desktop/src/components/settings/backup-section.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, type ReactElement } from 'react'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { useQuery } from '@tanstack/react-query'
-import { getConflictedNotes, getDuplicateNoteIds, hasBridge } from '@reflect/core'
+import { getConflictedNotes, getDuplicateNoteIds } from '@reflect/core'
 import { ExternalLink } from 'lucide-react'
 import { ConnectGithubDialog } from '@/components/settings/connect-github-dialog'
 import { ConflictedNoteLinks } from '@/components/settings/conflicted-note-links'
@@ -11,6 +11,7 @@ import { SyncForkNotice } from '@/components/settings/sync-fork-notice'
 import { Button } from '@/components/ui/button'
 import { useAsyncAction } from '@/hooks/use-async-action'
 import { useGithubConnected } from '@/hooks/use-github-connected'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { suggestRepoName } from '@/lib/github-repos'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
@@ -54,10 +55,11 @@ export function BackupSettingsField(): ReactElement {
   const openRepoAttempt = useRef(0)
   const action = useAsyncAction()
 
+  const bridgeReady = useHasBridge()
   const conflicted = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, 'conflicted-notes', graph?.root],
     queryFn: () => getConflictedNotes(),
-    enabled: hasBridge() && graph !== null,
+    enabled: bridgeReady && graph !== null,
   })
   const conflictedNotes = conflicted.data ?? []
   const conflictCount = conflictedNotes.length
@@ -68,7 +70,7 @@ export function BackupSettingsField(): ReactElement {
   const duplicateIds = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, 'duplicate-note-ids', graph?.root],
     queryFn: () => getDuplicateNoteIds(),
-    enabled: hasBridge() && graph !== null,
+    enabled: bridgeReady && graph !== null,
   })
   const forkGroups = duplicateIds.data ?? []
 

--- a/apps/desktop/src/components/settings/icloud-section.tsx
+++ b/apps/desktop/src/components/settings/icloud-section.tsx
@@ -4,12 +4,12 @@ import {
   errorMessage,
   getConflictedNotes,
   getDuplicateNoteIds,
-  hasBridge,
   icloudAdoptGraph,
   icloudPendingCount,
   icloudStatus,
 } from '@reflect/core'
 import { ConflictedNoteLinks } from '@/components/settings/conflicted-note-links'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { SettingsField } from '@/components/settings/field'
 import { Button } from '@/components/ui/button'
 import {
@@ -79,7 +79,7 @@ export function IcloudSettingsField(): ReactElement | null {
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const bridgeAvailable = hasBridge()
+  const bridgeAvailable = useHasBridge()
   const hosted = graph !== null && isICloudRoot(graph.root)
   const { data: status } = useQuery({
     queryKey: ICLOUD_STATUS_QUERY_KEY,

--- a/apps/desktop/src/components/settings/icloud-section.tsx
+++ b/apps/desktop/src/components/settings/icloud-section.tsx
@@ -9,7 +9,7 @@ import {
   icloudStatus,
 } from '@reflect/core'
 import { ConflictedNoteLinks } from '@/components/settings/conflicted-note-links'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { SettingsField } from '@/components/settings/field'
 import { Button } from '@/components/ui/button'
 import {
@@ -79,7 +79,7 @@ export function IcloudSettingsField(): ReactElement | null {
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const bridgeAvailable = useHasBridge()
+  const bridgeAvailable = useBridgeReady()
   const hosted = graph !== null && isICloudRoot(graph.root)
   const { data: status } = useQuery({
     queryKey: ICLOUD_STATUS_QUERY_KEY,

--- a/apps/desktop/src/components/sync-conflict-notice.tsx
+++ b/apps/desktop/src/components/sync-conflict-notice.tsx
@@ -1,12 +1,7 @@
 import type { ReactElement, ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { GitMerge } from 'lucide-react'
-import {
-  conflictMarkerBlockCount,
-  conflictMarkerLabels,
-  getNote,
-  readNote,
-} from '@reflect/core'
+import { conflictMarkerBlockCount, conflictMarkerLabels, getNote, readNote } from '@reflect/core'
 import { CONFLICT_SIDE_DOT } from '@/components/conflict-note-view'
 import { InlineAlert } from '@/components/inline-alert'
 import { Button } from '@/components/ui/button'

--- a/apps/desktop/src/components/sync-conflict-notice.tsx
+++ b/apps/desktop/src/components/sync-conflict-notice.tsx
@@ -5,13 +5,13 @@ import {
   conflictMarkerBlockCount,
   conflictMarkerLabels,
   getNote,
-  hasBridge,
   readNote,
 } from '@reflect/core'
 import { CONFLICT_SIDE_DOT } from '@/components/conflict-note-view'
 import { InlineAlert } from '@/components/inline-alert'
 import { Button } from '@/components/ui/button'
 import { useConflictResolution } from '@/hooks/use-conflict-resolution'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { isMobileSurface } from '@/lib/platform-surface'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { cn } from '@/lib/utils'
@@ -49,10 +49,11 @@ export function SyncConflictNotice({
 }: SyncConflictNoticeProps): ReactElement | null {
   const { graph } = useGraph()
   const { busy, error, resolve } = useConflictResolution(path)
+  const bridgeReady = useHasBridge()
   const { data } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, 'note-conflict', graph?.root, path],
     queryFn: async () => (await getNote(path)) ?? null,
-    enabled: hasBridge() && graph !== null,
+    enabled: bridgeReady && graph !== null,
   })
   const hasConflict = data?.hasConflict === true
   // The iCloud sweep labels marker sides with real device names (or the two
@@ -69,7 +70,7 @@ export function SyncConflictNotice({
         blocks: conflictMarkerBlockCount(source),
       }
     },
-    enabled: hasBridge() && graph !== null && hasConflict,
+    enabled: bridgeReady && graph !== null && hasConflict,
   })
 
   if (data == null || !hasConflict || graph === null) {

--- a/apps/desktop/src/components/sync-conflict-notice.tsx
+++ b/apps/desktop/src/components/sync-conflict-notice.tsx
@@ -10,8 +10,8 @@ import {
 import { CONFLICT_SIDE_DOT } from '@/components/conflict-note-view'
 import { InlineAlert } from '@/components/inline-alert'
 import { Button } from '@/components/ui/button'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { useConflictResolution } from '@/hooks/use-conflict-resolution'
-import { useHasBridge } from '@/hooks/use-has-bridge'
 import { isMobileSurface } from '@/lib/platform-surface'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { cn } from '@/lib/utils'
@@ -49,7 +49,7 @@ export function SyncConflictNotice({
 }: SyncConflictNoticeProps): ReactElement | null {
   const { graph } = useGraph()
   const { busy, error, resolve } = useConflictResolution(path)
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const { data } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, 'note-conflict', graph?.root, path],
     queryFn: async () => (await getNote(path)) ?? null,

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -9,12 +9,7 @@ import {
 } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Archive, CalendarClock, List, Search } from 'lucide-react'
-import {
-  getCompletedTasks,
-  getOpenTasks,
-  type OpenTask,
-  type TaskGroup,
-} from '@reflect/core'
+import { getCompletedTasks, getOpenTasks, type OpenTask, type TaskGroup } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useBridgeReady } from '@/hooks/use-bridge-ready'

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -12,12 +12,12 @@ import { Archive, CalendarClock, List, Search } from 'lucide-react'
 import {
   getCompletedTasks,
   getOpenTasks,
-  hasBridge,
   type OpenTask,
   type TaskGroup,
 } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { useNoteLinkNavigation } from '@/hooks/use-note-link-navigation'
 import { useRecentlyCompleted } from '@/lib/tasks/recently-completed'
 import { sameTask, taskKey } from '@/lib/tasks/task-identity'
@@ -82,7 +82,8 @@ export function TasksScreen(): ReactElement {
   const [scheduleOpen, setScheduleOpen] = useState(false)
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null)
   const rootRef = useRef<HTMLDivElement>(null)
-  const enabled = hasBridge() && graph !== null
+  const bridgeReady = useHasBridge()
+  const enabled = bridgeReady && graph !== null
 
   const { data: open, isError: openFailed } = useQuery({
     queryKey: tasksQueryKey(graph?.root),

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -17,7 +17,7 @@ import {
 } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { useNoteLinkNavigation } from '@/hooks/use-note-link-navigation'
 import { useRecentlyCompleted } from '@/lib/tasks/recently-completed'
 import { sameTask, taskKey } from '@/lib/tasks/task-identity'
@@ -82,7 +82,7 @@ export function TasksScreen(): ReactElement {
   const [scheduleOpen, setScheduleOpen] = useState(false)
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null)
   const rootRef = useRef<HTMLDivElement>(null)
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const enabled = bridgeReady && graph !== null
 
   const { data: open, isError: openFailed } = useQuery({

--- a/apps/desktop/src/desktop-root.tsx
+++ b/apps/desktop/src/desktop-root.tsx
@@ -1,5 +1,5 @@
 import { useEffect, type ReactElement } from 'react'
-import { hasBridge, subscribeNoteMoved } from '@reflect/core'
+import { subscribeNoteMoved } from '@reflect/core'
 import { App } from '@/app'
 import { followHealedMove } from '@/editor/move-note'
 import { OperationsStatus } from '@/components/operations-status'
@@ -7,6 +7,7 @@ import { UpdateToast } from '@/components/update-toast'
 import { Toaster } from '@/components/ui/sonner'
 import { WindowDragRegion } from '@/components/window-drag-region'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { useMainWindowEffect } from '@/hooks/use-main-window-effect'
 import { startDeepLinkListener } from '@/lib/deep-links/intake'
 import { isNativeShell } from '@/lib/platform'
@@ -21,6 +22,7 @@ import { UpdateProvider } from '@/providers/update-provider'
  * chooser/workspace app — none of which exist on mobile.
  */
 export function DesktopRoot(): ReactElement {
+  const bridgeReady = useHasBridge()
   // Deep-link intake starts with the surface, not the workspace: a
   // `reflect://` URL that launched the app (or arrived on the graph chooser)
   // buffers in `intake.ts` until a graph opens. Browser dev has no plugin.
@@ -43,7 +45,7 @@ export function DesktopRoot(): ReactElement {
   // window also followed in-process; the echo is idempotent (the session no
   // longer matches `from`, and re-routing an absent entry is a no-op).
   useEffect(() => {
-    if (!hasBridge()) {
+    if (!bridgeReady) {
       return
     }
     const subscriptions = trackSubscriptions()
@@ -51,7 +53,7 @@ export function DesktopRoot(): ReactElement {
     return () => {
       subscriptions.disposeAll()
     }
-  }, [])
+  }, [bridgeReady])
 
   return (
     <UpdateProvider>

--- a/apps/desktop/src/desktop-root.tsx
+++ b/apps/desktop/src/desktop-root.tsx
@@ -7,7 +7,7 @@ import { UpdateToast } from '@/components/update-toast'
 import { Toaster } from '@/components/ui/sonner'
 import { WindowDragRegion } from '@/components/window-drag-region'
 import { TooltipProvider } from '@/components/ui/tooltip'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { useMainWindowEffect } from '@/hooks/use-main-window-effect'
 import { startDeepLinkListener } from '@/lib/deep-links/intake'
 import { isNativeShell } from '@/lib/platform'
@@ -22,7 +22,7 @@ import { UpdateProvider } from '@/providers/update-provider'
  * chooser/workspace app — none of which exist on mobile.
  */
 export function DesktopRoot(): ReactElement {
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   // Deep-link intake starts with the surface, not the workspace: a
   // `reflect://` URL that launched the app (or arrived on the graph chooser)
   // buffers in `intake.ts` until a graph opens. Browser dev has no plugin.

--- a/apps/desktop/src/dev/dev-bridge.test.ts
+++ b/apps/desktop/src/dev/dev-bridge.test.ts
@@ -70,6 +70,41 @@ describe('dev bridge index_reconcile_scan', () => {
   })
 })
 
+describe('dev bridge desktop boot surface', () => {
+  it('answers the desktop chooser and workspace queries with honest stand-ins', async () => {
+    const files = createDevFileStore({
+      'notes/one.md': '# One',
+      'notes/two.md': '# Two',
+    })
+    const bridge = createDevBridge({
+      platform: 'desktop',
+      files,
+      index: await createDevIndexDb(),
+    })
+
+    const recents = (await bridge.invoke('recent_graphs', {})) as Array<Record<string, unknown>>
+    expect(recents).toHaveLength(1)
+    expect(recents[0]).toMatchObject({ root: '/dev-graph', name: 'Dev Graph' })
+    expect(recents[0]!['openedMs']).toEqual(expect.any(Number))
+
+    await expect(bridge.invoke('icloud_status', {})).resolves.toEqual({
+      available: false,
+      documentsRoot: null,
+      existingGraphRoots: [],
+    })
+    await expect(bridge.invoke('embed_status', {})).resolves.toEqual({
+      status: 'failed',
+      message: 'embeddings are unavailable in browser dev',
+    })
+    await expect(bridge.invoke('vault_scan_stats', { generation: 1 })).resolves.toEqual({
+      notes: 2,
+      attachments: 0,
+      skipped: 0,
+    })
+    await expect(bridge.invoke('list_attachments', { generation: 1 })).resolves.toEqual([])
+  })
+})
+
 describe('dev bridge background task parity', () => {
   it('reports native background assertions as unavailable and accepts cleanup', async () => {
     const bridge = createDevBridge({

--- a/apps/desktop/src/dev/dev-bridge.ts
+++ b/apps/desktop/src/dev/dev-bridge.ts
@@ -52,8 +52,9 @@ const chatDeleteArgsSchema = z.object({ id: z.string() })
 
 /**
  * The in-browser stand-in for the Rust shell (dev builds only): answers the
- * command surface the mobile tree exercises from an in-memory file map and the
- * wasm SQLite index. The in-memory graph has one fixed generation (`1`); the
+ * command surface the desktop and mobile trees exercise from an in-memory
+ * file map and the wasm SQLite index. The in-memory graph has one fixed
+ * generation (`1`); the
  * no-clobber note-create command validates that value before touching the
  * store, matching its native race-safety contract.
  *
@@ -94,6 +95,19 @@ export function createDevBridge(backend: DevBridgeBackend): IpcBridge {
       case 'graph_create':
         return graphInfo
       case 'recent_graphs':
+        // One seeded recent so the desktop chooser has something to open —
+        // the browser has no folder picker, so this is the only entry point.
+        return [{ root: graphInfo.root, name: graphInfo.name, openedMs: Date.now() }]
+      case 'icloud_status':
+        // No iCloud container in a browser; the chooser's iCloud card hides.
+        return { available: false, documentsRoot: null, existingGraphRoots: [] }
+      case 'embed_status':
+        // `failed` is the designed recoverable "unavailable" state — semantic
+        // search surfaces show it honestly instead of offering a download.
+        return { status: 'failed', message: 'embeddings are unavailable in browser dev' }
+      case 'vault_scan_stats':
+        return { notes: files.list().length, attachments: 0, skipped: 0 }
+      case 'list_attachments':
         return []
       case 'forget_recent':
       case 'capture_host_register':

--- a/apps/desktop/src/dev/install-dev-bridge.ts
+++ b/apps/desktop/src/dev/install-dev-bridge.ts
@@ -9,10 +9,11 @@ let installation: Promise<void> | null = null
 /**
  * Install the in-browser dev bridge (dev builds only): an in-memory graph
  * seeded with demo notes, backed by the real index schema in wasm SQLite.
- * Loaded lazily by `PlatformRoot` when `?platform=ios` (or `android`) is in
- * the URL and no native shell is present — the mobile tree then boots through
- * its ordinary path: graph open, full index rebuild from the seeded files,
- * queries over `db_query`.
+ * Loaded lazily by `PlatformRoot` whenever plain-browser dev has no native
+ * shell — with platform `desktop` by default, or `ios`/`android` when the
+ * `?platform=` override forces the mobile tree. The chosen tree then boots
+ * through its ordinary path: graph open, full index rebuild from the seeded
+ * files, queries over `db_query`.
  *
  * Idempotent: React 19 StrictMode double-fires the installing effect, and the
  * second call must not re-seed or swap the bridge mid-boot.

--- a/apps/desktop/src/dev/seed-graph.ts
+++ b/apps/desktop/src/dev/seed-graph.ts
@@ -31,20 +31,20 @@ export function seedGraphFiles(): Record<string, string> {
   return {
     [`daily/${today}.md`]: [
       `- Morning review with [[Sarah Chen]] about the [[Reflect V2]] launch`,
-      `- [ ] Ship the mobile filter badges [[${today}]]`,
-      `- [ ] Reply to the beta feedback thread`,
+      `+ [ ] Ship the mobile filter badges [[${today}]]`,
+      `+ [ ] Reply to the beta feedback thread`,
       `- Started reading [[Atomic Habits]] on the train #book`,
       ``,
     ].join('\n'),
     [`daily/${yesterday}.md`]: [
       `- Pairing session on the day carousel swipe physics`,
-      `- [x] Fix the week-strip echo guard`,
+      `+ [x] Fix the week-strip echo guard`,
       `- Lunch with [[James Clear]] — talked habit loops #person`,
       ``,
     ].join('\n'),
     [`daily/${isoDay(2)}.md`]: [
       `- Sketched the [[Quarterly Goals]] doc`,
-      `- [ ] Book flights for the offsite [[${nextWeek}]]`,
+      `+ [ ] Book flights for the offsite [[${nextWeek}]]`,
       ``,
     ].join('\n'),
     [`daily/${isoDay(4)}.md`]: [
@@ -54,7 +54,7 @@ export function seedGraphFiles(): Record<string, string> {
     ].join('\n'),
     [`daily/${isoDay(7)}.md`]: [
       `- Weekly planning: reviewed [[Reading List]]`,
-      `- [x] Cut the 0.2 beta release`,
+      `+ [x] Cut the 0.2 beta release`,
       ``,
     ].join('\n'),
     'notes/reflect-v2.md': [
@@ -65,8 +65,8 @@ export function seedGraphFiles(): Record<string, string> {
       `projection, sync over Git.`,
       ``,
       `- Owner: [[Sarah Chen]]`,
-      `- [ ] Mobile parity pass [[${nextWeek}]]`,
-      `- [x] Ship the All tab search`,
+      `+ [ ] Mobile parity pass [[${nextWeek}]]`,
+      `+ [x] Ship the All tab search`,
       ``,
     ].join('\n'),
     'notes/sarah-chen.md': [
@@ -120,9 +120,9 @@ export function seedGraphFiles(): Record<string, string> {
       frontmatter({ id: '01hv3xq7c2dm8k4t9w5e6r1n0g' }),
       `# Quarterly Goals`,
       ``,
-      `- [ ] Mobile app in TestFlight [[${nextWeek}]]`,
-      `- [ ] 1k beta signups`,
-      `- [x] Open-source the core`,
+      `+ [ ] Mobile app in TestFlight [[${nextWeek}]]`,
+      `+ [ ] 1k beta signups`,
+      `+ [x] Open-source the core`,
       ``,
     ].join('\n'),
     'notes/private-journal.md': [

--- a/apps/desktop/src/editor/use-editor-autocomplete.ts
+++ b/apps/desktop/src/editor/use-editor-autocomplete.ts
@@ -77,6 +77,8 @@ export function useEditorAutocomplete(): EditorAutocomplete {
 
   const onWikilinkSearch = useCallback(
     async (query: string): Promise<WikilinkItem[]> => {
+      // Call-time check on purpose: search handlers run on user action, so
+      // they read the live bridge state instead of a captured one.
       if (!hasBridge() || graph === null) {
         return []
       }

--- a/apps/desktop/src/editor/use-template-slash-items.ts
+++ b/apps/desktop/src/editor/use-template-slash-items.ts
@@ -23,6 +23,8 @@ export function useTemplateSlashItems(
 
   return useCallback(
     async (_query: string): Promise<SlashMenuItem[]> => {
+      // Call-time check on purpose: this runs on user action, not in render
+      // scope, so it reads the live bridge state instead of a captured one.
       if (!hasBridge() || graph === null) {
         return []
       }

--- a/apps/desktop/src/hooks/use-backlink-sources.ts
+++ b/apps/desktop/src/hooks/use-backlink-sources.ts
@@ -6,7 +6,7 @@ import {
   type BacklinkContextPage,
   type BacklinkSourceCursor,
 } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { groupBacklinksBySource, type BacklinkSource } from '@/lib/group-backlinks'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
@@ -70,7 +70,7 @@ function groupLoadedBacklinks(pages: readonly BacklinkContextPage[]): BacklinkSo
  */
 export function useBacklinkSources(path: string): BacklinkSources {
   const { graph } = useGraph()
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const {
     data,
     fetchNextPage,

--- a/apps/desktop/src/hooks/use-backlink-sources.ts
+++ b/apps/desktop/src/hooks/use-backlink-sources.ts
@@ -2,11 +2,11 @@ import { useCallback, useMemo } from 'react'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import {
   getBacklinksWithContext,
-  hasBridge,
   type BacklinkContext,
   type BacklinkContextPage,
   type BacklinkSourceCursor,
 } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { groupBacklinksBySource, type BacklinkSource } from '@/lib/group-backlinks'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
@@ -70,6 +70,7 @@ function groupLoadedBacklinks(pages: readonly BacklinkContextPage[]): BacklinkSo
  */
 export function useBacklinkSources(path: string): BacklinkSources {
   const { graph } = useGraph()
+  const bridgeReady = useHasBridge()
   const {
     data,
     fetchNextPage,
@@ -87,7 +88,7 @@ export function useBacklinkSources(path: string): BacklinkSources {
       }),
     initialPageParam: null as BacklinkSourceCursor | null,
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
-    enabled: hasBridge() && graph !== null,
+    enabled: bridgeReady && graph !== null,
   })
   const groups = useMemo(() => groupLoadedBacklinks(data?.pages ?? []), [data])
   const loadMore = useCallback(() => {

--- a/apps/desktop/src/hooks/use-bridge-ready.ts
+++ b/apps/desktop/src/hooks/use-bridge-ready.ts
@@ -13,6 +13,6 @@ import { hasBridge, subscribeBridgeChanges } from '@reflect/core'
  * callbacks and non-React modules keep calling `hasBridge()` at their own
  * call time.
  */
-export function useHasBridge(): boolean {
+export function useBridgeReady(): boolean {
   return useSyncExternalStore(subscribeBridgeChanges, hasBridge, hasBridge)
 }

--- a/apps/desktop/src/hooks/use-contacts-authorization.ts
+++ b/apps/desktop/src/hooks/use-contacts-authorization.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { contactsAuthorizationStatus, hasBridge, type ContactsAuthorization } from '@reflect/core'
+import { contactsAuthorizationStatus, type ContactsAuthorization } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 
 /**
  * One shared query for the Contacts permission state, consumed by the
@@ -13,10 +14,11 @@ export const CONTACTS_AUTHORIZATION_QUERY_KEY = ['contacts', 'authorization'] as
 
 /** The Contacts permission state, or `null` while the first read is in flight. */
 export function useContactsAuthorization(): ContactsAuthorization | null {
+  const bridgeReady = useHasBridge()
   const { data } = useQuery({
     queryKey: CONTACTS_AUTHORIZATION_QUERY_KEY,
     queryFn: () => contactsAuthorizationStatus(),
-    enabled: hasBridge(),
+    enabled: bridgeReady,
   })
   return data ?? null
 }

--- a/apps/desktop/src/hooks/use-contacts-authorization.ts
+++ b/apps/desktop/src/hooks/use-contacts-authorization.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { contactsAuthorizationStatus, type ContactsAuthorization } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 
 /**
  * One shared query for the Contacts permission state, consumed by the
@@ -14,7 +14,7 @@ export const CONTACTS_AUTHORIZATION_QUERY_KEY = ['contacts', 'authorization'] as
 
 /** The Contacts permission state, or `null` while the first read is in flight. */
 export function useContactsAuthorization(): ContactsAuthorization | null {
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const { data } = useQuery({
     queryKey: CONTACTS_AUTHORIZATION_QUERY_KEY,
     queryFn: () => contactsAuthorizationStatus(),

--- a/apps/desktop/src/hooks/use-github-connected.ts
+++ b/apps/desktop/src/hooks/use-github-connected.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { loadGithubAuth } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { GITHUB_AUTH_QUERY_KEY } from '@/lib/github-auth-state'
 
 /**
@@ -11,7 +11,7 @@ import { GITHUB_AUTH_QUERY_KEY } from '@/lib/github-auth-state'
  * saves or clears the credential.
  */
 export function useGithubConnected(): boolean {
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const { data } = useQuery({
     queryKey: GITHUB_AUTH_QUERY_KEY,
     queryFn: async () => (await loadGithubAuth()) !== null,

--- a/apps/desktop/src/hooks/use-github-connected.ts
+++ b/apps/desktop/src/hooks/use-github-connected.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
-import { hasBridge, loadGithubAuth } from '@reflect/core'
+import { loadGithubAuth } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { GITHUB_AUTH_QUERY_KEY } from '@/lib/github-auth-state'
 
 /**
@@ -10,10 +11,11 @@ import { GITHUB_AUTH_QUERY_KEY } from '@/lib/github-auth-state'
  * saves or clears the credential.
  */
 export function useGithubConnected(): boolean {
+  const bridgeReady = useHasBridge()
   const { data } = useQuery({
     queryKey: GITHUB_AUTH_QUERY_KEY,
     queryFn: async () => (await loadGithubAuth()) !== null,
-    enabled: hasBridge(),
+    enabled: bridgeReady,
   })
   return data ?? false
 }

--- a/apps/desktop/src/hooks/use-has-bridge.ts
+++ b/apps/desktop/src/hooks/use-has-bridge.ts
@@ -1,0 +1,18 @@
+import { useSyncExternalStore } from 'react'
+import { hasBridge, subscribeBridgeChanges } from '@reflect/core'
+
+/**
+ * Reactive `hasBridge()` for React code. The Tauri bridge installs before the
+ * first render, but the browser dev bridge installs *asynchronously* after
+ * it — a component that samples `hasBridge()` during render keeps the stale
+ * answer forever (a disabled query never re-enables). Subscribing through
+ * `useSyncExternalStore` re-renders the component when `setBridge` runs, so
+ * bridge-gated UI comes alive the moment the install lands. Components and
+ * hooks must use this instead of calling `hasBridge()` in render scope
+ * (query `enabled:` flags, rendered booleans, effect guards); imperative
+ * callbacks and non-React modules keep calling `hasBridge()` at their own
+ * call time.
+ */
+export function useHasBridge(): boolean {
+  return useSyncExternalStore(subscribeBridgeChanges, hasBridge, hasBridge)
+}

--- a/apps/desktop/src/hooks/use-note-row.ts
+++ b/apps/desktop/src/hooks/use-note-row.ts
@@ -1,11 +1,12 @@
 import { useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { getNote, hasBridge, type NoteRow } from '@reflect/core'
+import { getNote, type NoteRow } from '@reflect/core'
 import {
   applyNoteRowOverlay,
   reconcileNoteRowOverlay,
   useNoteRowOverlay,
 } from '@/hooks/note-row-overlay'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 
@@ -21,10 +22,11 @@ import { useGraph } from '@/providers/graph-provider'
 export function useNoteRow(path: string): NoteRow | null {
   const { graph } = useGraph()
   const generation = graph?.generation
+  const bridgeReady = useHasBridge()
   const { data } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'note', path],
     queryFn: async () => (await getNote(path)) ?? null,
-    enabled: hasBridge() && graph !== null,
+    enabled: bridgeReady && graph !== null,
   })
   const row = data ?? null
   const overlay = useNoteRowOverlay(path, generation)

--- a/apps/desktop/src/hooks/use-note-row.ts
+++ b/apps/desktop/src/hooks/use-note-row.ts
@@ -6,7 +6,7 @@ import {
   reconcileNoteRowOverlay,
   useNoteRowOverlay,
 } from '@/hooks/note-row-overlay'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 
@@ -22,7 +22,7 @@ import { useGraph } from '@/providers/graph-provider'
 export function useNoteRow(path: string): NoteRow | null {
   const { graph } = useGraph()
   const generation = graph?.generation
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const { data } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'note', path],
     queryFn: async () => (await getNote(path)) ?? null,

--- a/apps/desktop/src/hooks/use-pinned-notes.ts
+++ b/apps/desktop/src/hooks/use-pinned-notes.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
-import { getPinnedNotes, hasBridge, type PinnedNote } from '@reflect/core'
+import { getPinnedNotes, type PinnedNote } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 
@@ -17,10 +18,11 @@ export function pinnedNotesQueryKey(
  */
 export function usePinnedNotes(): PinnedNote[] {
   const { graph } = useGraph()
+  const bridgeReady = useHasBridge()
   const { data } = useQuery({
     queryKey: pinnedNotesQueryKey(graph?.root),
     queryFn: () => getPinnedNotes(),
-    enabled: hasBridge() && graph !== null,
+    enabled: bridgeReady && graph !== null,
   })
   return data ?? []
 }

--- a/apps/desktop/src/hooks/use-pinned-notes.ts
+++ b/apps/desktop/src/hooks/use-pinned-notes.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { getPinnedNotes, type PinnedNote } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 
@@ -18,7 +18,7 @@ export function pinnedNotesQueryKey(
  */
 export function usePinnedNotes(): PinnedNote[] {
   const { graph } = useGraph()
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const { data } = useQuery({
     queryKey: pinnedNotesQueryKey(graph?.root),
     queryFn: () => getPinnedNotes(),

--- a/apps/desktop/src/hooks/use-suggested-contact.ts
+++ b/apps/desktop/src/hooks/use-suggested-contact.ts
@@ -10,7 +10,7 @@ import {
   suggestContactForTitle,
   type ContactMatch,
 } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { readNoteSource } from '@/lib/note-frontmatter'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
@@ -45,7 +45,7 @@ export function useSuggestedContact(path: string): ContactMatch | null {
   const { settings } = useSettings()
   const authorization = useContactsAuthorization()
   const readable = authorization !== null && isContactsReadable(authorization)
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const enabled =
     bridgeReady && graph !== null && settings.contactsEnabled && readable && !isDaily(path)
   const { data } = useQuery({

--- a/apps/desktop/src/hooks/use-suggested-contact.ts
+++ b/apps/desktop/src/hooks/use-suggested-contact.ts
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query'
 import {
   contactDetailsMarkdown,
   contactNamesEqual,
-  hasBridge,
   isContactsReadable,
   isDaily,
   noteHasContactDetails,
@@ -11,6 +10,7 @@ import {
   suggestContactForTitle,
   type ContactMatch,
 } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { readNoteSource } from '@/lib/note-frontmatter'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
@@ -45,8 +45,9 @@ export function useSuggestedContact(path: string): ContactMatch | null {
   const { settings } = useSettings()
   const authorization = useContactsAuthorization()
   const readable = authorization !== null && isContactsReadable(authorization)
+  const bridgeReady = useHasBridge()
   const enabled =
-    hasBridge() && graph !== null && settings.contactsEnabled && readable && !isDaily(path)
+    bridgeReady && graph !== null && settings.contactsEnabled && readable && !isDaily(path)
   const { data } = useQuery({
     queryKey: suggestedContactQueryKey(graph?.root, path),
     queryFn: async () => {

--- a/apps/desktop/src/lib/backup-controller.ts
+++ b/apps/desktop/src/lib/backup-controller.ts
@@ -28,6 +28,7 @@ import {
 import { setBackupFlusher } from '@/lib/backup-flush'
 import { invalidateGithubAuth } from '@/lib/github-auth-state'
 import { startOperation } from '@/lib/operations'
+import { isNativeShell } from '@/lib/platform'
 import { isMobileSurface } from '@/lib/platform-surface'
 import { providerFetch } from '@/lib/provider-fetch'
 import { throttledInvalidateIndexQueries } from '@/lib/query-client'
@@ -258,7 +259,9 @@ export function createBackupController(options: BackupControllerOptions): Backup
    * happened not to come up would be the worse trade.
    */
   async function startLocalHistory(initialized: boolean): Promise<void> {
-    if (isMobileSurface()) {
+    // Real git on a real folder — a shell capability the browser-dev bridge
+    // honestly lacks, so don't start (and noisily fail) the commit loop there.
+    if (isMobileSurface() || !isNativeShell()) {
       return
     }
     try {

--- a/apps/desktop/src/lib/tauri-bridge.ts
+++ b/apps/desktop/src/lib/tauri-bridge.ts
@@ -30,8 +30,10 @@ export const tauriBridge: IpcBridge = {
 
 /**
  * Install the Tauri bridge when running inside a Tauri webview. Plain-browser
- * dev (`pnpm dev` without the shell) installs nothing; `hasBridge()` then gates
- * native-only features like the file watcher and the recents store.
+ * dev (`pnpm dev` without the shell) installs nothing here — `PlatformRoot`
+ * later installs the in-memory dev bridge instead (unless `?platform=none`
+ * opts out), and features that need the real shell rather than just an
+ * answering bridge gate on `isNativeShell()`.
  */
 export function installTauriBridge(): void {
   if (isTauri()) {

--- a/apps/desktop/src/lib/use-calendar.ts
+++ b/apps/desktop/src/lib/use-calendar.ts
@@ -12,7 +12,7 @@ import {
   type CalendarAuthorizationStatus,
   type Unlisten,
 } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { isMacosDesktop } from '@/lib/platform'
 import { useSettings } from '@/providers/settings-provider'
 
@@ -31,7 +31,7 @@ export const CALENDAR_LIST_QUERY_KEY = ['calendar', 'calendars'] as const
 
 /** Whether calendar queries can run at all in this environment. */
 function useCalendarAvailable(): boolean {
-  return useHasBridge() && isMacosDesktop
+  return useBridgeReady() && isMacosDesktop
 }
 
 /**

--- a/apps/desktop/src/lib/use-calendar.ts
+++ b/apps/desktop/src/lib/use-calendar.ts
@@ -4,7 +4,6 @@ import {
   calendarAuthorizationStatus,
   dayRange,
   displayEvents,
-  hasBridge,
   listCalendarEvents,
   listCalendars,
   subscribeCalendarChanged,
@@ -13,6 +12,7 @@ import {
   type CalendarAuthorizationStatus,
   type Unlisten,
 } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { isMacosDesktop } from '@/lib/platform'
 import { useSettings } from '@/providers/settings-provider'
 
@@ -30,8 +30,8 @@ export const CALENDAR_AUTH_QUERY_KEY = ['calendar', 'authorization'] as const
 export const CALENDAR_LIST_QUERY_KEY = ['calendar', 'calendars'] as const
 
 /** Whether calendar queries can run at all in this environment. */
-export function calendarAvailable(): boolean {
-  return hasBridge() && isMacosDesktop
+function useCalendarAvailable(): boolean {
+  return useHasBridge() && isMacosDesktop
 }
 
 /**
@@ -45,10 +45,11 @@ export function calendarAvailable(): boolean {
 export function useCalendarAuthorization(
   enabled: boolean,
 ): CalendarAuthorizationStatus | undefined {
+  const available = useCalendarAvailable()
   const query = useQuery({
     queryKey: CALENDAR_AUTH_QUERY_KEY,
     queryFn: calendarAuthorizationStatus,
-    enabled: enabled && calendarAvailable(),
+    enabled: enabled && available,
     staleTime: 0,
     refetchOnWindowFocus: 'always',
   })
@@ -66,10 +67,11 @@ export interface CalendarsResult {
 
 /** Every calendar on the Mac, for the Settings section's checkbox list. */
 export function useCalendars(enabled: boolean): CalendarsResult {
+  const available = useCalendarAvailable()
   const query = useQuery({
     queryKey: CALENDAR_LIST_QUERY_KEY,
     queryFn: listCalendars,
-    enabled: enabled && calendarAvailable(),
+    enabled: enabled && available,
   })
   return useMemo(
     () => ({ calendars: query.data ?? [], isLoaded: query.isSuccess }),
@@ -85,7 +87,8 @@ export function useCalendars(enabled: boolean): CalendarsResult {
  */
 export function useDayEvents(date: string): CalendarEvent[] {
   const { settings } = useSettings()
-  const enabled = settings.calendarEnabled && settings.calendarIds.length > 0 && calendarAvailable()
+  const available = useCalendarAvailable()
+  const enabled = settings.calendarEnabled && settings.calendarIds.length > 0 && available
   const query = useQuery({
     queryKey: ['calendar', 'events', date, settings.calendarIds],
     queryFn: () => {
@@ -108,8 +111,9 @@ export function useDayEvents(date: string): CalendarEvent[] {
  */
 export function useCalendarChangeInvalidation(enabled: boolean): void {
   const queryClient = useQueryClient()
+  const available = useCalendarAvailable()
   useEffect(() => {
-    if (!enabled || !calendarAvailable()) {
+    if (!enabled || !available) {
       return
     }
     let unlisten: Unlisten | null = null
@@ -127,5 +131,5 @@ export function useCalendarChangeInvalidation(enabled: boolean): void {
       disposed = true
       unlisten?.()
     }
-  }, [enabled, queryClient])
+  }, [available, enabled, queryClient])
 }

--- a/apps/desktop/src/lib/use-embed-status.ts
+++ b/apps/desktop/src/lib/use-embed-status.ts
@@ -1,16 +1,18 @@
 import { useEffect, useState } from 'react'
-import { embedStatus, hasBridge, subscribeEmbedStatus, type EmbedStatus } from '@reflect/core'
+import { embedStatus, subscribeEmbedStatus, type EmbedStatus } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 
 /**
  * The embedding runtime's live status (Plan 09). Polls once on mount, then
- * tracks `embed:status` events. Without a bridge (browser dev) semantic
+ * tracks `embed:status` events. Without a bridge (`?platform=none`) semantic
  * features stay in `uninitialized` — i.e. invisible.
  */
 export function useEmbedStatus(): EmbedStatus {
   const [status, setStatus] = useState<EmbedStatus>({ status: 'uninitialized' })
+  const bridgeReady = useHasBridge()
 
   useEffect(() => {
-    if (!hasBridge()) {
+    if (!bridgeReady) {
       return
     }
     let active = true
@@ -35,7 +37,7 @@ export function useEmbedStatus(): EmbedStatus {
       active = false
       unlisten?.()
     }
-  }, [])
+  }, [bridgeReady])
 
   return status
 }

--- a/apps/desktop/src/lib/use-embed-status.ts
+++ b/apps/desktop/src/lib/use-embed-status.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { embedStatus, subscribeEmbedStatus, type EmbedStatus } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 
 /**
  * The embedding runtime's live status (Plan 09). Polls once on mount, then
@@ -9,7 +9,7 @@ import { useHasBridge } from '@/hooks/use-has-bridge'
  */
 export function useEmbedStatus(): EmbedStatus {
   const [status, setStatus] = useState<EmbedStatus>({ status: 'uninitialized' })
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
 
   useEffect(() => {
     if (!bridgeReady) {

--- a/apps/desktop/src/lib/use-file-changes.ts
+++ b/apps/desktop/src/lib/use-file-changes.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
-import { hasBridge, subscribeFileChanges, type FileChange } from '@reflect/core'
+import { subscribeFileChanges, type FileChange } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 
 /**
  * Subscribe to the watcher's file-change events (Plan 04b) for the lifetime of
@@ -17,8 +18,9 @@ import { hasBridge, subscribeFileChanges, type FileChange } from '@reflect/core'
  * Pass `null` to disable.
  */
 export function useFileChanges(handler: ((changes: FileChange[]) => void) | null): void {
+  const bridgeReady = useHasBridge()
   useEffect(() => {
-    if (handler === null || !hasBridge()) {
+    if (handler === null || !bridgeReady) {
       return
     }
     let active = true
@@ -44,5 +46,5 @@ export function useFileChanges(handler: ((changes: FileChange[]) => void) | null
       active = false
       unlisten?.()
     }
-  }, [handler])
+  }, [bridgeReady, handler])
 }

--- a/apps/desktop/src/lib/use-file-changes.ts
+++ b/apps/desktop/src/lib/use-file-changes.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { subscribeFileChanges, type FileChange } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 
 /**
  * Subscribe to the watcher's file-change events (Plan 04b) for the lifetime of
@@ -18,7 +18,7 @@ import { useHasBridge } from '@/hooks/use-has-bridge'
  * Pass `null` to disable.
  */
 export function useFileChanges(handler: ((changes: FileChange[]) => void) | null): void {
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   useEffect(() => {
     if (handler === null || !bridgeReady) {
       return

--- a/apps/desktop/src/lib/use-similar-notes.ts
+++ b/apps/desktop/src/lib/use-similar-notes.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { hasBridge, isDaily, relatedNotes, type RetrievalHit } from '@reflect/core'
+import { isDaily, relatedNotes, type RetrievalHit } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { readNoteSource } from '@/lib/note-frontmatter'
 import { isOstensiblyEmptyNoteSource } from '@/lib/note-emptiness'
 import { INDEX_QUERY_SCOPE, SIMILAR_QUERY_SCOPE } from '@/lib/query-client'
@@ -43,7 +44,7 @@ export function useSimilarNotes(path: string): RetrievalHit[] {
   const { graph } = useGraph()
   const { settings } = useSettings()
   const queryClient = useQueryClient()
-  const bridgeAvailable = hasBridge()
+  const bridgeAvailable = useHasBridge()
   const dailyNote = isDaily(path)
   const { data: dailyNoteIsEmpty } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'daily-empty', path],

--- a/apps/desktop/src/lib/use-similar-notes.ts
+++ b/apps/desktop/src/lib/use-similar-notes.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { isDaily, relatedNotes, type RetrievalHit } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { readNoteSource } from '@/lib/note-frontmatter'
 import { isOstensiblyEmptyNoteSource } from '@/lib/note-emptiness'
 import { INDEX_QUERY_SCOPE, SIMILAR_QUERY_SCOPE } from '@/lib/query-client'
@@ -44,7 +44,7 @@ export function useSimilarNotes(path: string): RetrievalHit[] {
   const { graph } = useGraph()
   const { settings } = useSettings()
   const queryClient = useQueryClient()
-  const bridgeAvailable = useHasBridge()
+  const bridgeAvailable = useBridgeReady()
   const dailyNote = isDaily(path)
   const { data: dailyNoteIsEmpty } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'daily-empty', path],

--- a/apps/desktop/src/mobile/chat-history-drawer.tsx
+++ b/apps/desktop/src/mobile/chat-history-drawer.tsx
@@ -4,7 +4,7 @@ import { formatDistanceToNow } from 'date-fns'
 import { listChatConversations } from '@reflect/core'
 import { Check, Trash2 } from 'lucide-react'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { CHAT_QUERY_SCOPE } from '@/lib/query-client'
 import { useChatSession } from '@/providers/chat-provider'
 import { useGraph } from '@/providers/graph-provider'
@@ -25,7 +25,7 @@ export function ChatHistoryDrawer({ open, onOpenChange }: ChatHistoryDrawerProps
   const { graph, indexGeneration } = useGraph()
   const { activeConversationId, openConversation, deleteConversation } = useChatSession()
 
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const enabled = bridgeReady && indexGeneration !== null
   const { data: conversations } = useQuery({
     // The graph root is part of the key: conversations belong to one graph,

--- a/apps/desktop/src/mobile/chat-history-drawer.tsx
+++ b/apps/desktop/src/mobile/chat-history-drawer.tsx
@@ -1,9 +1,10 @@
 import type { ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
-import { hasBridge, listChatConversations } from '@reflect/core'
+import { listChatConversations } from '@reflect/core'
 import { Check, Trash2 } from 'lucide-react'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { CHAT_QUERY_SCOPE } from '@/lib/query-client'
 import { useChatSession } from '@/providers/chat-provider'
 import { useGraph } from '@/providers/graph-provider'
@@ -24,7 +25,8 @@ export function ChatHistoryDrawer({ open, onOpenChange }: ChatHistoryDrawerProps
   const { graph, indexGeneration } = useGraph()
   const { activeConversationId, openConversation, deleteConversation } = useChatSession()
 
-  const enabled = hasBridge() && indexGeneration !== null
+  const bridgeReady = useHasBridge()
+  const enabled = bridgeReady && indexGeneration !== null
   const { data: conversations } = useQuery({
     // The graph root is part of the key: conversations belong to one graph,
     // and a graph switch must never serve the previous graph's cached list.

--- a/apps/desktop/src/mobile/screens/all-notes.tsx
+++ b/apps/desktop/src/mobile/screens/all-notes.tsx
@@ -11,7 +11,7 @@ import {
 } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { FilterBar } from '@/mobile/search-filters/filter-bar'
 import {
@@ -80,7 +80,7 @@ export function MobileAllNotes({
 }: MobileAllNotesProps): ReactElement {
   const { graph } = useGraph()
   const { navigate, back, arrivalSeq, arrivalFocusEditor } = useRouter()
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const enabled = bridgeReady && graph !== null
 
   // The All-tab double-tap (`focusEditor` arrivals) lands in the search bar,

--- a/apps/desktop/src/mobile/screens/all-notes.tsx
+++ b/apps/desktop/src/mobile/screens/all-notes.tsx
@@ -3,7 +3,6 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { ChevronLeft, FileText, SearchX } from 'lucide-react'
 import {
   foldTag,
-  hasBridge,
   listNoteTags,
   parseHighlights,
   searchWithFilters,
@@ -12,6 +11,7 @@ import {
 } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { FilterBar } from '@/mobile/search-filters/filter-bar'
 import {
@@ -80,7 +80,8 @@ export function MobileAllNotes({
 }: MobileAllNotesProps): ReactElement {
   const { graph } = useGraph()
   const { navigate, back, arrivalSeq, arrivalFocusEditor } = useRouter()
-  const enabled = hasBridge() && graph !== null
+  const bridgeReady = useHasBridge()
+  const enabled = bridgeReady && graph !== null
 
   // The All-tab double-tap (`focusEditor` arrivals) lands in the search bar,
   // the tab's capture surface — the daily double-tap's All-flavored twin.

--- a/apps/desktop/src/mobile/screens/graphs.tsx
+++ b/apps/desktop/src/mobile/screens/graphs.tsx
@@ -4,7 +4,7 @@ import { Plus } from 'lucide-react'
 import { errorMessage, mobileStorage, type MobileStorageKind } from '@reflect/core'
 import { InlineAlert } from '@/components/inline-alert'
 import { Spinner } from '@/components/ui/spinner'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { graphNameFromRoot } from '@/lib/graph-names'
 import { NewGraphDrawer } from '@/mobile/new-graph-drawer'
 import { MobileScreenHeader } from '@/mobile/screen-header'
@@ -30,7 +30,7 @@ export function MobileGraphs(): ReactElement {
   const [switchError, setSwitchError] = useState<string | null>(null)
   const [createOpen, setCreateOpen] = useState(false)
 
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const { data: storage } = useQuery({
     queryKey: ['mobile-storage'],
     queryFn: mobileStorage,

--- a/apps/desktop/src/mobile/screens/graphs.tsx
+++ b/apps/desktop/src/mobile/screens/graphs.tsx
@@ -1,9 +1,10 @@
 import { useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Plus } from 'lucide-react'
-import { errorMessage, hasBridge, mobileStorage, type MobileStorageKind } from '@reflect/core'
+import { errorMessage, mobileStorage, type MobileStorageKind } from '@reflect/core'
 import { InlineAlert } from '@/components/inline-alert'
 import { Spinner } from '@/components/ui/spinner'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { graphNameFromRoot } from '@/lib/graph-names'
 import { NewGraphDrawer } from '@/mobile/new-graph-drawer'
 import { MobileScreenHeader } from '@/mobile/screen-header'
@@ -29,10 +30,11 @@ export function MobileGraphs(): ReactElement {
   const [switchError, setSwitchError] = useState<string | null>(null)
   const [createOpen, setCreateOpen] = useState(false)
 
+  const bridgeReady = useHasBridge()
   const { data: storage } = useQuery({
     queryKey: ['mobile-storage'],
     queryFn: mobileStorage,
-    enabled: hasBridge(),
+    enabled: bridgeReady,
     refetchOnMount: 'always',
   })
 

--- a/apps/desktop/src/mobile/screens/settings.tsx
+++ b/apps/desktop/src/mobile/screens/settings.tsx
@@ -4,7 +4,6 @@ import {
   aiProvider,
   aiProviderRequiresApiKey,
   errorMessage,
-  hasBridge,
   listNotes,
   normalizeChatSystemPrompt,
   type AiPrompt,
@@ -16,6 +15,7 @@ import { openUrl } from '@tauri-apps/plugin-opener'
 import { useAiPrompts } from '@/hooks/use-ai-prompts'
 import { useAiProviders } from '@/hooks/use-ai-providers'
 import { useAppVersion } from '@/hooks/use-app-version'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { marketingVersion } from '@/lib/marketing-version'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { AddAiProviderDrawer } from '@/mobile/add-ai-provider-drawer'
@@ -96,10 +96,11 @@ export function MobileSettings(): ReactElement {
   const [managedProvider, setManagedProvider] = useState<AiProviderConfig | null>(null)
   const [manageOpen, setManageOpen] = useState(false)
 
+  const bridgeReady = useHasBridge()
   const { data: notes } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'mobile-note-count'],
     queryFn: () => listNotes(),
-    enabled: hasBridge() && graph !== null,
+    enabled: bridgeReady && graph !== null,
   })
 
   const backup = sync?.backup ?? null

--- a/apps/desktop/src/mobile/screens/settings.tsx
+++ b/apps/desktop/src/mobile/screens/settings.tsx
@@ -15,7 +15,7 @@ import { openUrl } from '@tauri-apps/plugin-opener'
 import { useAiPrompts } from '@/hooks/use-ai-prompts'
 import { useAiProviders } from '@/hooks/use-ai-providers'
 import { useAppVersion } from '@/hooks/use-app-version'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { marketingVersion } from '@/lib/marketing-version'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { AddAiProviderDrawer } from '@/mobile/add-ai-provider-drawer'
@@ -96,7 +96,7 @@ export function MobileSettings(): ReactElement {
   const [managedProvider, setManagedProvider] = useState<AiProviderConfig | null>(null)
   const [manageOpen, setManageOpen] = useState(false)
 
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const { data: notes } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'mobile-note-count'],
     queryFn: () => listNotes(),

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -4,7 +4,7 @@ import { Archive, CircleCheck, Plus, SlidersHorizontal } from 'lucide-react'
 import { getCompletedTasks, getOpenTasks, type OpenTask } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { useRecentlyCompleted } from '@/lib/tasks/recently-completed'
 import { taskKey } from '@/lib/tasks/task-identity'
 import { useTaskFilters } from '@/lib/tasks/task-filters'
@@ -52,7 +52,7 @@ export function MobileTasks(): ReactElement {
   // Whether the current sheet visit should open with the editor focused
   // (keyboard up) — set per visit: true for "+"-added tasks, false for row taps.
   const [autoFocusEditor, setAutoFocusEditor] = useState(false)
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const enabled = bridgeReady && graph !== null
 
   // The Tasks-tab double-tap lands in the tab's capture surface: its live

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -1,9 +1,10 @@
 import { useDeferredValue, useMemo, useRef, useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Archive, CircleCheck, Plus, SlidersHorizontal } from 'lucide-react'
-import { getCompletedTasks, getOpenTasks, hasBridge, type OpenTask } from '@reflect/core'
+import { getCompletedTasks, getOpenTasks, type OpenTask } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { useRecentlyCompleted } from '@/lib/tasks/recently-completed'
 import { taskKey } from '@/lib/tasks/task-identity'
 import { useTaskFilters } from '@/lib/tasks/task-filters'
@@ -51,7 +52,8 @@ export function MobileTasks(): ReactElement {
   // Whether the current sheet visit should open with the editor focused
   // (keyboard up) — set per visit: true for "+"-added tasks, false for row taps.
   const [autoFocusEditor, setAutoFocusEditor] = useState(false)
-  const enabled = hasBridge() && graph !== null
+  const bridgeReady = useHasBridge()
+  const enabled = bridgeReady && graph !== null
 
   // The Tasks-tab double-tap lands in the tab's capture surface: its live
   // search filter, selected so a replacement query can start immediately.

--- a/apps/desktop/src/mobile/search-filters/note-picker-drawer.tsx
+++ b/apps/desktop/src/mobile/search-filters/note-picker-drawer.tsx
@@ -3,7 +3,7 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { parseSearchQuery, searchWithFilters } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { SearchInput } from '@/mobile/search-input'
 import { useGraph } from '@/providers/graph-provider'
@@ -37,7 +37,7 @@ export function NotePickerDrawer({
   const [query, setQuery] = useState('')
   const deferredQuery = useDeferredValue(query)
 
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const { data: hits } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'mobile-note-picker', deferredQuery],
     queryFn: () => searchWithFilters(parseSearchQuery(deferredQuery), { limit: PICKER_LIMIT }),

--- a/apps/desktop/src/mobile/search-filters/note-picker-drawer.tsx
+++ b/apps/desktop/src/mobile/search-filters/note-picker-drawer.tsx
@@ -1,8 +1,9 @@
 import { useDeferredValue, useState, type ReactElement } from 'react'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
-import { hasBridge, parseSearchQuery, searchWithFilters } from '@reflect/core'
+import { parseSearchQuery, searchWithFilters } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { SearchInput } from '@/mobile/search-input'
 import { useGraph } from '@/providers/graph-provider'
@@ -36,10 +37,11 @@ export function NotePickerDrawer({
   const [query, setQuery] = useState('')
   const deferredQuery = useDeferredValue(query)
 
+  const bridgeReady = useHasBridge()
   const { data: hits } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'mobile-note-picker', deferredQuery],
     queryFn: () => searchWithFilters(parseSearchQuery(deferredQuery), { limit: PICKER_LIMIT }),
-    enabled: open && hasBridge() && graph !== null,
+    enabled: open && bridgeReady && graph !== null,
     // Typing re-keys the query as the deferred value settles; holding the
     // previous rows avoids a "No matches" flash between keystrokes.
     placeholderData: keepPreviousData,

--- a/apps/desktop/src/mobile/use-daily-note-dates.ts
+++ b/apps/desktop/src/mobile/use-daily-note-dates.ts
@@ -1,14 +1,14 @@
 import { useMemo } from 'react'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { dailyDatesInRange } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 
 /** Indexed daily-note dates in an inclusive range, ready for calendar lookup. */
 export function useDailyNoteDates(start: string, end: string): ReadonlySet<string> {
   const { graph } = useGraph()
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const { data } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'dailyDates', start, end],
     queryFn: () => dailyDatesInRange(start, end),

--- a/apps/desktop/src/mobile/use-daily-note-dates.ts
+++ b/apps/desktop/src/mobile/use-daily-note-dates.ts
@@ -1,16 +1,18 @@
 import { useMemo } from 'react'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
-import { dailyDatesInRange, hasBridge } from '@reflect/core'
+import { dailyDatesInRange } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 
 /** Indexed daily-note dates in an inclusive range, ready for calendar lookup. */
 export function useDailyNoteDates(start: string, end: string): ReadonlySet<string> {
   const { graph } = useGraph()
+  const bridgeReady = useHasBridge()
   const { data } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'dailyDates', start, end],
     queryFn: () => dailyDatesInRange(start, end),
-    enabled: hasBridge() && graph !== null,
+    enabled: bridgeReady && graph !== null,
     placeholderData: keepPreviousData,
   })
 

--- a/apps/desktop/src/mobile/use-icloud-refresh.ts
+++ b/apps/desktop/src/mobile/use-icloud-refresh.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
-import { errorMessage, hasBridge, icloudDownloadPending, icloudPendingCount } from '@reflect/core'
+import { errorMessage, icloudDownloadPending, icloudPendingCount } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { useGraph } from '@/providers/graph-provider'
 
 /**
@@ -53,9 +54,10 @@ const PENDING_POLL_LIMIT_MS = 20_000
 export function useICloudRefresh(): void {
   const { graph, mobileStorageKind, refreshIndex } = useGraph()
   const root = mobileStorageKind === 'icloud' ? (graph?.root ?? null) : null
+  const bridgeReady = useHasBridge()
 
   useEffect(() => {
-    if (root === null || !hasBridge()) {
+    if (root === null || !bridgeReady) {
       return
     }
     let disposed = false
@@ -180,5 +182,5 @@ export function useICloudRefresh(): void {
       window.removeEventListener('focus', onResume)
       document.removeEventListener('visibilitychange', onVisibilityChange)
     }
-  }, [root, refreshIndex])
+  }, [bridgeReady, root, refreshIndex])
 }

--- a/apps/desktop/src/mobile/use-icloud-refresh.ts
+++ b/apps/desktop/src/mobile/use-icloud-refresh.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { errorMessage, icloudDownloadPending, icloudPendingCount } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { useGraph } from '@/providers/graph-provider'
 
 /**
@@ -54,7 +54,7 @@ const PENDING_POLL_LIMIT_MS = 20_000
 export function useICloudRefresh(): void {
   const { graph, mobileStorageKind, refreshIndex } = useGraph()
   const root = mobileStorageKind === 'icloud' ? (graph?.root ?? null) : null
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
 
   useEffect(() => {
     if (root === null || !bridgeReady) {

--- a/apps/desktop/src/mobile/use-sync-status.ts
+++ b/apps/desktop/src/mobile/use-sync-status.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
-import { getConflictedNotes, hasBridge } from '@reflect/core'
+import { getConflictedNotes } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { mobileSyncStatus, type MobileSyncStatus } from '@/mobile/sync-status'
 import { useGraph } from '@/providers/graph-provider'
@@ -22,10 +23,11 @@ export function useMobileSyncStatus(): MobileSyncStatus | null {
   const backup = sync?.backup ?? null
   const connected = backup !== null && backup.phase === 'connected'
 
+  const bridgeReady = useHasBridge()
   const { data: conflicted, isError: countUnavailable } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'conflicted-notes'],
     queryFn: getConflictedNotes,
-    enabled: hasBridge() && graph !== null && connected,
+    enabled: bridgeReady && graph !== null && connected,
   })
 
   // Loading hides the status (no flip); a *failed* count must not — the

--- a/apps/desktop/src/mobile/use-sync-status.ts
+++ b/apps/desktop/src/mobile/use-sync-status.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { getConflictedNotes } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { mobileSyncStatus, type MobileSyncStatus } from '@/mobile/sync-status'
 import { useGraph } from '@/providers/graph-provider'
@@ -23,7 +23,7 @@ export function useMobileSyncStatus(): MobileSyncStatus | null {
   const backup = sync?.backup ?? null
   const connected = backup !== null && backup.phase === 'connected'
 
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const { data: conflicted, isError: countUnavailable } = useQuery({
     queryKey: [INDEX_QUERY_SCOPE, graph?.root, 'conflicted-notes'],
     queryFn: getConflictedNotes,

--- a/apps/desktop/src/platform-root.tsx
+++ b/apps/desktop/src/platform-root.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useEffect, useState, type ReactElement } from 'react'
 import { getAppPlatform, hasBridge, isMobilePlatform, type AppPlatform } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { warmMobileStorage } from '@/lib/mobile-boot-warm'
 
 const DesktopRoot = lazy(() =>
@@ -70,8 +71,8 @@ function readDevPlatformOverride(): DevPlatformOverride | null {
  * `pnpm dev` in a browser gets the desktop tree over the dev bridge by
  * default — an un-flagged tab boots into a seeded, workable graph instead of
  * a bridgeless empty chooser. Whether a *real* shell is present is decided at
- * the call site via `hasBridge()`: the Tauri bridge installs before the first
- * render, so a bridge at mount time means Tauri, not this harness.
+ * the call site via the bridge state: the Tauri bridge installs before the
+ * first render, so a bridge at mount time means Tauri, not this harness.
  */
 function devBridgePlatform(): AppPlatform | null {
   if (!import.meta.env.DEV || devPlatformOverride === 'none') {
@@ -89,20 +90,23 @@ function devBridgePlatform(): AppPlatform | null {
  * bridgeless). Dev builds only — production always has the Tauri bridge.
  */
 export function PlatformRoot(): ReactElement {
+  // This component drives the install itself, so it reads the reactive value
+  // once per render rather than sampling `hasBridge()` mid-render.
+  const bridgeReady = useHasBridge()
   // Hold the blank frame while the dev bridge chunk loads in plain-browser
   // dev; render the desktop tree directly when bridgeless (`?platform=none`,
   // production-in-browser). With a bridge, resolve the real platform.
   const [platform, setPlatform] = useState<AppPlatform | null>(() => {
-    if (devBridgePlatform() !== null && !hasBridge()) {
+    if (devBridgePlatform() !== null && !bridgeReady) {
       return null
     }
-    return hasBridge() ? null : 'desktop'
+    return bridgeReady ? null : 'desktop'
   })
 
   useEffect(() => {
     let active = true
     const devPlatform = devBridgePlatform()
-    if (devPlatform !== null && !hasBridge()) {
+    if (devPlatform !== null && !bridgeReady) {
       void import('@/dev/install-dev-bridge')
         .then(async (module) => {
           await module.installDevBridge(devPlatform)
@@ -122,7 +126,7 @@ export function PlatformRoot(): ReactElement {
         active = false
       }
     }
-    if (!hasBridge()) {
+    if (!bridgeReady) {
       return
     }
     void resolveAppPlatform().then((resolved) => {
@@ -133,7 +137,7 @@ export function PlatformRoot(): ReactElement {
     return () => {
       active = false
     }
-  }, [])
+  }, [bridgeReady])
 
   if (platform === null) {
     return <div className="h-screen w-screen" />

--- a/apps/desktop/src/platform-root.tsx
+++ b/apps/desktop/src/platform-root.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useState, type ReactElement } from 'react'
 import { getAppPlatform, hasBridge, isMobilePlatform, type AppPlatform } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { warmMobileStorage } from '@/lib/mobile-boot-warm'
 
 const DesktopRoot = lazy(() =>
@@ -92,7 +92,7 @@ function devBridgePlatform(): AppPlatform | null {
 export function PlatformRoot(): ReactElement {
   // This component drives the install itself, so it reads the reactive value
   // once per render rather than sampling `hasBridge()` mid-render.
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   // Hold the blank frame while the dev bridge chunk loads in plain-browser
   // dev; render the desktop tree directly when bridgeless (`?platform=none`,
   // production-in-browser). With a bridge, resolve the real platform.

--- a/apps/desktop/src/platform-root.tsx
+++ b/apps/desktop/src/platform-root.tsx
@@ -47,32 +47,53 @@ export function warmPlatformRoot(): void {
   })
 }
 
-// Dev-only escape hatch: `?platform=ios` (or `android`) in a plain browser
-// forces the mobile tree, backed by the in-memory dev bridge, so mobile UI
-// work is visible without an iOS build. Statically false in production
-// builds, so the check and the dev-bridge chunk are both dead code there.
-const devPlatformOverride: AppPlatform | null = import.meta.env.DEV
+// Dev-only `?platform=` override for the plain-browser harness: `ios` (or
+// `android`) forces the mobile tree over the dev bridge, so mobile UI work is
+// visible without an iOS build; `none` opts out of the dev bridge entirely,
+// reproducing the bridgeless render for gate debugging. Statically false in
+// production builds, so the check and the dev-bridge chunk are both dead code
+// there.
+type DevPlatformOverride = AppPlatform | 'none'
+
+const devPlatformOverride: DevPlatformOverride | null = import.meta.env.DEV
   ? readDevPlatformOverride()
   : null
 
-function readDevPlatformOverride(): AppPlatform | null {
+function readDevPlatformOverride(): DevPlatformOverride | null {
   const requested = new URLSearchParams(window.location.search).get('platform')
-  return requested === 'ios' || requested === 'android' ? requested : null
+  return requested === 'ios' || requested === 'android' || requested === 'none' ? requested : null
+}
+
+/**
+ * The platform the in-browser dev bridge should emulate, or null when it must
+ * not install (production build, or the `?platform=none` opt-out). Plain
+ * `pnpm dev` in a browser gets the desktop tree over the dev bridge by
+ * default — an un-flagged tab boots into a seeded, workable graph instead of
+ * a bridgeless empty chooser. Whether a *real* shell is present is decided at
+ * the call site via `hasBridge()`: the Tauri bridge installs before the first
+ * render, so a bridge at mount time means Tauri, not this harness.
+ */
+function devBridgePlatform(): AppPlatform | null {
+  if (!import.meta.env.DEV || devPlatformOverride === 'none') {
+    return null
+  }
+  return devPlatformOverride ?? 'desktop'
 }
 
 /**
  * The Plan 19 root gate: one bundle, two surface trees. The shell reports
  * which platform it was built for and the matching tree loads as a lazy
  * chunk — desktop chrome never reaches the mobile critical path, and vice
- * versa. Plain-browser dev (no Tauri bridge) gets the desktop tree, unless
- * `?platform=ios` forces the mobile tree over the dev bridge (dev builds only).
+ * versa. Plain-browser dev boots the desktop tree over the in-memory dev
+ * bridge (or the mobile tree with `?platform=ios`; `?platform=none` renders
+ * bridgeless). Dev builds only — production always has the Tauri bridge.
  */
 export function PlatformRoot(): ReactElement {
-  // Plain-browser dev has no bridge — start on the desktop tree directly
-  // (or hold the blank frame while the dev bridge chunk loads when a dev
-  // platform override is active). With a bridge, resolve the real platform.
+  // Hold the blank frame while the dev bridge chunk loads in plain-browser
+  // dev; render the desktop tree directly when bridgeless (`?platform=none`,
+  // production-in-browser). With a bridge, resolve the real platform.
   const [platform, setPlatform] = useState<AppPlatform | null>(() => {
-    if (import.meta.env.DEV && devPlatformOverride !== null && !hasBridge()) {
+    if (devBridgePlatform() !== null && !hasBridge()) {
       return null
     }
     return hasBridge() ? null : 'desktop'
@@ -80,12 +101,13 @@ export function PlatformRoot(): ReactElement {
 
   useEffect(() => {
     let active = true
-    if (import.meta.env.DEV && devPlatformOverride !== null && !hasBridge()) {
+    const devPlatform = devBridgePlatform()
+    if (devPlatform !== null && !hasBridge()) {
       void import('@/dev/install-dev-bridge')
         .then(async (module) => {
-          await module.installDevBridge(devPlatformOverride)
+          await module.installDevBridge(devPlatform)
           if (active) {
-            setPlatform(devPlatformOverride)
+            setPlatform(devPlatform)
           }
         })
         .catch((cause: unknown) => {

--- a/apps/desktop/src/providers/capture-provider.test.tsx
+++ b/apps/desktop/src/providers/capture-provider.test.tsx
@@ -17,7 +17,12 @@ const hasBridge = vi.hoisted(() => vi.fn(() => true))
 const isMobileSurface = vi.hoisted(() => vi.fn(() => false))
 
 vi.mock('@/lib/capture-controller', () => ({ createCaptureController }))
-vi.mock('@reflect/core', () => ({ captureHostRegister, captureSharedInboxRelay, hasBridge }))
+vi.mock('@reflect/core', () => ({
+  captureHostRegister,
+  captureSharedInboxRelay,
+  hasBridge,
+  subscribeBridgeChanges: () => () => {},
+}))
 vi.mock('@/lib/platform-surface', () => ({ isMobileSurface }))
 vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({

--- a/apps/desktop/src/providers/capture-provider.tsx
+++ b/apps/desktop/src/providers/capture-provider.tsx
@@ -2,10 +2,10 @@ import { useEffect, useRef, type ReactElement, type ReactNode } from 'react'
 import {
   captureHostRegister,
   captureSharedInboxRelay,
-  hasBridge,
   type AiProvidersState,
   type GraphInfo,
 } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { useMainWindowEffect } from '@/hooks/use-main-window-effect'
 import { createCaptureController } from '@/lib/capture-controller'
 import { isMobileSurface } from '@/lib/platform-surface'
@@ -47,6 +47,7 @@ export function CaptureProvider({ graph, children }: CaptureProviderProps): Reac
 
   // One drain per app: a secondary note window running its own would race
   // the main window's over the same spooled envelopes.
+  const bridgeReady = useHasBridge()
   useMainWindowEffect(() => {
     const mobile = isMobileSurface()
     const controller = createCaptureController({
@@ -65,7 +66,7 @@ export function CaptureProvider({ graph, children }: CaptureProviderProps): Reac
     // "host not found" with install guidance on its side. Mobile has no host
     // process at all: the share extension finds the App Group inbox itself.
     const registered =
-      hasBridge() && !mobile
+      bridgeReady && !mobile
         ? captureHostRegister().catch((cause: unknown) => {
             console.error('capture host registration failed:', cause)
           })
@@ -76,7 +77,7 @@ export function CaptureProvider({ graph, children }: CaptureProviderProps): Reac
     return () => {
       controller.dispose()
     }
-  }, [graph.generation])
+  }, [bridgeReady, graph.generation])
 
   return <>{children}</>
 }

--- a/apps/desktop/src/providers/capture-provider.tsx
+++ b/apps/desktop/src/providers/capture-provider.tsx
@@ -5,7 +5,7 @@ import {
   type AiProvidersState,
   type GraphInfo,
 } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { useMainWindowEffect } from '@/hooks/use-main-window-effect'
 import { createCaptureController } from '@/lib/capture-controller'
 import { isMobileSurface } from '@/lib/platform-surface'
@@ -47,7 +47,7 @@ export function CaptureProvider({ graph, children }: CaptureProviderProps): Reac
 
   // One drain per app: a secondary note window running its own would race
   // the main window's over the same spooled envelopes.
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   useMainWindowEffect(() => {
     const mobile = isMobileSurface()
     const controller = createCaptureController({

--- a/apps/desktop/src/providers/chat-provider.tsx
+++ b/apps/desktop/src/providers/chat-provider.tsx
@@ -29,7 +29,7 @@ import {
   type ChatTurn,
   type GraphInfo,
 } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { toChatAttachment, type ChatAttachment } from '@/lib/chat-attachments'
 import { todayIso } from '@/lib/dates'
 import { isMobileSurface } from '@/lib/platform-surface'
@@ -70,7 +70,7 @@ interface ChatProviderProps {
 export function ChatProvider({ graph, children }: ChatProviderProps): ReactElement {
   const { settings, updateSettings } = useSettings()
   const { indexGeneration } = useGraph()
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const [turns, setTurns] = useState<ChatTurn[]>([])
   const [draft, setDraft] = useState('')
   const [attachments, setAttachments] = useState<ChatAttachment[]>([])

--- a/apps/desktop/src/providers/chat-provider.tsx
+++ b/apps/desktop/src/providers/chat-provider.tsx
@@ -29,6 +29,7 @@ import {
   type ChatTurn,
   type GraphInfo,
 } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { toChatAttachment, type ChatAttachment } from '@/lib/chat-attachments'
 import { todayIso } from '@/lib/dates'
 import { isMobileSurface } from '@/lib/platform-surface'
@@ -69,6 +70,7 @@ interface ChatProviderProps {
 export function ChatProvider({ graph, children }: ChatProviderProps): ReactElement {
   const { settings, updateSettings } = useSettings()
   const { indexGeneration } = useGraph()
+  const bridgeReady = useHasBridge()
   const [turns, setTurns] = useState<ChatTurn[]>([])
   const [draft, setDraft] = useState('')
   const [attachments, setAttachments] = useState<ChatAttachment[]>([])
@@ -151,6 +153,8 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
   const persistTurn = useCallback(
     (conversation: ChatConversation, turn: ChatTurn, createdMs: number) => {
       const generation = generationRef.current
+      // Call-time check on purpose — saves fire from user actions, so they
+      // read the live bridge state instead of a captured render value.
       if (
         !hasBridge() ||
         generation === null ||
@@ -181,7 +185,7 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
   // stays in the history). Guarded against races: by the time the rows
   // arrive the user may have started typing into the fresh conversation.
   useEffect(() => {
-    if (!hasBridge() || indexGeneration === null) {
+    if (!bridgeReady || indexGeneration === null) {
       return
     }
     const session = sessionRef.current
@@ -205,7 +209,7 @@ export function ChatProvider({ graph, children }: ChatProviderProps): ReactEleme
     return () => {
       active = false
     }
-  }, [indexGeneration])
+  }, [bridgeReady, indexGeneration])
 
   const send = useCallback(
     async (text: string): Promise<void> => {

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -499,6 +499,9 @@ export function GraphProvider({
   // be expressed as per-file events; the watcher asks for one full reconcile
   // instead, and `refresh` coalesces bursts into a single queued rerun.
   useEffect(() => {
+    if (!hasBridge()) {
+      return // bridgeless browser dev — no native event stream to subscribe to
+    }
     let unlisten: (() => void) | null = null
     let disposed = false
     void subscribeReconcileRequests(() => refreshIndex()).then(

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -27,7 +27,7 @@ import {
 } from '@reflect/core'
 import { followHealedMove } from '@/editor/move-note'
 import { resetNoteRowOverlays } from '@/hooks/note-row-overlay'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { setIndexProgress } from '@/lib/index-progress'
 import {
   dropIcloudStatusQuery,
@@ -139,7 +139,7 @@ export function GraphProvider({
   children: ReactNode
   platform?: AppPlatform
 }) {
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const [status, setStatus] = useState<GraphStatus>('loading')
   const [graph, setGraph] = useState<GraphInfo | null>(null)
   const [recents, setRecents] = useState<RecentGraph[]>([])

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -27,6 +27,7 @@ import {
 } from '@reflect/core'
 import { followHealedMove } from '@/editor/move-note'
 import { resetNoteRowOverlays } from '@/hooks/note-row-overlay'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { setIndexProgress } from '@/lib/index-progress'
 import {
   dropIcloudStatusQuery,
@@ -138,6 +139,7 @@ export function GraphProvider({
   children: ReactNode
   platform?: AppPlatform
 }) {
+  const bridgeReady = useHasBridge()
   const [status, setStatus] = useState<GraphStatus>('loading')
   const [graph, setGraph] = useState<GraphInfo | null>(null)
   const [recents, setRecents] = useState<RecentGraph[]>([])
@@ -217,9 +219,12 @@ export function GraphProvider({
   }, [indexGeneration, platform])
 
   const loadRecents = useCallback(
+    // Call-time check on purpose: an imperative load reads the live bridge
+    // state, and a captured value would churn this callback's identity (and
+    // every boot effect downstream of it) on install/teardown.
     async (options?: { surfaceErrors?: boolean }): Promise<RecentGraph[]> => {
       if (!hasBridge()) {
-        return [] // browser dev — there's no backend store to read.
+        return [] // bridgeless browser dev — there's no backend store to read.
       }
       try {
         const list = await recentGraphs()
@@ -499,7 +504,7 @@ export function GraphProvider({
   // be expressed as per-file events; the watcher asks for one full reconcile
   // instead, and `refresh` coalesces bursts into a single queued rerun.
   useEffect(() => {
-    if (!hasBridge()) {
+    if (!bridgeReady) {
       return // bridgeless browser dev — no native event stream to subscribe to
     }
     let unlisten: (() => void) | null = null
@@ -518,7 +523,7 @@ export function GraphProvider({
       disposed = true
       unlisten?.()
     }
-  }, [refreshIndex])
+  }, [bridgeReady, refreshIndex])
 
   const value = useMemo<GraphContextValue>(
     () => ({

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -12,12 +12,12 @@ import {
 import { useQuery } from '@tanstack/react-query'
 import {
   DEFAULT_SETTINGS,
-  hasBridge,
   loadSettings,
   saveSettings,
   errorMessage,
   type Settings,
 } from '@reflect/core'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { startOperation } from '@/lib/operations'
 import { setSettingsFlusher } from '@/lib/settings-flush'
 
@@ -135,10 +135,11 @@ interface SettingsProviderProps {
 }
 
 export function SettingsProvider({ children }: SettingsProviderProps): ReactElement {
+  const bridgeReady = useHasBridge()
   const { data: loaded, error: loadError } = useQuery({
     queryKey: SETTINGS_QUERY_KEY,
     queryFn: loadSettings,
-    enabled: hasBridge(),
+    enabled: bridgeReady,
     staleTime: Infinity,
   })
   const [overrides, setOverrides] = useState<Partial<Settings>>({})
@@ -153,7 +154,7 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
   // for: that settles immediately as 'failed' — i.e. session-only — instead
   // of leaving waiters hanging on a load that will never happen.
   const loadState: SettingsLoadState =
-    !hasBridge() || loadError !== null ? 'failed' : loaded !== undefined ? 'loaded' : 'pending'
+    !bridgeReady || loadError !== null ? 'failed' : loaded !== undefined ? 'loaded' : 'pending'
 
   // Defaults are usable before the IPC load settles — no loading gate.
   const settings = useMemo<Settings>(

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -17,7 +17,7 @@ import {
   errorMessage,
   type Settings,
 } from '@reflect/core'
-import { useHasBridge } from '@/hooks/use-has-bridge'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { startOperation } from '@/lib/operations'
 import { setSettingsFlusher } from '@/lib/settings-flush'
 
@@ -135,7 +135,7 @@ interface SettingsProviderProps {
 }
 
 export function SettingsProvider({ children }: SettingsProviderProps): ReactElement {
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   const { data: loaded, error: loadError } = useQuery({
     queryKey: SETTINGS_QUERY_KEY,
     queryFn: loadSettings,

--- a/apps/desktop/src/providers/sync-provider.tsx
+++ b/apps/desktop/src/providers/sync-provider.tsx
@@ -7,7 +7,7 @@ import {
   type ReactElement,
   type ReactNode,
 } from 'react'
-import { hasBridge, ReflectError, type GithubRepoRef, type GraphInfo } from '@reflect/core'
+import { ReflectError, type GithubRepoRef, type GraphInfo } from '@reflect/core'
 import {
   createBackupController,
   type BackupController,
@@ -15,6 +15,7 @@ import {
   type ConnectExistingResult,
 } from '@/lib/backup-controller'
 import { createIcloudController, isICloudRoot } from '@/lib/icloud-controller'
+import { useHasBridge } from '@/hooks/use-has-bridge'
 import { useMainWindowEffect } from '@/hooks/use-main-window-effect'
 import { isMobileSurface } from '@/lib/platform-surface'
 import { useGraph } from '@/providers/graph-provider'
@@ -75,8 +76,9 @@ export function SyncProvider({ graph, children }: SyncProviderProps): ReactEleme
   // the metadata-query watch, debounced conflict sweeps, and shadow-base
   // bookkeeping. Same per-(graph, index session) shape as the backup
   // controller; a graph outside iCloud mounts nothing.
+  const bridgeReady = useHasBridge()
   useMainWindowEffect(() => {
-    if (!hasBridge() || !isICloudRoot(graph.root)) {
+    if (!bridgeReady || !isICloudRoot(graph.root)) {
       return
     }
     const icloud = createIcloudController({
@@ -88,7 +90,7 @@ export function SyncProvider({ graph, children }: SyncProviderProps): ReactEleme
     return () => {
       icloud.dispose()
     }
-  }, [graph, indexGeneration])
+  }, [bridgeReady, graph, indexGeneration])
 
   const backup = useSyncExternalStore(
     controller?.subscribe ?? (() => () => {}),

--- a/apps/desktop/src/providers/sync-provider.tsx
+++ b/apps/desktop/src/providers/sync-provider.tsx
@@ -14,8 +14,8 @@ import {
   type BackupState,
   type ConnectExistingResult,
 } from '@/lib/backup-controller'
+import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { createIcloudController, isICloudRoot } from '@/lib/icloud-controller'
-import { useHasBridge } from '@/hooks/use-has-bridge'
 import { useMainWindowEffect } from '@/hooks/use-main-window-effect'
 import { isMobileSurface } from '@/lib/platform-surface'
 import { useGraph } from '@/providers/graph-provider'
@@ -76,7 +76,7 @@ export function SyncProvider({ graph, children }: SyncProviderProps): ReactEleme
   // the metadata-query watch, debounced conflict sweeps, and shadow-base
   // bookkeeping. Same per-(graph, index session) shape as the backup
   // controller; a graph outside iCloud mounts nothing.
-  const bridgeReady = useHasBridge()
+  const bridgeReady = useBridgeReady()
   useMainWindowEffect(() => {
     if (!bridgeReady || !isICloudRoot(graph.root)) {
       return

--- a/packages/core/src/exports/platform.ts
+++ b/packages/core/src/exports/platform.ts
@@ -1,4 +1,10 @@
-export { setBridge, hasBridge, type IpcBridge, type Unlisten } from '../ipc/bridge'
+export {
+  setBridge,
+  hasBridge,
+  subscribeBridgeChanges,
+  type IpcBridge,
+  type Unlisten,
+} from '../ipc/bridge'
 export { call, callBinary } from '../ipc/invoke'
 export {
   getAppVersion,

--- a/packages/core/src/ipc/bridge.ts
+++ b/packages/core/src/ipc/bridge.ts
@@ -1,12 +1,14 @@
 /**
- * The pluggable transport between `@reflect/core` and the native shell.
+ * The pluggable transport between `@reflect/core` and its host backend.
  *
  * `@reflect/core` is platform-agnostic: nothing in this package imports
- * `@tauri-apps/*`. A host installs a bridge once at startup — the desktop app
+ * `@tauri-apps/*`. A host installs a bridge at startup — the desktop app
  * adapts Tauri's `invoke`/`listen` (see `apps/desktop/src/lib/tauri-bridge.ts`),
- * tests install in-memory fakes via {@link setBridge}, and future hosts (the
- * CLI, Plan 14) either bring their own transport or skip IPC entirely and read
- * the index directly.
+ * plain-browser dev installs the in-memory dev bridge
+ * (`apps/desktop/src/dev/`), and tests install fakes via {@link setBridge}.
+ * A bridge answering commands does NOT imply a native shell: gates that need
+ * real plugins, custom URL schemes, or OS windows use the desktop app's
+ * `isNativeShell()` instead of {@link hasBridge}.
  */
 
 /** Tears down a subscription created by {@link IpcBridge.listen}. */
@@ -34,19 +36,45 @@ export interface IpcBridge {
 
 let activeBridge: IpcBridge | null = null
 
+/** Notified on every {@link setBridge}, so UI layers can re-read {@link hasBridge}. */
+const changeListeners = new Set<() => void>()
+
 /**
- * Install the process-wide bridge (or remove it with `null`). Call once at
- * startup, before any command binding runs.
+ * Install the process-wide bridge (or remove it with `null`), then notify
+ * {@link subscribeBridgeChanges} subscribers. The Tauri bridge installs
+ * before the first render; the browser dev bridge installs asynchronously
+ * after it, which is why UI gates must subscribe rather than sample once.
  */
 export function setBridge(bridge: IpcBridge | null): void {
   activeBridge = bridge
+  for (const listener of changeListeners) {
+    listener()
+  }
 }
 
 /**
- * True when a bridge is installed — i.e. a native shell is reachable. UI code
- * uses this to gate native-only features (e.g. the file watcher) in
- * environments like browser dev where no shell exists.
- * REVIEW: FIX the comment/docs in this file and related files
+ * Subscribe to bridge installs/removals; returns the unsubscribe function.
+ * The `useSyncExternalStore`-shaped companion to {@link hasBridge} — the
+ * desktop app's `useHasBridge()` hook builds on this pair so React gates
+ * re-render when the (possibly async) install lands.
+ */
+export function subscribeBridgeChanges(listener: () => void): Unlisten {
+  changeListeners.add(listener)
+  return () => {
+    changeListeners.delete(listener)
+  }
+}
+
+/**
+ * True when a bridge is installed — i.e. IPC commands can be answered. True
+ * in the real shell AND in browser dev once the in-memory dev bridge
+ * installs, so this means "data is reachable", never "a native shell
+ * exists" (that question is the desktop app's `isNativeShell()`). React
+ * render scope must not sample this directly (the answer would go stale
+ * when the dev bridge installs asynchronously) — components use
+ * `useHasBridge()`, which subscribes via {@link subscribeBridgeChanges}.
+ * Imperative code (event handlers, controllers) keeps calling this at its
+ * own call time.
  */
 export function hasBridge(): boolean {
   return activeBridge !== null
@@ -54,9 +82,9 @@ export function hasBridge(): boolean {
 
 /**
  * True when the installed bridge has the raw-binary transport ({@link
- * IpcBridge.invokeBinary}) — i.e. a real native shell, not the browser-dev
- * in-memory bridge. Callers use this to choose streamed binary asset IO over
- * the base64 JSON fallback.
+ * IpcBridge.invokeBinary}) — the real shell has it, the browser-dev
+ * in-memory bridge does not. Callers use this to choose streamed binary
+ * asset IO over the base64 JSON fallback.
  */
 export function hasBinaryIpc(): boolean {
   return activeBridge !== null && activeBridge.invokeBinary !== undefined

--- a/packages/core/src/ipc/bridge.ts
+++ b/packages/core/src/ipc/bridge.ts
@@ -55,7 +55,7 @@ export function setBridge(bridge: IpcBridge | null): void {
 /**
  * Subscribe to bridge installs/removals; returns the unsubscribe function.
  * The `useSyncExternalStore`-shaped companion to {@link hasBridge} — the
- * desktop app's `useHasBridge()` hook builds on this pair so React gates
+ * desktop app's `useBridgeReady()` hook builds on this pair so React gates
  * re-render when the (possibly async) install lands.
  */
 export function subscribeBridgeChanges(listener: () => void): Unlisten {
@@ -72,7 +72,7 @@ export function subscribeBridgeChanges(listener: () => void): Unlisten {
  * exists" (that question is the desktop app's `isNativeShell()`). React
  * render scope must not sample this directly (the answer would go stale
  * when the dev bridge installs asynchronously) — components use
- * `useHasBridge()`, which subscribes via {@link subscribeBridgeChanges}.
+ * `useBridgeReady()`, which subscribes via {@link subscribeBridgeChanges}.
  * Imperative code (event handlers, controllers) keeps calling this at its
  * own call time.
  */

--- a/packages/core/src/ipc/bridge.ts
+++ b/packages/core/src/ipc/bridge.ts
@@ -46,6 +46,7 @@ export function setBridge(bridge: IpcBridge | null): void {
  * True when a bridge is installed — i.e. a native shell is reachable. UI code
  * uses this to gate native-only features (e.g. the file watcher) in
  * environments like browser dev where no shell exists.
+ * REVIEW: FIX the comment/docs in this file and related files
  */
 export function hasBridge(): boolean {
   return activeBridge !== null


### PR DESCRIPTION
Plain `pnpm dev` in a browser now installs the in-memory dev bridge and boots the desktop tree into a seeded, workable graph (`?platform=ios|android` still forces the mobile harness; `?platform=none` opts out); also fixes the bridgeless render crashing since https://github.com/team-reflect/reflect-open/pull/920 and seeds tasks with the `+ [ ]` markers the indexer actually extracts.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading and synchronization across desktop and mobile by waiting for services to become ready before running searches, queries, subscriptions, and updates.
  * Reduced failures caused by services becoming available after the app initially loads.
  * Prevented local-history features from starting in unsupported mobile or browser-development environments.

* **New Features**
  * Browser development now supports reactive service installation, platform selection, and optional service disabling.
  * Added development coverage for graphs, cloud status, embeddings, vault statistics, and attachments.

* **Documentation**
  * Clarified browser-development setup and platform behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->