### PR TITLE
fix: pick up iCloud note changes that arrive while the Mac sleeps

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -115,6 +115,7 @@ objc2-app-kit = { version = "0.3.2", default-features = false, features = [
   "NSEvent",
   "NSMenu",
   "NSMenuItem",
+  "NSWorkspace",
 ] }
 
 # Apple Contacts integration (`contacts.rs`): live CNContactStore lookups on

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -34,6 +34,8 @@ mod recents;
 mod secrets;
 mod settings;
 mod skill;
+#[cfg(target_os = "macos")]
+mod wake;
 mod windows;
 
 // The watcher and the embedding runtime are desktop capabilities (Plan 19):
@@ -380,6 +382,12 @@ pub fn run() {
             // registration hook, which Tauri stores as a single callback.)
             #[cfg(desktop)]
             tauri::RunEvent::Ready => {
+                // Wake-from-sleep is the one moment external iCloud writes
+                // can land without the FSEvents watcher seeing them; the
+                // observer asks the frontend for one full reconcile per wake
+                // (wake.rs).
+                #[cfg(target_os = "macos")]
+                wake::install(app);
                 let app = app.clone();
                 windows::arm_reveal_fallback(
                     &revealed_main,

--- a/apps/desktop/src-tauri/src/wake.rs
+++ b/apps/desktop/src-tauri/src/wake.rs
@@ -1,0 +1,57 @@
+//! Wake-from-sleep catch-up (macOS).
+//!
+//! On desktop the `notify` FSEvents watcher is the *only* live source of
+//! external content changes: the iCloud metadata watch deliberately does not
+//! emit file events here (`emit_file_changes: false`), and the resume/focus
+//! triggers only run conflict sweeps. A file that iCloud downloads while the
+//! machine sleeps (Power Nap) or during the wake transition can miss FSEvents
+//! delivery entirely — the process is suspended when the write lands — and
+//! with no backstop the note stays stale until the next full reconcile, which
+//! ordinarily means an app restart.
+//!
+//! This observer closes that gap: `NSWorkspaceDidWakeNotification` emits one
+//! coarse `index:reconcile`, and the frontend answers with its ordinary full
+//! reconcile pass (re-list, hash, repair — the same pass a structural watcher
+//! change requests), which also surfaces stale iCloud placeholders for
+//! targeted downloads. The frontend coalesces bursts, and the event is
+//! ignored whenever no graph is open, so a spurious wake costs one no-op.
+
+use std::ptr::NonNull;
+
+use block2::RcBlock;
+use objc2::msg_send;
+use objc2::rc::Retained;
+use objc2::runtime::AnyObject;
+use objc2_app_kit::{NSWorkspace, NSWorkspaceDidWakeNotification};
+use objc2_foundation::NSNotification;
+use tauri::Emitter;
+
+/// Install the app-lifetime wake observer. Called once from
+/// `RunEvent::Ready` (the main thread — where AppKit expects observer
+/// registration, and the same spot the reveal fallback arms; `.setup()` is
+/// avoided because Tauri stores a single setup callback and a second
+/// registration would silently replace the first).
+pub fn install(app: &tauri::AppHandle) {
+    let app = app.clone();
+    let block = RcBlock::new(move |_notification: NonNull<NSNotification>| {
+        // Delivered on the main thread (workspace notifications post there;
+        // no delivery queue is requested). `emit` is thread-safe and cheap —
+        // the reconcile itself runs in the frontend's index lifecycle.
+        let _ = app.emit(crate::watcher::RECONCILE_EVENT, ());
+    });
+    let workspace = NSWorkspace::sharedWorkspace();
+    let center = workspace.notificationCenter();
+    let token: Retained<AnyObject> = unsafe {
+        msg_send![
+            &center,
+            addObserverForName: NSWorkspaceDidWakeNotification,
+            object: Option::<&AnyObject>::None,
+            queue: Option::<&AnyObject>::None,
+            usingBlock: &*block
+        ]
+    };
+    // The observer lives for the whole app run — leak the token rather than
+    // house it in a static nobody reads (dropping it would not deregister
+    // the observer anyway; only removeObserver does).
+    std::mem::forget(token);
+}


### PR DESCRIPTION
## Problem

A note edited on iOS while a Mac sleeps can stay invisible on that Mac until the app is restarted — even though the bytes are already on disk.

On desktop, the `notify` FSEvents watcher is the **only** live source of external content changes. Everything else deliberately excludes this case:

- The iCloud metadata watch runs with `emit_file_changes: false` on desktop ("the notify watcher already reports file events") — it only invalidates the listing cache and signals conflicts.
- The resume/focus listeners in `icloud-controller.ts` only schedule an `NSFileVersion` *conflict* sweep; a clean fast-forward edit produces nothing.
- The full index reconcile runs only at graph open, the metadata query's initial gather, or when the watcher itself demands a rescan.

So when iCloud downloads an update while the machine sleeps (Power Nap) or during the wake transition — with the process suspended when the write lands — the FSEvents delivery for that write can be lost, and the miss is permanent: the note renders stale until the next restart, whose open-path reconcile reads the file fresh. This is exactly the observed field failure (iOS edit synced mid-flight-recovery; Mac woke from sleep showing stale content; restart showed the edit instantly, proving the bytes were already local).

Scope boundary: this does not touch the mobile resume path (visibility → full pass, already present) and does not change the desktop metadata watch's role.

## Before → After

| Scenario | Before | After |
| --- | --- | --- |
| iCloud writes a note while the Mac sleeps, FSEvents delivery lost | Note stale until app restart | One full reconcile on wake picks it up |
| Wake with nothing changed | — | One coalesced no-op reconcile pass |

## Changes

1. **New `apps/desktop/src-tauri/src/wake.rs`** (macOS only): registers a block observer for `NSWorkspaceDidWakeNotification` on `NSWorkspace`'s notification center and emits the existing coarse `index:reconcile` event once per wake. The frontend's existing subscription (`subscribeReconcileRequests` → `refreshIndex`) coalesces bursts into a single full reconcile — the same pass a structural watcher change requests — which also surfaces stale iCloud placeholders for targeted downloads (`onStalePlaceholders`). The observer token is app-lifetime and intentionally leaked.
2. **`lib.rs`**: installs the observer from the `RunEvent::Ready` arm — the established spot for this (arming from `.setup()` would silently replace the deep-link registration hook, which Tauri stores as a single callback), and the first point where the main thread has an app handle.
3. **`Cargo.toml`**: adds the `NSWorkspace` feature to the existing trimmed `objc2-app-kit` dependency.

No frontend changes: the reconcile event and its coalescing/`isMainWindow` guards already exist, and the event is a no-op when no graph is open.

## Tests

None added — the change is a thin AppKit observer registration with no seam to drive `NSWorkspaceDidWakeNotification` from a unit test. The reconcile path it triggers is the existing, already-tested `index:reconcile` machinery.

## Verification

- `cargo check -p reflect-open` — clean
- `cargo clippy -p reflect-open` — clean
- `cargo fmt -p reflect-open --check` — clean
- Manual sleep/wake pass on a real Mac (edit on iOS while the Mac lid is closed, open lid, note refreshes without restart) still owed.

## Risk / Rollout

Low. The observer fires once per wake and emits one event; the frontend guards make a spurious wake cost a single coalesced reconcile (list + hash — same cost as app open, already tuned for mature graphs). macOS-gated; no behavior change on iOS/Windows/Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> macOS-only, reuses the existing reconcile path with one event per wake; spurious wakes cost at most one coalesced no-op reconcile when a graph is open.
> 
> **Overview**
> **Fixes stale notes on macOS** when iCloud downloads edits while the Mac sleeps or during wake — writes can land while the process is suspended, so FSEvents never fires and the desktop index has no other live backstop for that case.
> 
> Adds a **macOS-only** `wake` module that registers for `NSWorkspaceDidWakeNotification` and emits the existing **`index:reconcile`** event once per wake. The frontend’s current coalescing and “no graph open” guards handle the rest; no TypeScript changes.
> 
> Wiring runs from **`RunEvent::Ready`** (same lifecycle hook as the reveal fallback). **`objc2-app-kit`** gains the **`NSWorkspace`** feature for the workspace notification center API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc39567d82cb5153656b8d2080f9e98618c263eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop synchronization after macOS wakes from sleep.
  * Changes made to iCloud files while the app was asleep are now detected and reflected when the app resumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->