### PR TITLE
fix: capture titles and descriptions from oversized pages

### DIFF
--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -520,9 +520,12 @@ pub async fn capture_link_preview(app: tauri::AppHandle, url: String) -> AppResu
 
 // ---- meta fetch -----------------------------------------------------------------
 
-/// How much HTML the meta scrape reads: `<head>` metadata lives well inside
-/// the first half-megabyte of any real page.
-const META_FETCH_MAX_BYTES: usize = 512 * 1024;
+/// How much HTML the meta scrape reads. Sized for the worst page measured:
+/// a YouTube watch page is ~1.2 MiB of identity-encoded HTML with every
+/// meta tag at ~690 KiB, near the end of a ~697 KiB `<head>` (2026-08).
+/// 2 MiB keeps whole pages of that shape, with margin for head growth,
+/// while still bounding what this command buffers and ships over IPC.
+const META_FETCH_MAX_BYTES: usize = 2 * 1024 * 1024;
 const META_FETCH_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// The meta fetch presents as a mainstream browser navigation: sites that
@@ -647,6 +650,15 @@ mod tests {
             classify_fetch_status(url, StatusCode::FORBIDDEN),
             Some(AppError::Io { .. })
         ));
+    }
+
+    #[test]
+    fn meta_fetch_cap_clears_measured_youtube_metadata_offsets() {
+        // Measured 2026-08 with browser headers and identity encoding: YouTube
+        // watch pages put <title>/og:title at ~686-691 KiB and close <head> at
+        // ~697 KiB. Keep at least 2x that, or the scrape silently parses zero
+        // metadata there and the AI leg fabricates titles from the thumbnail.
+        assert!(META_FETCH_MAX_BYTES >= 1_400_000);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -526,9 +526,6 @@ pub async fn capture_link_preview(app: tauri::AppHandle, url: String) -> AppResu
 /// 2 MiB keeps whole pages of that shape, with margin for head growth,
 /// while still bounding what this command buffers and ships over IPC.
 const META_FETCH_MAX_BYTES: usize = 2 * 1024 * 1024;
-// Compile-time floor: below 2x the measured ~690 KiB offsets, the scrape
-// silently parses zero metadata on YouTube and the bug returns.
-const _: () = assert!(META_FETCH_MAX_BYTES >= 1_400_000);
 const META_FETCH_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// The meta fetch presents as a mainstream browser navigation: sites that

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -526,6 +526,9 @@ pub async fn capture_link_preview(app: tauri::AppHandle, url: String) -> AppResu
 /// 2 MiB keeps whole pages of that shape, with margin for head growth,
 /// while still bounding what this command buffers and ships over IPC.
 const META_FETCH_MAX_BYTES: usize = 2 * 1024 * 1024;
+// Compile-time floor: below 2x the measured ~690 KiB offsets, the scrape
+// silently parses zero metadata on YouTube and the bug returns.
+const _: () = assert!(META_FETCH_MAX_BYTES >= 1_400_000);
 const META_FETCH_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// The meta fetch presents as a mainstream browser navigation: sites that
@@ -650,15 +653,6 @@ mod tests {
             classify_fetch_status(url, StatusCode::FORBIDDEN),
             Some(AppError::Io { .. })
         ));
-    }
-
-    #[test]
-    fn meta_fetch_cap_clears_measured_youtube_metadata_offsets() {
-        // Measured 2026-08 with browser headers and identity encoding: YouTube
-        // watch pages put <title>/og:title at ~686-691 KiB and close <head> at
-        // ~697 KiB. Keep at least 2x that, or the scrape silently parses zero
-        // metadata there and the AI leg fabricates titles from the thumbnail.
-        assert!(META_FETCH_MAX_BYTES >= 1_400_000);
     }
 
     #[test]


### PR DESCRIPTION
Raises the capture meta-fetch byte cap from 512 KiB to 2 MiB: a YouTube watch page serves ~1.2 MB of identity-encoded HTML with every meta tag at ~690 KiB, so the 512 KiB scrape parsed zero metadata and captures kept placeholder or AI-invented titles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata retrieval for larger pages by increasing the supported HTML response size limit.
  * Added clearer documentation for the updated bounded payload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->