### PR TITLE
fix(ios): fix TestFlight archive re-signing

### DIFF
--- a/apps/desktop/src-tauri/xcode-scripts/preserve-entitlements.sh
+++ b/apps/desktop/src-tauri/xcode-scripts/preserve-entitlements.sh
@@ -9,11 +9,20 @@ if [ -f "$ENV_LOCAL" ]; then
   . "$ENV_LOCAL"
 fi
 
-# CODE_SIGN_ENTITLEMENTS is per-target and per-configuration (Debug selects
-# the .dev entitlements with the dev App Group), so re-sign with the file the
-# active build picked rather than hardcoding one.
+# The path is derived from TARGET_NAME + CONFIGURATION rather than read from
+# $CODE_SIGN_ENTITLEMENTS: skip-codesign builds are exactly the flow where
+# tauri blanks that setting on the xcodebuild command line (cargo-mobile2
+# src/apple/target.rs passes CODE_SIGN_ENTITLEMENTS="" when skipping
+# codesign), and a command-line override beats every target setting. Debug
+# picks the .dev entitlements (dev App Group), everything else the release
+# file.
 if [ "${CODE_SIGNING_ALLOWED:-YES}" = "NO" ]; then
+  if [ "${CONFIGURATION:?}" = "debug" ]; then
+    ENTITLEMENTS="${SRCROOT:?}/${TARGET_NAME:?}/${TARGET_NAME:?}.dev.entitlements"
+  else
+    ENTITLEMENTS="${SRCROOT:?}/${TARGET_NAME:?}/${TARGET_NAME:?}.entitlements"
+  fi
   /usr/bin/codesign --force --sign - \
-    --entitlements "${SRCROOT:?}/${CODE_SIGN_ENTITLEMENTS:?}" \
+    --entitlements "$ENTITLEMENTS" \
     "${CODESIGNING_FOLDER_PATH:?}"
 fi


### PR DESCRIPTION
Fixes the TestFlight build failure in https://github.com/team-reflect/reflect-open/actions/runs/31384140197/job/93440820273: `tauri ios build` passes `CODE_SIGN_ENTITLEMENTS=""` as an xcodebuild command-line override in skip-codesign archives (cargo-mobile2 `src/apple/target.rs`), which beats every target setting, so the re-sign script now derives the entitlements file from `TARGET_NAME` + `CONFIGURATION` instead of reading that variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entitlement handling for desktop debug and skip-code-signing builds.
  * Ensured the appropriate development or standard entitlements are selected based on the build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->