### PR TITLE
chore: remove unused imports

### DIFF
--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -10,8 +10,7 @@
 
 import { execFileSync, execSync } from 'node:child_process'
 import { copyFileSync, mkdirSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 const platform = process.env.TAURI_ENV_PLATFORM ?? ''
 if (platform === 'ios' || platform === 'android') {

--- a/apps/desktop/scripts/release-ios.mjs
+++ b/apps/desktop/scripts/release-ios.mjs
@@ -15,8 +15,8 @@
 import { execFileSync, spawnSync } from 'node:child_process'
 import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
-import { basename, dirname, join, resolve } from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { basename, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 const DEFAULT_EXPORT_METHOD = 'app-store-connect'
 const EXPORT_METHODS = new Set(['app-store-connect', 'release-testing', 'debugging', 'validation'])

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -35,7 +35,7 @@ import {
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
 import { createInterface } from 'node:readline/promises'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { pathToFileURL } from 'node:url'
 
 const KEYCHAIN_SERVICE = 'reflect-notary'
 const UPDATER_KEYCHAIN_SERVICE = 'reflect-updater'

--- a/apps/desktop/scripts/release-macos.test.mjs
+++ b/apps/desktop/scripts/release-macos.test.mjs
@@ -1,7 +1,6 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { expect, test } from 'vitest'
 
 import {

--- a/apps/desktop/scripts/release-please-workflow.test.mjs
+++ b/apps/desktop/scripts/release-please-workflow.test.mjs
@@ -1,6 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { expect, test } from 'vitest'
 
 const scriptsDirectory = import.meta.dirname

--- a/apps/desktop/scripts/release-workflow.test.mjs
+++ b/apps/desktop/scripts/release-workflow.test.mjs
@@ -1,6 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { expect, test } from 'vitest'
 
 const scriptsDirectory = import.meta.dirname

--- a/packages/db/scripts/generate-schema.mjs
+++ b/packages/db/scripts/generate-schema.mjs
@@ -12,7 +12,6 @@ import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import Database from 'better-sqlite3'
 import * as sqliteVec from 'sqlite-vec'
 


### PR DESCRIPTION
Remove unused `dirname` / `fileURLToPath` imports from release and sidecar scripts. Each script uses `import.meta.dirname`, so the `node:url` and `node:path` helpers are dead code.

Resolves the `no-unused-vars` oxlint warnings for these files. The `max-lines` warnings are left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified internal build, release, workflow, and schema-generation scripts by removing unused path utilities.
  - Updated path handling to use the runtime’s built-in directory support where applicable.

- **Tests**
  - Aligned release workflow tests with the updated path handling.
  - No user-facing behavior or exported functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->