### PR TITLE
refactor: rebuild the mobile Drawer on Base UI

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -53,7 +53,6 @@
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
     "ulidx": "^2.4.1",
-    "vaul": "^1.1.2",
     "virtua": "^0.50.0",
     "zod": "4.4.3"
   },

--- a/apps/desktop/src/components/ui/drawer.tsx
+++ b/apps/desktop/src/components/ui/drawer.tsx
@@ -1,41 +1,79 @@
 import * as React from 'react'
-import { Drawer as DrawerPrimitive } from 'vaul'
+import { Drawer as DrawerPrimitive } from '@base-ui/react/drawer'
 
 import { cn } from '@/lib/utils'
 
+interface DrawerContextProps {
+  hasSnapPoints: boolean
+  modal: DrawerPrimitive.Root.Props['modal']
+  showSwipeHandle: boolean
+  swipeDirection: NonNullable<DrawerPrimitive.Root.Props['swipeDirection']>
+}
+
+const DrawerContext = React.createContext<DrawerContextProps | null>(null)
+
+function useDrawer(): DrawerContextProps {
+  const context = React.useContext(DrawerContext)
+
+  if (!context) {
+    throw new Error('useDrawer must be used within a Drawer.')
+  }
+
+  return context
+}
+
 /**
- * A bottom sheet for touch surfaces, built on vaul (drag-to-dismiss + spring
+ * A bottom sheet for touch surfaces, built on Base UI (drag-to-dismiss + spring
  * physics). The mobile-native answer to a centered dialog or a popover: content
  * slides up from the bottom edge and can be flicked back down to dismiss.
  * Tokens mirror {@link Dialog} so the two read as one system. Bottom-anchored
- * only — the other directions vaul supports aren't needed on Reflect's mobile
+ * only — the other directions Base UI supports aren't needed on Reflect's mobile
  * surfaces — and the home-indicator safe area is padded for by default.
  */
