### PR TITLE
fix: stop AI enrichment from inventing titles for captured links

### DIFF
--- a/packages/core/src/ai/describe-page.test.ts
+++ b/packages/core/src/ai/describe-page.test.ts
@@ -127,7 +127,7 @@ describe('describePage', () => {
 
     const text = userText(calls)
     expect(text).toContain('share sheets often supply boilerplate')
-    expect(text).toContain('build the title from the meta title, page text, or screenshot')
+    expect(text).toContain('rebuild the title only from text you can actually quote')
   })
 
   it('sanitizes the returned title for wiki-link display', async () => {

--- a/packages/core/src/ai/describe-page.ts
+++ b/packages/core/src/ai/describe-page.ts
@@ -124,8 +124,8 @@ function describePrompt(request: DescribePageRequest): string {
     lines.push(`Extracted page text: ${request.contentText.slice(0, MAX_CONTENT_TEXT_CHARS)}`)
   }
   lines.push(
-    'Ground both fields in the extracted page text when present, and the screenshot when one is attached.',
-    'title: the page\'s own title cleaned up for display — drop the site name, separators, and SEO clutter; keep the page\'s language and its plain wording. The captured title may not describe the page at all: share sheets often supply boilerplate ("See this Instagram post by @user"), a bare domain, or message text — in that case build the title from the meta title, page text, or screenshot instead of keeping it. Never invent an editorial retitle; when the captured title already describes the page cleanly, return it unchanged.',
+    'Ground both fields in the extracted page text when present, and the screenshot when one is attached. State only what those inputs show: recognizing the site, a show, or a person in the screenshot is not knowing which page this is.',
+    "title: the page's own title cleaned up for display — drop the site name, separators, and SEO clutter; keep the page's language and its plain wording. The captured title may not describe the page at all: share sheets often supply boilerplate (\"See this Instagram post by @user\"), a bare domain, or message text — in that case rebuild the title only from text you can actually quote: the meta title, the page text, or words readable in the screenshot. When none of those contain the page's title, return null for the title; a specific-sounding guess is worse than none. Never invent an editorial retitle; when the captured title already describes the page cleanly, return it unchanged.",
     'description: one or two plain sentences describing the page — no preamble, no markdown.',
   )
   return lines.join('\n')

--- a/packages/core/src/ai/describe-page.ts
+++ b/packages/core/src/ai/describe-page.ts
@@ -59,7 +59,7 @@ export interface PageEnrichment {
 }
 
 const pageDescriptionSchema = z.object({
-  title: z.string(),
+  title: z.string().nullable(),
   description: z.string(),
 })
 
@@ -168,7 +168,7 @@ export async function describePage(request: DescribePageRequest): Promise<PageEn
       maxRetries: 0,
     })
     return {
-      title: normalizedPageTitle(result.object.title),
+      title: result.object.title === null ? null : normalizedPageTitle(result.object.title),
       description: result.object.description.trim(),
     }
   } catch (cause) {


### PR DESCRIPTION
When the capture inputs contain no quotable text for a page title, the model is now asked (and the schema now allows it) to return `null` for the title, so the note keeps its current title instead of getting an invented one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatically generated page titles by grounding them in quotable page text.
  - Titles now remain blank when reliable source text is unavailable, avoiding guessed or unsupported titles.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->