### PR TITLE
fix: pick up Mac note edits after the iOS app returns from background

### DIFF
--- a/apps/desktop/src/lib/icloud-controller.test.tsx
+++ b/apps/desktop/src/lib/icloud-controller.test.tsx
@@ -241,6 +241,39 @@ describe('createIcloudController', () => {
     }
   })
 
+  it('a mobile resume restarts the metadata watch (stop before start)', async () => {
+    // A long iOS suspension can kill NSMetadataQuery update delivery, and on
+    // mobile the query is the sole external-change source — the resume must
+    // reinstall it or remote edits stay invisible until relaunch.
+    const icloud = controller({ emit: true })
+    await icloud.start()
+    await settleScan()
+    invoked.length = 0
+
+    window.dispatchEvent(new Event('focus'))
+    await settleScan()
+
+    const commands = invoked.map(([command]) => command)
+    const stopAt = commands.indexOf('icloud_watch_stop')
+    const startAt = commands.indexOf('icloud_watch_start')
+    expect(stopAt).toBeGreaterThanOrEqual(0)
+    expect(startAt).toBeGreaterThan(stopAt)
+    expect(invoked[startAt]?.[1]).toMatchObject({ root: GRAPH.root, emitFileChanges: true })
+  })
+
+  it('a desktop resume sweeps without restarting the watch', async () => {
+    const icloud = controller()
+    await icloud.start()
+    await settleScan()
+    invoked.length = 0
+
+    window.dispatchEvent(new Event('focus'))
+    await settleScan()
+
+    expect(invoked.some(([command]) => command === 'icloud_watch_stop')).toBe(false)
+    expect(scanCalls).toHaveLength(2) // baseline + the resume sweep itself
+  })
+
   it('preserves desktop baseline scanning while the document is hidden', async () => {
     const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
     try {

--- a/apps/desktop/src/lib/icloud-controller.test.tsx
+++ b/apps/desktop/src/lib/icloud-controller.test.tsx
@@ -271,6 +271,7 @@ describe('createIcloudController', () => {
     await settleScan()
 
     expect(invoked.some(([command]) => command === 'icloud_watch_stop')).toBe(false)
+    expect(invoked.some(([command]) => command === 'icloud_watch_start')).toBe(false)
     expect(scanCalls).toHaveLength(2) // baseline + the resume sweep itself
   })
 

--- a/apps/desktop/src/lib/icloud-controller.ts
+++ b/apps/desktop/src/lib/icloud-controller.ts
@@ -89,6 +89,11 @@ export interface IcloudController {
  *   folder get no conflict signal — and a conflict version can appear
  *   without the working file changing, which the `notify` watcher can't see
  *   either. The resume sweep is the backstop for both.
+ * - On mobile, restarts the watch on every foreground resume: a long iOS
+ *   suspension can sever the query's link to `fileproviderd` and update
+ *   delivery never recovers, and the query is the *sole* external-change
+ *   source there — a silently dead watch means a Mac edit synced while
+ *   backgrounded stays invisible until the app is relaunched.
  *
  * Dirty open sessions are deferred (their paths ride `skipPaths`) as a
  * courtesy, not a safety net — even without it, a sweep write lands on disk
@@ -282,6 +287,28 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
     }
   }
 
+  /**
+   * Tear down and reinstall the metadata watch — the mobile resume recovery.
+   * A stop/start pair is the canonical cure for a post-suspension
+   * NSMetadataQuery that has stopped delivering updates: the Rust epoch
+   * lifecycle serializes rapid restarts, the fresh gather round emits one
+   * coarse `index:reconcile` (folded into the resume's own refresh), and the
+   * live query then reports the remote metadata whenever `fileproviderd`
+   * learns of it — which closes the resume race where the nudge-and-poll
+   * backstop runs before the OS even knows a newer version exists.
+   */
+  async function restartWatch(): Promise<void> {
+    try {
+      await icloudWatchStop()
+      if (disposed) {
+        return // closed mid-restart: never leave a watch running for a dead graph
+      }
+      await icloudWatchStart(graph.root, emitFileChangesFromWatch)
+    } catch (err) {
+      console.error('iCloud watch restart failed:', err)
+    }
+  }
+
   async function start(): Promise<void> {
     if (disposed) {
       return
@@ -352,7 +379,17 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
     } catch (err) {
       console.error('iCloud change subscriptions failed to start:', err)
     }
-    disposers.push(...attachResumeListeners(scheduleScan))
+    disposers.push(
+      ...attachResumeListeners(() => {
+        if (emitFileChangesFromWatch) {
+          // Mobile only: desktop's query survives sleep well enough for its
+          // conflict-signal role, and desktop content freshness rides the
+          // `notify` watcher plus the wake-time reconcile, not this query.
+          void restartWatch()
+        }
+        scheduleScan()
+      }),
+    )
     // The adoption baseline + any conflicts that accrued while closed.
     scheduleScan()
   }

--- a/apps/desktop/src/lib/icloud-controller.ts
+++ b/apps/desktop/src/lib/icloud-controller.ts
@@ -300,12 +300,24 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
   async function restartWatch(): Promise<void> {
     try {
       await icloudWatchStop()
-      if (disposed) {
-        return // closed mid-restart: never leave a watch running for a dead graph
-      }
+    } catch (err) {
+      // A failed stop must not abort the restart: the Rust install tears
+      // down any live watch itself, so starting over a possibly-live query
+      // is safe — and the reinstall is the half that matters here.
+      console.error('iCloud watch stop failed during restart:', err)
+    }
+    if (disposed) {
+      return // closed mid-restart: never leave a watch running for a dead graph
+    }
+    try {
       await icloudWatchStart(graph.root, emitFileChangesFromWatch)
     } catch (err) {
-      console.error('iCloud watch restart failed:', err)
+      // Same degradation contract as a failed initial start: freshness
+      // rides file-change batches and resume sweeps (this resume already
+      // scheduled one), and the next resume retries the reinstall. A
+      // Rust-side install failure additionally emits `icloud:watch-failed`,
+      // which the subscription above answers with an immediate sweep.
+      console.error('iCloud watch restart failed; relying on resume-triggered sweeps:', err)
     }
   }
 


### PR DESCRIPTION
## Problem

A daily note edited on the Mac while the iOS app sat backgrounded showed stale content on iOS until the app was force-quit; the relaunch showed the updated note instantly (the bytes were already on disk — only the running app had missed them).

Two holes compound on iOS:

1. **The metadata watch can die silently after a long suspension.** NSMetadataQuery's update delivery is known to stop after iOS suspends the app for a while (its internal link to `fileproviderd` is severed and never re-established). On mobile the query is the *sole* external-change source — no file watcher exists there — so a dead query means the entire notice → download-nudge → upsert pipeline is gone.
2. **The resume backstop can't see "downloaded but stale."** `use-icloud-refresh`'s resume pass runs at the instant of foregrounding — before `fileproviderd` has even learned the cloud holds a newer version — and its pending walk counts only dataless placeholders, so a materialized-but-outdated note reads as zero pending and no poll is scheduled.

## Change

Restart the metadata watch (stop + start) on every mobile foreground resume, from the iCloud controller's existing deduped resume listener:

- A fresh query is the canonical recovery for the post-suspension stall — update rounds flow again, so the Mac edit is noticed, nudged, downloaded, and upserted whenever the metadata arrives in the seconds after resume. This also closes the too-early-backstop race without polling.
- The fresh gather round already emits one coarse `index:reconcile` on mobile, giving a second reconcile after the listing lands.
- The Rust `EPOCH` lifecycle already serializes rapid stop/start pairs, and the cleared conflict view degrades sweeps to full — the safe direction.
- Desktop resumes are unchanged (content freshness there rides the `notify` watcher plus the wake-time reconcile from #1076); the restart is gated on the mobile flag.

Cost: one gather round per foreground resume — the same walk every cold open performs, on top of the full `refreshIndex` mobile already runs per resume.

## Testing

- Two new tests in `icloud-controller.test.tsx`: a mobile resume restarts the watch (stop strictly before start, correct args), and a desktop resume sweeps without restarting. Full suite: 17/17 pass.
- `pnpm check` (typecheck + lint) passes.
- Not yet verified on a device: the real repro (edit on Mac, resume the long-suspended iOS app) — owed as a manual pass on the next TestFlight build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches iCloud sync lifecycle on every mobile resume; logic is isolated behind the mobile flag with tests, but incorrect restart timing could affect freshness or watch stability.
> 
> **Overview**
> Fixes stale iOS note content after long backgrounding by **reinstalling the iCloud metadata watch** (`icloud_watch_stop` then `icloud_watch_start`) whenever the app resumes on mobile, alongside the existing resume conflict sweep.
> 
> The new `restartWatch()` path is wired into the deduped resume listener and gated on `emitFileChangesFromWatch` (mobile); desktop resumes still only schedule a full sweep. Stop/start failures are logged but do not block the resume sweep; dispose mid-restart skips starting a new watch.
> 
> Tests assert mobile resume issues stop-before-start with the correct root/emit args, and desktop resume does not restart the watch but does run a second scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 064b1d3d4c124a08f051c7bb22022d87d7fa6c01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved iCloud synchronization when the app resumes on mobile by restarting metadata monitoring and performing the necessary resume check.
  - Prevented metadata monitoring from restarting after the service has been disposed.
  - Added error handling so monitoring restart failures are recorded without interrupting resume behavior.
  - Desktop resume behavior remains unchanged, continuing to trigger a synchronization sweep.

- **Tests**
  - Added coverage for mobile and desktop resume scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->