### PR TITLE
fix: capture YouTube video titles via oEmbed

### DIFF
--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -566,9 +566,9 @@ fn classify_fetch_status(url: &str, status: reqwest::StatusCode) -> Option<AppEr
 
 /// Fetch a captured page's HTML for meta-tag scraping, hard-capped (timeout,
 /// byte cap, redirect limit, http(s) only). Lives here rather than widening
-/// the webview's HTTP-plugin capability to every URL — the only thing that
-/// can reach arbitrary hosts is this bounded, HTML-only primitive, and the
-/// privacy gate in `@reflect/core` runs before it is ever called.
+/// the webview's HTTP-plugin capability to every URL — the only things that
+/// can reach arbitrary hosts are this module's bounded fetch primitives, and
+/// the privacy gate in `@reflect/core` runs before either is ever called.
 #[tauri::command]
 pub async fn capture_meta_fetch(url: String) -> AppResult<String> {
     if !url.starts_with("https://") && !url.starts_with("http://") {
@@ -623,6 +623,64 @@ pub async fn capture_meta_fetch(url: String) -> AppResult<String> {
         }
     }
     Ok(String::from_utf8_lossy(&body).into_owned())
+}
+
+// ---- oEmbed fetch ---------------------------------------------------------------
+
+/// oEmbed answers are ~1 KB of JSON; anything past this cap is not an oEmbed
+/// answer, and a truncated one would be unparseable, so oversize is an error
+/// rather than a cut.
+const OEMBED_FETCH_MAX_BYTES: usize = 64 * 1024;
+
+/// Fetch an oEmbed endpoint's JSON answer for the capture meta scrape. Which
+/// URLs are oEmbed endpoints is policy and lives in `@reflect/core`
+/// (`actions/oembed`), behind the same privacy gate as `capture_meta_fetch`;
+/// this side only bounds the transport, strictly tighter than the HTML
+/// fetch: https only, JSON only, a small byte cap, and no redirects (oEmbed
+/// endpoints answer directly, so a redirect is a failure).
+#[tauri::command]
+pub async fn capture_oembed_fetch(url: String) -> AppResult<String> {
+    if !url.starts_with("https://") {
+        return Err(AppError::parse(format!("not an https url: {url}")));
+    }
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(META_FETCH_TIMEOUT)
+        .user_agent(META_FETCH_USER_AGENT)
+        .build()
+        .map_err(|err| AppError::io(err.to_string()))?;
+    let response = client
+        .get(&url)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(classify_fetch_error)?;
+    if let Some(err) = classify_fetch_status(&url, response.status()) {
+        return Err(err);
+    }
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+        .to_ascii_lowercase(); // MIME types are case-insensitive (`TEXT/HTML`)
+    if !content_type.contains("json") {
+        return Err(AppError::parse(format!(
+            "{url} did not answer JSON ({content_type})"
+        )));
+    }
+    let mut body: Vec<u8> = Vec::new();
+    let mut response = response;
+    while let Some(chunk) = response.chunk().await.map_err(classify_fetch_error)? {
+        if body.len() + chunk.len() > OEMBED_FETCH_MAX_BYTES {
+            return Err(AppError::parse(format!(
+                "{url} answered more than {OEMBED_FETCH_MAX_BYTES} bytes"
+            )));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    String::from_utf8(body)
+        .map_err(|err| AppError::parse(format!("{url} answered non-UTF-8: {err}")))
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -355,6 +355,7 @@ pub fn run() {
             capture::capture_screenshot_promote,
             capture::capture_link_preview,
             capture::capture_meta_fetch,
+            capture::capture_oembed_fetch,
             git::git_status,
             git::git_setup,
             git::git_disconnect,

--- a/packages/core/src/actions/meta-scrape-routing.test.ts
+++ b/packages/core/src/actions/meta-scrape-routing.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ReflectError } from '../errors'
+import { captureMetaFetch, captureOEmbedFetch } from '../graph/commands'
+import { scrapePageMeta } from './meta-scrape'
+
+vi.mock('../graph/commands', () => ({
+  captureMetaFetch: vi.fn(),
+  captureOEmbedFetch: vi.fn(),
+}))
+
+const oembedFetchMock = vi.mocked(captureOEmbedFetch)
+const metaFetchMock = vi.mocked(captureMetaFetch)
+
+const VIDEO_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+const REQUEST_URL =
+  'https://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ&format=json'
+const OEMBED_ANSWER = JSON.stringify({
+  title: 'Rick Astley - Never Gonna Give You Up (Official Video) (4K Remaster)',
+  author_name: 'Rick Astley',
+  provider_name: 'YouTube',
+  type: 'video',
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('scrapePageMeta', () => {
+  it('resolves a claimed URL through oEmbed without touching the HTML fetch', async () => {
+    oembedFetchMock.mockResolvedValue(OEMBED_ANSWER)
+
+    const meta = await scrapePageMeta(VIDEO_URL)
+
+    expect(meta).toEqual({
+      title: 'Rick Astley - Never Gonna Give You Up (Official Video) (4K Remaster)',
+      description: null,
+      siteName: 'YouTube',
+    })
+    expect(oembedFetchMock).toHaveBeenCalledWith(REQUEST_URL)
+    expect(metaFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the HTML scrape when the endpoint refuses the id', async () => {
+    oembedFetchMock.mockRejectedValue(new ReflectError('io', 'answered 400'))
+    metaFetchMock.mockRejectedValue(new ReflectError('parse', 'fallback reached'))
+
+    await expect(scrapePageMeta(VIDEO_URL)).rejects.toMatchObject({
+      message: 'fallback reached',
+    })
+  })
+
+  it('falls back to the HTML scrape when the answer does not parse', async () => {
+    oembedFetchMock.mockResolvedValue('not json')
+    metaFetchMock.mockRejectedValue(new ReflectError('parse', 'fallback reached'))
+
+    await expect(scrapePageMeta(VIDEO_URL)).rejects.toMatchObject({
+      message: 'fallback reached',
+    })
+  })
+
+  it('falls back to the HTML scrape when the answer has a blank title', async () => {
+    oembedFetchMock.mockResolvedValue('{"title":"   "}')
+    metaFetchMock.mockRejectedValue(new ReflectError('parse', 'fallback reached'))
+
+    await expect(scrapePageMeta(VIDEO_URL)).rejects.toMatchObject({
+      message: 'fallback reached',
+    })
+  })
+
+  it('propagates a transient oEmbed failure for retry', async () => {
+    oembedFetchMock.mockRejectedValue(new ReflectError('network', 'offline'))
+
+    await expect(scrapePageMeta(VIDEO_URL)).rejects.toMatchObject({ kind: 'network' })
+    expect(metaFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('sends unclaimed URLs straight to the HTML fetch', async () => {
+    metaFetchMock.mockRejectedValue(new ReflectError('parse', 'fallback reached'))
+
+    await expect(scrapePageMeta('https://example.com/article')).rejects.toMatchObject({
+      message: 'fallback reached',
+    })
+    expect(oembedFetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/actions/meta-scrape.ts
+++ b/packages/core/src/actions/meta-scrape.ts
@@ -1,4 +1,6 @@
-import { captureMetaFetch } from '../graph/commands'
+import { toAppError } from '../errors'
+import { captureMetaFetch, captureOEmbedFetch } from '../graph/commands'
+import { oembedRequestURL, parseOEmbedAnswer } from './oembed'
 
 /**
  * Meta-tag scraping for link capture (Plan 11) — the no-AI half of
@@ -46,11 +48,48 @@ export function parsePageMeta(html: string): PageMeta {
   }
 }
 
+async function scrapeOEmbed(requestURL: string): Promise<PageMeta | null> {
+  let json: string
+  try {
+    json = await captureOEmbedFetch(requestURL)
+  } catch (cause) {
+    const kind = toAppError(cause).kind
+    if (kind === 'network' || kind === 'auth') {
+      throw cause
+    }
+    // A refused id (400), a private or embed-disabled video (401/403), and a
+    // non-JSON answer are permanent for the shortcut; the generic HTML
+    // scrape still gets its turn.
+    return null
+  }
+  const answer = parseOEmbedAnswer(json)
+  if (answer === null) {
+    return null
+  }
+  const title = clean(answer.title)
+  if (title === null) {
+    return null
+  }
+  // oEmbed has no description field; the capture keeps none until (and
+  // unless) the AI leg writes one, now grounded in this real title.
+  return { title, description: null, siteName: clean(answer.providerName) }
+}
+
 /**
- * Fetch and parse one captured page's meta tags. Propagates the fetch's
+ * Fetch and parse one captured page's meta tags. URLs a registered oEmbed
+ * provider claims (see `actions/oembed`) resolve through that provider's
+ * endpoint first; every other page, and any claimed URL whose oEmbed attempt
+ * failed permanently, takes the generic HTML scrape. Propagates the fetch's
  * typed errors (`network` for transient failures the enrichment pass should
  * retry, `io`/`parse` for permanent ones it should write through without).
  */
 export async function scrapePageMeta(url: string): Promise<PageMeta> {
+  const requestURL = oembedRequestURL(url)
+  if (requestURL !== null) {
+    const meta = await scrapeOEmbed(requestURL)
+    if (meta !== null) {
+      return meta
+    }
+  }
   return parsePageMeta(await captureMetaFetch(url))
 }

--- a/packages/core/src/actions/oembed.test.ts
+++ b/packages/core/src/actions/oembed.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { oembedRequestURL, parseOEmbedAnswer } from './oembed'
+
+describe('oembedRequestURL', () => {
+  it('builds the YouTube request with the capture URL form-encoded', () => {
+    expect(oembedRequestURL('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(
+      'https://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ&format=json',
+    )
+  })
+
+  it.each([
+    'https://youtu.be/dQw4w9WgXcQ?si=abc123',
+    'https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL0abc&t=42',
+    'https://m.youtube.com/watch?v=dQw4w9WgXcQ',
+    'https://music.youtube.com/watch?v=dQw4w9WgXcQ',
+    'https://www.youtube.com/shorts/dQw4w9WgXcQ',
+    'https://www.youtube.com/live/dQw4w9WgXcQ',
+    'https://www.youtube.com/embed/dQw4w9WgXcQ',
+    'http://youtu.be/dQw4w9WgXcQ',
+  ])('claims %s', (url) => {
+    expect(oembedRequestURL(url)).toContain('https://www.youtube.com/oembed?')
+  })
+
+  it.each([
+    'https://www.youtube.com/',
+    'https://www.youtube.com/@RickAstleyYT',
+    'https://www.youtube.com/playlist?list=PL0abc',
+    'https://www.youtube.com/watch',
+    'https://www.youtube.com/results?search_query=rick+astley',
+    'https://youtu.be/',
+    'https://youtube.com.evil.com/watch?v=dQw4w9WgXcQ',
+    'https://example.com/watch?v=dQw4w9WgXcQ',
+    'ftp://youtu.be/dQw4w9WgXcQ',
+    'not a url',
+  ])('leaves %s to the HTML scrape', (url) => {
+    expect(oembedRequestURL(url)).toBeNull()
+  })
+})
+
+describe('parseOEmbedAnswer', () => {
+  it('reads the title and provider name', () => {
+    const json =
+      '{"title":"Rick Astley - Never Gonna Give You Up (Official Video) (4K Remaster)","author_name":"Rick Astley","provider_name":"YouTube","type":"video"}'
+    expect(parseOEmbedAnswer(json)).toEqual({
+      title: 'Rick Astley - Never Gonna Give You Up (Official Video) (4K Remaster)',
+      providerName: 'YouTube',
+    })
+  })
+
+  it('treats an absent provider name as null', () => {
+    expect(parseOEmbedAnswer('{"title":"T"}')).toEqual({ title: 'T', providerName: null })
+  })
+
+  it('reads malformed JSON and a wrong shape as null', () => {
+    expect(parseOEmbedAnswer('<html>')).toBeNull()
+    expect(parseOEmbedAnswer('{"error":"Bad Request"}')).toBeNull()
+  })
+})

--- a/packages/core/src/actions/oembed.ts
+++ b/packages/core/src/actions/oembed.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod'
+
+/**
+ * oEmbed policy for link capture: which capture URLs have an oEmbed answer
+ * worth asking for, where to ask, and what a valid answer looks like. The
+ * Rust `capture_oembed_fetch` primitive only bounds the transport (https,
+ * JSON, a small byte cap, no redirects); everything provider-shaped lives
+ * here, so supporting another provider is a TypeScript-only change: one more
+ * entry in `OEMBED_PROVIDERS`.
+ */
+
+interface OEmbedProvider {
+  /** Does this capture URL address one resource the provider can describe? */
+  matches: (url: URL) => boolean
+  /** The provider's oEmbed endpoint, before the `url`/`format` params. */
+  endpoint: string
+}
+
+function isYouTubeHost(host: string): boolean {
+  return host === 'youtu.be' || host === 'youtube.com' || host.endsWith('.youtube.com')
+}
+
+/**
+ * Id-safe characters only. The endpoint is the authority on real ids: a shape
+ * this misses skips the shortcut, and junk that slips through answers 400 and
+ * falls back, so the check stays permissive.
+ */
+const YOUTUBE_VIDEO_ID = /^[\w-]+$/
+
+/**
+ * YouTube watch pages bury `<title>` and the `og:` tags ~700 KB into ~1.2 MB
+ * of identity-encoded HTML, so the HTML scrape must pull the whole page to
+ * read them; the oEmbed answer carries the exact title in ~1 KB.
+ */
+const youtube: OEmbedProvider = {
+  matches: (url) => {
+    if (!isYouTubeHost(url.hostname)) {
+      return false
+    }
+    if (url.hostname === 'youtu.be') {
+      return YOUTUBE_VIDEO_ID.test(url.pathname.slice(1))
+    }
+    if (url.pathname === '/watch') {
+      return YOUTUBE_VIDEO_ID.test(url.searchParams.get('v') ?? '')
+    }
+    const prefixed = /^\/(?:shorts|live|embed)\/([^/]+)$/.exec(url.pathname)
+    return prefixed !== null && YOUTUBE_VIDEO_ID.test(prefixed[1]!)
+  },
+  endpoint: 'https://www.youtube.com/oembed',
+}
+
+const OEMBED_PROVIDERS: readonly OEmbedProvider[] = [youtube]
+
+/**
+ * The oEmbed request URL for a capture URL, or `null` when no registered
+ * provider claims it. The capture URL rides along URL-encoded, exactly as
+ * shared (no canonicalization: the endpoints resolve short links, mobile
+ * hosts, and junk params themselves).
+ */
+export function oembedRequestURL(captureURL: string): string | null {
+  let parsed: URL
+  try {
+    parsed = new URL(captureURL)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    return null
+  }
+  const provider = OEMBED_PROVIDERS.find((candidate) => candidate.matches(parsed))
+  if (provider === undefined) {
+    return null
+  }
+  const request = new URL(provider.endpoint)
+  request.searchParams.set('url', captureURL)
+  request.searchParams.set('format', 'json')
+  return request.href
+}
+
+const oembedAnswerSchema = z.object({
+  title: z.string(),
+  provider_name: z.string().optional(),
+})
+
+/** The fields of an oEmbed answer the capture pipeline consumes. */
+export interface OEmbedAnswer {
+  title: string
+  /** `provider_name`, the `og:site_name` analogue (`"YouTube"`). */
+  providerName: string | null
+}
+
+/** Parse one oEmbed answer's JSON text, or `null` when it is not one. */
+export function parseOEmbedAnswer(json: string): OEmbedAnswer | null {
+  let raw: unknown
+  try {
+    raw = JSON.parse(json)
+  } catch {
+    return null
+  }
+  const parsed = oembedAnswerSchema.safeParse(raw)
+  if (!parsed.success) {
+    return null
+  }
+  return { title: parsed.data.title, providerName: parsed.data.provider_name ?? null }
+}

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -409,6 +409,16 @@ export async function captureMetaFetch(url: string): Promise<string> {
   return await call('capture_meta_fetch', { url }, z.string())
 }
 
+/**
+ * Fetch an oEmbed endpoint's JSON answer as text. The Rust side only bounds
+ * the transport (https only, JSON only, a small byte cap, no redirects);
+ * which URLs are oEmbed endpoints is policy in `actions/oembed`. The privacy
+ * gate runs before any call here, exactly as for {@link captureMetaFetch}.
+ */
+export async function captureOEmbedFetch(url: string): Promise<string> {
+  return await call('capture_oembed_fetch', { url }, z.string())
+}
+
 /** The recently-opened graphs, newest first. */
 export async function recentGraphs(): Promise<RecentGraph[]> {
   return await call('recent_graphs', {}, z.array(recentGraphSchema))


### PR DESCRIPTION
Resolve YouTube capture titles through the oEmbed endpoint: a bounded `capture_oembed_fetch` Rust primitive plus a TypeScript oEmbed provider registry wired into `scrapePageMeta`, falling back to the HTML scrape on any permanent failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added YouTube oEmbed support for capturing page titles and provider names.
  * Metadata scraping now uses oEmbed when available and falls back to HTML when needed.
  * Added secure, bounded fetching for oEmbed endpoints.

* **Bug Fixes**
  * Improved handling of invalid, incomplete, or rejected oEmbed responses.
  * Network and authentication errors are surfaced appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->