-function Drawer(props: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+function Drawer({
+  modal = true,
+  showSwipeHandle = true,
+  snapPoints,
+  swipeDirection = 'down',
+  ...props
+}: DrawerPrimitive.Root.Props & { showSwipeHandle?: boolean }) {
+  const hasSnapPoints = snapPoints != null && snapPoints.length > 0
+  const contextValue = React.useMemo(
+    () => ({ hasSnapPoints, modal, showSwipeHandle, swipeDirection }),
+    [hasSnapPoints, modal, showSwipeHandle, swipeDirection],
+  )
+
+  return (
+    <DrawerContext.Provider value={contextValue}>
+      <DrawerPrimitive.Root
+        data-slot="drawer"
+        modal={modal}
+        snapPoints={snapPoints}
+        swipeDirection={swipeDirection}
+        {...props}
+      />
+    </DrawerContext.Provider>
+  )
 }
 
-function DrawerTrigger(props: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+function DrawerTrigger(props: DrawerPrimitive.Trigger.Props) {
   return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
 }
 
-function DrawerClose(props: React.ComponentProps<typeof DrawerPrimitive.Close>) {
-  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
-}
-
-function DrawerPortal(props: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+function DrawerPortal(props: DrawerPrimitive.Portal.Props) {
   return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
 }
 
-function DrawerOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+function DrawerClose(props: DrawerPrimitive.Close.Props) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+}
+
+function DrawerOverlay({ className, ...props }: DrawerPrimitive.Backdrop.Props) {
   return (
-    <DrawerPrimitive.Overlay
+    <DrawerPrimitive.Backdrop
       data-slot="drawer-overlay"
       className={cn(
-        'fixed inset-0 z-50 bg-black/30 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
+        'fixed inset-0 z-50 min-h-dvh bg-black/30 opacity-[max(var(--drawer-overlay-min-opacity,0),calc(1-var(--drawer-swipe-progress)))] transition-opacity duration-450 ease-[cubic-bezier(0.32,0.72,0,1)] select-none data-ending-style:pointer-events-none data-ending-style:opacity-0 data-ending-style:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-snap-points:[--drawer-overlay-min-opacity:0.5] data-starting-style:opacity-0 data-swiping:duration-0 supports-[-webkit-touch-callout:none]:absolute',
         className,
       )}
       {...props}
@@ -43,27 +81,78 @@ function DrawerOverlay({
   )
 }
 
-function DrawerContent({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+function DrawerSwipeHandle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="drawer-swipe-handle"
+      aria-hidden="true"
+      className={cn(
+        'mx-auto mb-1 h-1 w-10 shrink-0 cursor-grab rounded-full bg-border active:cursor-grabbing',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerContent({ className, children, ...props }: DrawerPrimitive.Popup.Props) {
+  const { hasSnapPoints, modal, showSwipeHandle, swipeDirection } = useDrawer()
+  const swipeAxis = swipeDirection === 'down' || swipeDirection === 'up' ? 'y' : 'x'
+
   return (
     <DrawerPortal>
-      <DrawerOverlay />
-      <DrawerPrimitive.Content
-        data-slot="drawer-content"
-        className={cn(
-          'fixed inset-x-0 bottom-0 z-50 mt-24 flex max-h-[85vh] flex-col gap-3 rounded-t-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 outline-none',
-          // Pad past the home indicator so the last row isn't tucked under it.
-          'pb-[max(env(safe-area-inset-bottom),1rem)]',
-          className,
-        )}
-        {...props}
+      {modal === true ? <DrawerOverlay data-snap-points={hasSnapPoints ? '' : undefined} /> : null}
+      <DrawerPrimitive.Viewport
+        data-slot="drawer-viewport"
+        data-modal={modal}
+        className="pointer-events-none fixed inset-0 z-50 select-none data-[modal=true]:pointer-events-auto"
       >
-        <DrawerPrimitive.Handle className="mx-auto mb-1 h-1 w-10 shrink-0 rounded-full bg-border" />
-        {children}
-      </DrawerPrimitive.Content>
+        <DrawerPrimitive.Popup
+          data-slot="drawer-popup"
+          data-swipe-axis={swipeAxis}
+          data-snap-points={hasSnapPoints ? '' : undefined}
+          className={cn(
+            // Base.
+            'group/drawer-popup pointer-events-auto fixed z-50 m-(--drawer-inset,0px) flex h-(--drawer-content-height) max-h-(--drawer-content-max-height,none) min-h-0 w-(--drawer-content-width,auto) transform-[translate3d(var(--translate-x,0px),var(--translate-y,0px),0)_scale(var(--stack-scale))] flex-col bg-popover text-sm text-popover-foreground ring-1 ring-foreground/10 transition-[transform,height,opacity,filter] duration-450 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform outline-none select-none [interpolate-size:allow-keywords] data-[swipe-direction=down]:rounded-t-xl data-[swipe-direction=left]:rounded-r-xl data-[swipe-direction=right]:rounded-l-xl data-[swipe-direction=up]:rounded-b-xl',
+            // Nested.
+            'data-nested-drawer-open:overflow-hidden data-nested-drawer-open:brightness-95',
+            // Bleed.
+            'after:pointer-events-none after:absolute after:bg-(--drawer-bleed-background,var(--color-popover)) data-[swipe-axis=x]:after:inset-y-0 data-[swipe-axis=x]:after:w-(--bleed) data-[swipe-axis=y]:after:inset-x-0 data-[swipe-axis=y]:after:h-(--bleed) data-[swipe-direction=down]:after:top-full data-[swipe-direction=left]:after:right-full data-[swipe-direction=right]:after:left-full data-[swipe-direction=up]:after:bottom-full',
+            // Sizing.
+            '[--drawer-content-height:var(--drawer-height,auto)] data-[swipe-axis=x]:[--drawer-content-width:75%] data-[swipe-axis=y]:[--drawer-content-max-height:85vh] data-[swipe-axis=y]:data-snap-points:[--drawer-content-height:100dvh] data-[swipe-axis=x]:sm:[--drawer-content-width:24rem]',
+            // Stack.
+            '[--bleed:3rem] [--peek:1rem] [--stack-height:var(--drawer-frontmost-height,var(--drawer-height,0px))] [--stack-peek-offset:max(0px,calc((var(--nested-drawers)-var(--stack-progress))*var(--peek)))] [--stack-progress:clamp(0,var(--drawer-swipe-progress),1)] [--stack-scale-base:max(0,calc(1-(var(--nested-drawers)*var(--stack-step))))] [--stack-scale:clamp(0,calc(var(--stack-scale-base)+(var(--stack-step)*var(--stack-progress))),1)] [--stack-shrink:calc(1-var(--stack-scale))] [--stack-step:0.05]',
+            // Transitions.
+            'data-ending-style:transform-(--closed-transform) data-ending-style:opacity-[0.9999] data-ending-style:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-nested-drawer-swiping:duration-0 data-ending-style:data-nested-drawer-swiping:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-starting-style:transform-(--closed-transform) data-swiping:duration-0 data-ending-style:data-swiping:duration-[calc(var(--drawer-swipe-strength)*400ms)]',
+            // Axis: y.
+            'data-[swipe-axis=y]:inset-x-0 data-[swipe-axis=y]:data-nested-drawer-open:h-(--stack-height)',
+            // Axis: x.
+            'data-[swipe-axis=x]:inset-y-0 data-[swipe-axis=x]:flex-row',
+            // Direction: down.
+            'data-[swipe-direction=down]:bottom-0 data-[swipe-direction=down]:origin-bottom data-[swipe-direction=down]:[--closed-transform:translate3d(0,calc(100%+var(--drawer-inset,0px)+2px),0)] data-[swipe-direction=down]:[--translate-y:calc(var(--drawer-snap-point-offset,0px)+var(--drawer-swipe-movement-y)-var(--stack-peek-offset)-(var(--stack-shrink)*var(--stack-height)))]',
+            // Direction: up.
+            'data-[swipe-direction=up]:top-0 data-[swipe-direction=up]:origin-top data-[swipe-direction=up]:[--closed-transform:translate3d(0,calc(-100%-var(--drawer-inset,0px)-2px),0)] data-[swipe-direction=up]:[--translate-y:calc(var(--drawer-snap-point-offset,0px)+var(--drawer-swipe-movement-y)+var(--stack-peek-offset)+(var(--stack-shrink)*var(--stack-height)))]',
+            // Direction: left.
+            'data-[swipe-direction=left]:left-0 data-[swipe-direction=left]:origin-left data-[swipe-direction=left]:[--closed-transform:translate3d(calc(-100%-var(--drawer-inset,0px)-2px),0,0)] data-[swipe-direction=left]:[--translate-x:calc(var(--drawer-swipe-movement-x)+var(--stack-peek-offset)+(var(--stack-shrink)*100%))]',
+            // Direction: right.
+            'data-[swipe-direction=right]:right-0 data-[swipe-direction=right]:origin-right data-[swipe-direction=right]:[--closed-transform:translate3d(calc(100%+var(--drawer-inset,0px)+2px),0,0)] data-[swipe-direction=right]:[--translate-x:calc(var(--drawer-swipe-movement-x)-var(--stack-peek-offset)-(var(--stack-shrink)*100%))]',
+            className,
+          )}
+          {...props}
+        >
+          {showSwipeHandle ? <DrawerSwipeHandle /> : null}
+          <DrawerPrimitive.Content
+            data-slot="drawer-content"
+            className={cn(
+              'flex min-h-0 flex-1 flex-col gap-3 overflow-hidden overscroll-contain rounded-[inherit] p-4 transition-opacity duration-300 ease-[cubic-bezier(0.45,1.005,0,1.005)] select-text group-data-nested-drawer-open/drawer-popup:opacity-0 group-data-nested-drawer-swiping/drawer-popup:opacity-100 group-data-swiping/drawer-popup:select-none',
+              // Pad past the home indicator so the last row isn't tucked under it.
+              'pb-[max(env(safe-area-inset-bottom),1rem)]',
+            )}
+          >
+            {children}
+          </DrawerPrimitive.Content>
+        </DrawerPrimitive.Popup>
+      </DrawerPrimitive.Viewport>
     </DrawerPortal>
   )
 }
@@ -84,7 +173,7 @@ function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
   )
 }
 
-function DrawerTitle({ className, ...props }: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+function DrawerTitle({ className, ...props }: DrawerPrimitive.Title.Props) {
   return (
     <DrawerPrimitive.Title
       data-slot="drawer-title"
@@ -94,10 +183,7 @@ function DrawerTitle({ className, ...props }: React.ComponentProps<typeof Drawer
   )
 }
 
-function DrawerDescription({
-  className,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+function DrawerDescription({ className, ...props }: DrawerPrimitive.Description.Props) {
   return (
     <DrawerPrimitive.Description
       data-slot="drawer-description"
@@ -116,6 +202,7 @@ export {
   DrawerHeader,
   DrawerOverlay,
   DrawerPortal,
+  DrawerSwipeHandle,
   DrawerTitle,
   DrawerTrigger,
 }

--- a/apps/desktop/src/components/ui/drawer.tsx
+++ b/apps/desktop/src/components/ui/drawer.tsx
@@ -13,7 +13,7 @@ interface DrawerContextProps {
 const DrawerContext = React.createContext<DrawerContextProps | null>(null)
 
 function useDrawer(): DrawerContextProps {
-  const context = React.useContext(DrawerContext)
+  const context = React.use(DrawerContext)
 
   if (!context) {
     throw new Error('useDrawer must be used within a Drawer.')
@@ -44,7 +44,7 @@ function Drawer({
   )
 
   return (
-    <DrawerContext.Provider value={contextValue}>
+    <DrawerContext value={contextValue}>
       <DrawerPrimitive.Root
         data-slot="drawer"
         modal={modal}
@@ -52,7 +52,7 @@ function Drawer({
         swipeDirection={swipeDirection}
         {...props}
       />
-    </DrawerContext.Provider>
+    </DrawerContext>
   )
 }
 

--- a/apps/desktop/src/mobile/add-ai-provider-drawer.test.tsx
+++ b/apps/desktop/src/mobile/add-ai-provider-drawer.test.tsx
@@ -23,7 +23,7 @@ vi.mock('@/lib/provider-fetch', () => ({ providerFetch: vi.fn() }))
 vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn(() => Promise.resolve()) }))
 
 // Keep the sheet content inline so this suite exercises its state flow
-// without depending on vaul's drag and animation behavior.
+// without depending on the drawer's drag and animation behavior.
 vi.mock('@/components/ui/drawer', () => ({
   Drawer: ({ children }: { children?: ReactNode }) => <>{children}</>,
   DrawerContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,

--- a/apps/desktop/src/mobile/ai-prompt-drawer.test.tsx
+++ b/apps/desktop/src/mobile/ai-prompt-drawer.test.tsx
@@ -13,7 +13,7 @@ import '@/test-utils/locator'
  */
 
 // Keep the sheet content inline so this suite exercises its state flow
-// without depending on vaul's drag and animation behavior.
+// without depending on the drawer's drag and animation behavior.
 vi.mock('@/components/ui/drawer', () => ({
   Drawer: ({ children }: { children?: ReactNode }) => <>{children}</>,
   DrawerContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,

--- a/apps/desktop/src/mobile/month-picker-drawer.test.tsx
+++ b/apps/desktop/src/mobile/month-picker-drawer.test.tsx
@@ -10,7 +10,7 @@ import { MonthPickerDrawer } from './month-picker-drawer'
  * month, and the selection/today months carry the strip's markings.
  */
 
-// vaul needs browser APIs jsdom doesn't provide (matchMedia, pointer
+// The drawer needs browser APIs jsdom doesn't provide (matchMedia, pointer
 // capture); its drag/animation is verified on-device. This passthrough
 // honours `open` so open/close behavior stays testable.
 vi.mock('@/components/ui/drawer', () => ({

--- a/apps/desktop/src/mobile/note-actions-menu.test.tsx
+++ b/apps/desktop/src/mobile/note-actions-menu.test.tsx
@@ -11,7 +11,7 @@ import { NoteActionsMenu } from './note-actions-menu'
  * delete confirms then moves the note to trash and notifies the screen. Runs
  * the real toggle/delete core paths over a fake IPC bridge.
  *
- * The drawer wrapper is vaul, which needs browser APIs jsdom doesn't provide
+ * The drawer wrapper needs browser APIs jsdom doesn't provide
  * (matchMedia, pointer capture); its drag/animation is verified on-device.
  * Here it's mocked to a passthrough so the action rows are always rendered and
  * the test can exercise the IPC side effects directly.

--- a/apps/desktop/src/mobile/note-actions-menu.tsx
+++ b/apps/desktop/src/mobile/note-actions-menu.tsx
@@ -68,10 +68,12 @@ export function NoteActionsMenu({ path, onDeleted }: NoteActionsMenuProps): Reac
   return (
     <>
       <Drawer open={actionsOpen} onOpenChange={setActionsOpen}>
-        <DrawerTrigger asChild>
-          <Button variant="ghost" size="icon" className="size-10" aria-label="Note actions">
-            <MoreHorizontal />
-          </Button>
+        <DrawerTrigger
+          render={
+            <Button variant="ghost" size="icon" className="size-10" aria-label="Note actions" />
+          }
+        >
+          <MoreHorizontal />
         </DrawerTrigger>
         <DrawerContent>
           <DrawerTitle className="sr-only">Note actions</DrawerTitle>

--- a/apps/desktop/src/mobile/search-filters/filter-bar.test.tsx
+++ b/apps/desktop/src/mobile/search-filters/filter-bar.test.tsx
@@ -11,7 +11,7 @@ import { EMPTY_ALL_NOTES_FILTERS, type AllNotesFilters } from './filter-state'
 /**
  * The filter badge row (Plan 19): chips toggle or open pickers, everything
  * ANDs, and Reset clears the lot including the route tag. The drawer wrapper
- * is vaul, which needs browser APIs jsdom doesn't provide; as in
+ * needs browser APIs jsdom doesn't provide; as in
  * `note-actions-menu.test.tsx` it's mocked to a passthrough so picker rows
  * are always rendered and the state flow is what's exercised.
  */

--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -213,8 +213,9 @@ export function MobileTaskEditSheet({
         }}
       >
         <DrawerTitle className="sr-only">Edit task</DrawerTitle>
-        {/* vaul must not turn a drag inside the editor (text selection) into a
-            sheet drag. */}
+        {/* A drag inside the editor (text selection) must not turn into a sheet
+            drag. `data-vaul-no-drag` is inert now; Base UI's swipe handling here
+            still needs an on-device check. */}
         <div
           data-vaul-no-drag
           className="rounded-md border border-border bg-surface px-3 py-2 focus-within:ring-1 focus-within:ring-accent"

--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -213,11 +213,8 @@ export function MobileTaskEditSheet({
         }}
       >
         <DrawerTitle className="sr-only">Edit task</DrawerTitle>
-        {/* A drag inside the editor (text selection) must not turn into a sheet
-            drag. `data-vaul-no-drag` is inert now; Base UI's swipe handling here
-            still needs an on-device check. */}
         <div
-          data-vaul-no-drag
+          data-base-ui-swipe-ignore
           className="rounded-md border border-border bg-surface px-3 py-2 focus-within:ring-1 focus-within:ring-accent"
         >
           <NoteEditor

--- a/apps/desktop/src/mobile/task-edit-sheet.tsx
+++ b/apps/desktop/src/mobile/task-edit-sheet.tsx
@@ -204,11 +204,12 @@ export function MobileTaskEditSheet({
         aria-label="Edit task"
         // On the "+"-add path the editor takes focus instead of the sheet
         // container, so typing can start immediately.
-        onOpenAutoFocus={(event) => {
-          if (autoFocusEditor) {
-            event.preventDefault()
-            editorRef.current?.focus()
+        initialFocus={() => {
+          if (!autoFocusEditor) {
+            return true
           }
+          editorRef.current?.focus()
+          return false
         }}
       >
         <DrawerTitle className="sr-only">Edit task</DrawerTitle>

--- a/apps/desktop/src/mobile/use-task-sheet-finalizer.ts
+++ b/apps/desktop/src/mobile/use-task-sheet-finalizer.ts
@@ -36,7 +36,7 @@ export interface TaskSheetFinalizer {
   setDraft: Dispatch<SetStateAction<string>>
   /** Resolve the draft against the frozen baseline: commit / cancel / delete. */
   resolve: () => TaskEditResult
-  /** vaul's onOpenChange — a user dismissal finishes the visit first. */
+  /** The drawer's onOpenChange — a user dismissal finishes the visit first. */
   handleOpenChange: (open: boolean) => void
   /** Close after an action button took over the write (no dismissal commit). */
   closeHandled: () => void

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -9,6 +9,8 @@ import babel from '@rolldown/plugin-babel'
 
 const host: string | undefined = process.env.TAURI_DEV_HOST
 
+console.log("host",host)
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
@@ -65,13 +67,6 @@ export default defineConfig({
     port: 1420,
     strictPort: true,
     host: host || false,
-    ...(host
-      ? {
-          protocol: 'ws',
-          host,
-          port: 1421,
-        }
-      : {}),
     watch: {
       // 3. tell Vite to ignore watching `src-tauri`
       ignored: ['**/src-tauri/**'],

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -9,8 +9,6 @@ import babel from '@rolldown/plugin-babel'
 
 const host: string | undefined = process.env.TAURI_DEV_HOST
 
-console.log("host",host)
-
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,9 +147,6 @@ importers:
       ulidx:
         specifier: ^2.4.1
         version: 2.4.1
-      vaul:
-        specifier: ^1.1.2
-        version: 1.1.2(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
       virtua:
         specifier: ^0.50.0
         version: 0.50.0(react-dom@19.2.8)(react@19.2.8)
@@ -6006,12 +6003,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  vaul@1.1.2:
-    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
-    peerDependencies:
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   verkit@0.3.2:
     resolution: {integrity: sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==}
@@ -12514,15 +12505,6 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
-
-  vaul@1.1.2(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8):
-    dependencies:
-      '@radix-ui/react-dialog': 1.1.21(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
 
   verkit@0.3.2: {}
 


### PR DESCRIPTION
Replaces the vaul bottom sheet with Base UI's own `Drawer`, so the sheet and the popups inside it come from one library and a portaled `Select` popup stays clickable (#1029).

Draft until an on-device pass: swipe feel, keyboard avoidance, and whether a text-selection drag inside the task editor still turns into a sheet drag (`data-vaul-no-drag` is inert now).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated mobile drawers with improved swipe gestures, snap points, directional layouts, nested stacking, and configurable swipe handles.
  - Improved drawer focus behavior when editing tasks.
  - Updated drawer triggers for more consistent button interactions.

- **Bug Fixes**
  - Improved responsive drawer positioning and overlay behavior across mobile layouts.

- **Tests**
  - Updated drawer-related test coverage and documentation to reflect the new drawer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->