### PR TITLE
feat: insert Zotero item links from the local Zotero library

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -35,6 +35,7 @@ mod secrets;
 mod settings;
 mod skill;
 mod windows;
+mod zotero;
 
 // The watcher and the embedding runtime are desktop capabilities (Plan 19):
 // mobile swaps in stand-ins with the identical command surface, so the
@@ -345,6 +346,7 @@ pub fn run() {
             contacts::contacts_request_access,
             contacts::contacts_lookup_by_email,
             contacts::contacts_lookup_by_name,
+            zotero::zotero_search,
             capture::capture_host_register,
             capture::capture_inbox_list,
             capture::capture_inbox_spool,

--- a/apps/desktop/src-tauri/src/zotero.rs
+++ b/apps/desktop/src-tauri/src/zotero.rs
@@ -36,6 +36,10 @@ pub struct ZoteroItem {
     /// The item's `date` field as authored ("2020-01-01", "2020", "n.d.").
     pub date: Option<String>,
     pub item_type: String,
+    /// The item's abstract as authored; the picker truncates for display.
+    pub abstract_note: Option<String>,
+    /// The item's URL field, when the item carries one.
+    pub url: Option<String>,
 }
 
 /// The `data` envelope every Local API item is wrapped in.
@@ -56,6 +60,10 @@ struct ZoteroApiData {
     date: Option<String>,
     #[serde(default)]
     item_type: String,
+    #[serde(default)]
+    abstract_note: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -149,6 +157,8 @@ pub async fn zotero_search(query: String) -> AppResult<Vec<ZoteroItem>> {
                     .collect(),
                 date: data.date,
                 item_type: data.item_type,
+                abstract_note: data.abstract_note,
+                url: data.url,
             }
         })
         .collect();

--- a/apps/desktop/src-tauri/src/zotero.rs
+++ b/apps/desktop/src-tauri/src/zotero.rs
@@ -1,0 +1,207 @@
+//! Zotero integration (desktop): search the local Zotero library through
+//! Zotero 7's built-in Local API and return candidate items for the link
+//! picker.
+//!
+//! Zotero runs a read-only HTTP server on `127.0.0.1:23119` when "Allow other
+//! applications on this computer to communicate with Zotero" is enabled
+//! (Settings → Advanced). No credentials are involved: the server answers
+//! anonymous localhost requests that carry the `Zotero-Allowed-Request`
+//! header — its guard against browser-originated CSRF/DNS-rebinding requests.
+//!
+//! Rust owns the capability (fetch + normalize); which item becomes which
+//! markdown link is policy in `@reflect/core` (`zotero/commands.ts`).
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, AppResult};
+
+/// Zotero's Local API item listing. `users/0` is the "current user" alias
+/// Zotero rewrites server-side, so no user id is ever needed.
+const ZOTERO_API_ITEMS: &str = "http://127.0.0.1:23119/api/users/0/items";
+/// Cap on returned items — the same 50-row ceiling the Obsidian plugin uses.
+const ZOTERO_RESULT_LIMIT: usize = 50;
+const ZOTERO_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// One searchable library item, normalized for the picker.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZoteroItem {
+    /// The 8-character Zotero item key — the `zotero://` deep-link target.
+    pub key: String,
+    pub title: String,
+    /// Creator display names in document order ("Smith, John").
+    pub creators: Vec<String>,
+    /// The item's `date` field as authored ("2020-01-01", "2020", "n.d.").
+    pub date: Option<String>,
+    pub item_type: String,
+}
+
+/// The `data` envelope every Local API item is wrapped in.
+#[derive(Debug, Deserialize)]
+struct ZoteroApiEnvelope {
+    data: ZoteroApiData,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ZoteroApiData {
+    key: String,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    creators: Vec<ZoteroApiCreator>,
+    #[serde(default)]
+    date: Option<String>,
+    #[serde(default)]
+    item_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ZoteroApiCreator {
+    #[serde(default)]
+    first_name: Option<String>,
+    #[serde(default)]
+    last_name: Option<String>,
+    /// The `name` field, set only for institution creators.
+    #[serde(default)]
+    name: Option<String>,
+}
+
+/// The display name for one creator: person creators render "Last, First",
+/// institution creators render their `name`. None when the creator has no
+/// renderable name at all.
+fn render_creator_name(creator: &ZoteroApiCreator) -> Option<String> {
+    if let Some(name) = creator.name.as_deref().filter(|name| !name.trim().is_empty()) {
+        return Some(name.to_string());
+    }
+    let first = creator.first_name.as_deref().unwrap_or("").trim();
+    let last = creator.last_name.as_deref().unwrap_or("").trim();
+    match (first.is_empty(), last.is_empty()) {
+        (true, true) => None,
+        (true, false) => Some(last.to_string()),
+        (false, true) => Some(first.to_string()),
+        (false, false) => Some(format!("{last}, {first}")),
+    }
+}
+
+fn classify_zotero_error(err: reqwest::Error) -> AppError {
+    AppError::Network {
+        message: format!(
+            "Couldn't connect to Zotero — is the app running with its local API enabled? ({err})"
+        ),
+    }
+}
+
+/// Search the local Zotero library by title/creator/year (Zotero's
+/// quicksearch). Returns an empty list for an empty query or when nothing
+/// matches; fails with a `Network` error when Zotero is closed or its Local
+/// API is disabled, and a `parse` error when the response is malformed.
+#[tauri::command]
+pub async fn zotero_search(query: String) -> AppResult<Vec<ZoteroItem>> {
+    let query = query.trim();
+    if query.is_empty() {
+        return Ok(Vec::new());
+    }
+    let client = reqwest::Client::builder()
+        .timeout(ZOTERO_TIMEOUT)
+        .user_agent("Reflect")
+        .build()
+        .map_err(|err| AppError::io(err.to_string()))?;
+    let response = client
+        .get(ZOTERO_API_ITEMS)
+        .query(&[
+            ("itemType", "-attachment"),
+            ("q", query),
+            ("limit", &ZOTERO_RESULT_LIMIT.to_string()),
+        ])
+        // Zotero's local server silently drops browser-looking requests unless
+        // they prove intent with this header (its CSRF/DNS-rebinding guard).
+        .header("Zotero-Allowed-Request", "true")
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(classify_zotero_error)?;
+
+    if !response.status().is_success() {
+        return Err(AppError::Network {
+            message: format!("Zotero answered {}", response.status()),
+        });
+    }
+    let envelopes: Vec<ZoteroApiEnvelope> = response
+        .json()
+        .await
+        .map_err(|err| AppError::parse(format!("invalid Zotero response: {err}")))?;
+
+    let items = envelopes
+        .into_iter()
+        .map(|envelope| {
+            let data = envelope.data;
+            ZoteroItem {
+                key: data.key,
+                title: data.title,
+                creators: data
+                    .creators
+                    .iter()
+                    .filter_map(render_creator_name)
+                    .collect(),
+                date: data.date,
+                item_type: data.item_type,
+            }
+        })
+        .collect();
+    Ok(items)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_creator_name;
+    use super::ZoteroApiCreator;
+
+    fn creator(last_name: &str, first_name: &str) -> ZoteroApiCreator {
+        ZoteroApiCreator {
+            first_name: Some(first_name.into()),
+            last_name: Some(last_name.into()),
+            name: None,
+        }
+    }
+
+    #[test]
+    fn renders_person_creators_as_last_comma_first() {
+        let creator = creator("Smith", "John");
+        assert_eq!(render_creator_name(&creator).as_deref(), Some("Smith, John"));
+    }
+
+    #[test]
+    fn renders_single_name_creators() {
+        let only_last = creator("Smith", "");
+        assert_eq!(render_creator_name(&only_last).as_deref(), Some("Smith"));
+        let only_first = creator("", "John");
+        assert_eq!(render_creator_name(&only_first).as_deref(), Some("John"));
+    }
+
+    #[test]
+    fn renders_institution_creators_by_name() {
+        let institution = ZoteroApiCreator {
+            first_name: None,
+            last_name: None,
+            name: Some("World Health Organization".into()),
+        };
+        assert_eq!(
+            render_creator_name(&institution).as_deref(),
+            Some("World Health Organization")
+        );
+    }
+
+    #[test]
+    fn skips_creators_without_a_name() {
+        let empty = ZoteroApiCreator {
+            first_name: None,
+            last_name: None,
+            name: None,
+        };
+        assert_eq!(render_creator_name(&empty), None);
+    }
+}

--- a/apps/desktop/src/components/command-palette/command-palette.test.tsx
+++ b/apps/desktop/src/components/command-palette/command-palette.test.tsx
@@ -100,6 +100,7 @@ async function renderPalette(query: string, context?: Partial<CommandContext>) {
     openShortcuts: vi.fn(),
     openTemplatePicker: vi.fn(),
     openTemplateCreate: vi.fn(),
+    openZoteroPicker: vi.fn(),
     enableSemanticSearch: vi.fn(),
     ...context,
   }

--- a/apps/desktop/src/components/note-pane.tsx
+++ b/apps/desktop/src/components/note-pane.tsx
@@ -28,6 +28,7 @@ import { useEditorAutocomplete } from '@/editor/use-editor-autocomplete'
 import { useNoteDocument } from '@/editor/use-note-document'
 import { useTagNavigation } from '@/editor/use-tag-navigation'
 import { useTemplateSlashItems } from '@/editor/use-template-slash-items'
+import { useZoteroSlashItem } from '@/editor/use-zotero-slash-item'
 import { useMarkdownLinkNavigation } from '@/editor/use-markdown-link-navigation'
 import { useWikiLinkNavigation } from '@/editor/use-wiki-link-navigation'
 import { useWikiLinkHoverPreview } from '@/editor/use-wiki-link-hover-preview'
@@ -192,9 +193,22 @@ export function NotePaneComponent({
   const registeredHandle = useRef<{ path: string; handle: NoteEditorHandle } | null>(null)
   // The `/` menu's template rows insert into this pane's own editor, read
   // through the registry ref at select time (a late resolve after the pane
-  // unmounted must insert nowhere rather than somewhere stale).
-  const onSlashMenuSearch = useTemplateSlashItems(
+  // unmounted must insert nowhere rather than somewhere stale). The Zotero
+  // row shares the menu; its picker inserts into this pane's note (desktop
+  // only — Zotero is a desktop app).
+  const templateSlashItems = useTemplateSlashItems(
     useCallback(() => registeredHandle.current?.handle ?? null, []),
+  )
+  const zoteroSlashItems = useZoteroSlashItem(path)
+  const onSlashMenuSearch = useCallback(
+    async (query: string) => {
+      const [templates, zotero] = await Promise.all([
+        templateSlashItems(query),
+        isTouchEditorSurface() ? Promise.resolve([]) : zoteroSlashItems(query),
+      ])
+      return [...templates, ...zotero]
+    },
+    [templateSlashItems, zoteroSlashItems],
   )
   const handleRef = useCallback(
     (handle: NoteEditorHandle | null) => {

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -151,6 +151,7 @@ async function renderSidebar(overrides?: Partial<CommandContext>, initialRoute?:
     openShortcuts: vi.fn(),
     openTemplatePicker: vi.fn(),
     openTemplateCreate: vi.fn(),
+    openZoteroPicker: vi.fn(),
     enableSemanticSearch: vi.fn(),
     ...overrides,
   }

--- a/apps/desktop/src/components/workspace-content.tsx
+++ b/apps/desktop/src/components/workspace-content.tsx
@@ -13,6 +13,7 @@ import { Sidebar } from '@/components/sidebar/sidebar'
 import { SidebarResizeHandle } from '@/components/sidebar-resize-handle'
 import { TemplateCreateDialog } from '@/components/templates/template-create-dialog'
 import { TemplatePicker } from '@/components/templates/template-picker'
+import { ZoteroPicker } from '@/components/zotero/zotero-picker'
 import { useDailyContextTarget } from '@/providers/focused-daily-provider'
 import { useSidebar } from '@/providers/sidebar-provider'
 import { useAppShortcuts } from '@/routing/app-shortcuts'
@@ -67,6 +68,7 @@ export function WorkspaceContent({ graph }: WorkspaceContentProps): ReactElement
         <ShortcutsDialog />
         <TemplatePicker context={commandContext} />
         <TemplateCreateDialog context={commandContext} />
+        <ZoteroPicker />
         <EmbeddingsSync />
       </div>
     </AppShell>

--- a/apps/desktop/src/components/zotero/zotero-picker-store.ts
+++ b/apps/desktop/src/components/zotero/zotero-picker-store.ts
@@ -1,0 +1,54 @@
+import { useSyncExternalStore } from 'react'
+
+/**
+ * Open state for the Zotero item picker. Module-level rather than a provider
+ * (the formatting-toolbar-store pattern): the picker's only readers are the
+ * dialog and the app-shortcuts modal guard, and its only writers are the
+ * palette command and the `/` menu row — none of which need React state or
+ * re-renders at the call site. The target note path is captured at open time,
+ * so the dialog needs no `CommandContext` of its own.
+ */
+
+export interface ZoteroPickerState {
+  /** The graph-relative path of the note the picked link inserts into. */
+  targetPath: string | null
+  /** Bumped on every open so the dialog remounts with fresh search state. */
+  epoch: number
+}
+
+let state: ZoteroPickerState | null = null
+const listeners = new Set<() => void>()
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+/** Open the picker for `targetPath` (the note whose editor receives the link). */
+export function openZoteroPicker(targetPath: string | null): void {
+  state = { targetPath, epoch: (state?.epoch ?? 0) + 1 }
+  notify()
+}
+
+/** Close the picker without inserting anything. */
+export function closeZoteroPicker(): void {
+  state = null
+  notify()
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+function snapshot(): ZoteroPickerState | null {
+  return state
+}
+
+/** The picker's open state as reactive state — null while closed. */
+export function useZoteroPicker(): ZoteroPickerState | null {
+  return useSyncExternalStore(subscribe, snapshot, snapshot)
+}

--- a/apps/desktop/src/components/zotero/zotero-picker.test.tsx
+++ b/apps/desktop/src/components/zotero/zotero-picker.test.tsx
@@ -58,7 +58,7 @@ describe('ZoteroPicker', () => {
   it('searches the Zotero library and inserts the picked item as a link', async () => {
     openZoteroPicker('notes/a.md')
     await render(<ZoteroPicker />, { wrapper })
-    const input = page.getByRole('combobox', { name: 'Search Zotero' })
+    const input = page.getByRole('combobox', { name: 'Insert Zotero item' })
     await expect.element(input).toHaveFocus()
 
     await userEvent.fill(input, 'attention')
@@ -79,7 +79,7 @@ describe('ZoteroPicker', () => {
   it('moves through results with arrow keys and picks with Enter', async () => {
     openZoteroPicker('notes/a.md')
     await render(<ZoteroPicker />, { wrapper })
-    const input = page.getByRole('combobox', { name: 'Search Zotero' })
+    const input = page.getByRole('combobox', { name: 'Insert Zotero item' })
     await userEvent.fill(input, 'attention')
 
     await expect.element(page.getByText('Attention is all you need')).toBeInTheDocument()
@@ -95,7 +95,21 @@ describe('ZoteroPicker', () => {
   it('shows a no-results state for an unmatched query', async () => {
     openZoteroPicker('notes/a.md')
     await render(<ZoteroPicker />, { wrapper })
-    await userEvent.fill(page.getByRole('combobox', { name: 'Search Zotero' }), 'nothing-matches')
+    await userEvent.fill(
+      page.getByRole('combobox', { name: 'Insert Zotero item' }),
+      'nothing-matches',
+    )
     await expect.element(page.getByText('No matching items.')).toBeInTheDocument()
+  })
+
+  it('shows the keyboard hint footer and closes on Escape', async () => {
+    openZoteroPicker('notes/a.md')
+    await render(<ZoteroPicker />, { wrapper })
+    await expect.element(page.getByText('Navigate')).toBeInTheDocument()
+    await expect.element(page.getByText('↩ Insert')).toBeInTheDocument()
+    await expect.element(page.getByText('Cancel')).toBeInTheDocument()
+
+    await userEvent.keyboard('{Escape}')
+    await expect.element(page.getByRole('combobox')).not.toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/components/zotero/zotero-picker.test.tsx
+++ b/apps/desktop/src/components/zotero/zotero-picker.test.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render } from 'vitest-browser-react'
+import { page, userEvent } from 'vitest/browser'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import '@/test-utils/locator'
+import { closeZoteroPicker, openZoteroPicker } from './zotero-picker-store'
+import { ZoteroPicker } from './zotero-picker'
+
+const mocks = vi.hoisted(() => ({
+  insertMarkdown: vi.fn(),
+  focus: vi.fn(),
+}))
+
+vi.mock('@reflect/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@reflect/core')>()
+  return {
+    ...actual,
+    zoteroSearch: vi.fn(async (query: string) => {
+      if (query.toLowerCase().includes('attention')) {
+        return [
+          {
+            key: 'ABCD1234',
+            title: 'Attention is all you need',
+            creators: ['Vaswani, Ashish'],
+            date: '2017-06-12',
+            itemType: 'journalArticle',
+          },
+        ]
+      }
+      return []
+    }),
+  }
+})
+
+vi.mock('@/editor/editor-handle-registry', () => ({
+  noteEditorHandleFor: (path: string) => (path === 'notes/a.md' ? mocks : null),
+}))
+
+let queryClient: QueryClient
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+describe('ZoteroPicker', () => {
+  beforeEach(() => {
+    mocks.insertMarkdown.mockClear()
+    mocks.focus.mockClear()
+    closeZoteroPicker()
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    })
+  })
+
+  it('searches the Zotero library and inserts the picked item as a link', async () => {
+    openZoteroPicker('notes/a.md')
+    await render(<ZoteroPicker />, { wrapper })
+    const input = page.getByRole('textbox', { name: 'Search Zotero' })
+    await expect.element(input).toHaveFocus()
+
+    await userEvent.fill(input, 'attention')
+
+    await expect.element(page.getByText('Attention is all you need')).toBeInTheDocument()
+    await userEvent.click(page.getByRole('button', { name: /Attention is all you need/ }))
+
+    expect(mocks.insertMarkdown).toHaveBeenCalledWith(
+      '[Attention is all you need](zotero://select/library/items/ABCD1234)',
+    )
+    expect(mocks.focus).toHaveBeenCalled()
+  })
+
+  it('shows a no-results state for an unmatched query', async () => {
+    openZoteroPicker('notes/a.md')
+    await render(<ZoteroPicker />, { wrapper })
+    await userEvent.fill(page.getByRole('textbox', { name: 'Search Zotero' }), 'nothing-matches')
+    await expect.element(page.getByText('No matching items.')).toBeInTheDocument()
+  })
+})

--- a/apps/desktop/src/components/zotero/zotero-picker.test.tsx
+++ b/apps/desktop/src/components/zotero/zotero-picker.test.tsx
@@ -25,6 +25,8 @@ vi.mock('@reflect/core', async (importOriginal) => {
             creators: ['Vaswani, Ashish'],
             date: '2017-06-12',
             itemType: 'journalArticle',
+            abstractNote: 'We propose a new network architecture for sequence transduction.',
+            url: 'https://arxiv.org/abs/1706.03762',
           },
         ]
       }
@@ -62,6 +64,10 @@ describe('ZoteroPicker', () => {
     await userEvent.fill(input, 'attention')
 
     await expect.element(page.getByText('Attention is all you need')).toBeInTheDocument()
+    await expect
+      .element(page.getByText(/We propose a new network architecture/))
+      .toBeInTheDocument()
+    await expect.element(page.getByText('https://arxiv.org/abs/1706.03762')).toBeInTheDocument()
     await userEvent.click(page.getByRole('button', { name: /Attention is all you need/ }))
 
     expect(mocks.insertMarkdown).toHaveBeenCalledWith(

--- a/apps/desktop/src/components/zotero/zotero-picker.test.tsx
+++ b/apps/desktop/src/components/zotero/zotero-picker.test.tsx
@@ -58,7 +58,7 @@ describe('ZoteroPicker', () => {
   it('searches the Zotero library and inserts the picked item as a link', async () => {
     openZoteroPicker('notes/a.md')
     await render(<ZoteroPicker />, { wrapper })
-    const input = page.getByRole('textbox', { name: 'Search Zotero' })
+    const input = page.getByRole('combobox', { name: 'Search Zotero' })
     await expect.element(input).toHaveFocus()
 
     await userEvent.fill(input, 'attention')
@@ -68,7 +68,23 @@ describe('ZoteroPicker', () => {
       .element(page.getByText(/We propose a new network architecture/))
       .toBeInTheDocument()
     await expect.element(page.getByText('https://arxiv.org/abs/1706.03762')).toBeInTheDocument()
-    await userEvent.click(page.getByRole('button', { name: /Attention is all you need/ }))
+    await userEvent.click(page.getByRole('option', { name: /Attention is all you need/ }))
+
+    expect(mocks.insertMarkdown).toHaveBeenCalledWith(
+      '[Attention is all you need](zotero://select/library/items/ABCD1234)',
+    )
+    expect(mocks.focus).toHaveBeenCalled()
+  })
+
+  it('moves through results with arrow keys and picks with Enter', async () => {
+    openZoteroPicker('notes/a.md')
+    await render(<ZoteroPicker />, { wrapper })
+    const input = page.getByRole('combobox', { name: 'Search Zotero' })
+    await userEvent.fill(input, 'attention')
+
+    await expect.element(page.getByText('Attention is all you need')).toBeInTheDocument()
+    await userEvent.keyboard('{ArrowDown}')
+    await userEvent.keyboard('{Enter}')
 
     expect(mocks.insertMarkdown).toHaveBeenCalledWith(
       '[Attention is all you need](zotero://select/library/items/ABCD1234)',
@@ -79,7 +95,7 @@ describe('ZoteroPicker', () => {
   it('shows a no-results state for an unmatched query', async () => {
     openZoteroPicker('notes/a.md')
     await render(<ZoteroPicker />, { wrapper })
-    await userEvent.fill(page.getByRole('textbox', { name: 'Search Zotero' }), 'nothing-matches')
+    await userEvent.fill(page.getByRole('combobox', { name: 'Search Zotero' }), 'nothing-matches')
     await expect.element(page.getByText('No matching items.')).toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/components/zotero/zotero-picker.tsx
+++ b/apps/desktop/src/components/zotero/zotero-picker.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import {
   errorMessage,
+  zoteroAbstractExcerpt,
   zoteroItemLink,
   zoteroItemSummary,
   zoteroSearch,
@@ -94,7 +95,7 @@ function ZoteroPickerDialog({
     >
       <DialogContent
         aria-describedby={undefined}
-        className="grid max-h-[calc(100dvh-2rem)] grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden sm:max-w-lg"
+        className="grid max-h-[calc(100dvh-2rem)] grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden sm:max-w-3xl"
       >
         <DialogHeader className="pr-8">
           <DialogTitle>Insert Zotero item</DialogTitle>
@@ -121,6 +122,7 @@ function ZoteroPickerDialog({
             <ul className="flex flex-col">
               {items?.map((item) => {
                 const summary = zoteroItemSummary(item)
+                const abstract = zoteroAbstractExcerpt(item)
                 return (
                   <li key={item.key}>
                     <button
@@ -133,6 +135,16 @@ function ZoteroPickerDialog({
                       </span>
                       {summary !== '' ? (
                         <span className="w-full truncate text-xs text-text-muted">{summary}</span>
+                      ) : null}
+                      {abstract !== '' ? (
+                        <span className="line-clamp-2 w-full text-xs text-text-secondary">
+                          {abstract}
+                        </span>
+                      ) : null}
+                      {item.url !== null && item.url.trim() !== '' ? (
+                        <span className="w-full truncate font-mono text-[11px] text-text-muted">
+                          {item.url}
+                        </span>
                       ) : null}
                     </button>
                   </li>

--- a/apps/desktop/src/components/zotero/zotero-picker.tsx
+++ b/apps/desktop/src/components/zotero/zotero-picker.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, type ReactElement } from 'react'
+import { useEffect, useState, type KeyboardEvent, type ReactElement } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { Command } from 'cmdk'
 import {
   errorMessage,
   zoteroAbstractExcerpt,
@@ -8,15 +9,8 @@ import {
   zoteroSearch,
   type ZoteroItem,
 } from '@reflect/core'
-import {
-  Command,
-  CommandDialog,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command'
+import { getIsComposing } from '@meowdown/core'
+import { Kbd } from '@/components/kbd'
 import { closeZoteroPicker, useZoteroPicker } from '@/components/zotero/zotero-picker-store'
 import { noteEditorHandleFor } from '@/editor/editor-handle-registry'
 import { startOperation } from '@/lib/operations'
@@ -29,10 +23,12 @@ const SEARCH_DEBOUNCE_MS = 250
  * insert its `[Title](zotero://…)` deep link at the caret of the note the
  * opener targeted. Mirrors the zotero-link Obsidian plugin's flow.
  *
- * The dialog is cmdk-driven (the ⌘K palette's component), so the candidate
- * list supports the same keyboard traversal — ↑/↓ to move, Enter to pick,
- * Esc to dismiss. `shouldFilter` is off: the rows are server results, and
- * ranking belongs to Zotero's own search, not client-side filtering.
+ * The dialog is cmdk-driven with the ⌘K palette's own frame — same overlay
+ * position (`pt-[12vh]`), same `max-w-4xl` width and `min(60vh, 36rem)` list
+ * height, same keyboard hint footer — so the Zotero picker feels like the
+ * note search: ↑/↓ to move, Enter to pick, Esc to dismiss. `shouldFilter` is
+ * off: the rows are server results, and ranking belongs to Zotero's own
+ * search, not client-side filtering.
  *
  * The target note is captured at open time (`targetPath`); at insert time it
  * resolves to the pane's live editor handle, so a protected or unloaded note
@@ -92,72 +88,122 @@ function ZoteroPickerDialog({
     editor.focus()
   }
 
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (getIsComposing()) {
+      // preventDefault keeps cmdk's root handler from selecting the highlighted
+      // item on the Enter that commits the composition.
+      if (event.key === 'Enter') {
+        event.preventDefault()
+      }
+      return
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      onClose()
+    }
+  }
+
   return (
-    <CommandDialog
-      title="Insert Zotero item"
-      description="Search your Zotero library and insert the selected item's link"
-      open
-      onOpenChange={(next) => {
-        if (!next) {
-          onClose()
-        }
-      }}
-      className="sm:max-w-3xl"
+    // The overlay mirrors the ⌘K palette's (click-outside closes, Esc below):
+    // same position, same click-to-dismiss contract.
+    <div
+      className="fixed inset-0 z-40 flex items-start justify-center bg-black/20 pt-[12vh]"
+      onPointerDown={onClose}
+      data-testid="zotero-picker-overlay"
     >
-      <Command shouldFilter={false} label="Search Zotero">
-        <CommandInput
-          autoFocus
-          value={draft}
-          onValueChange={setDraft}
-          placeholder="Search your Zotero library…"
-        />
-        <CommandList>
-          {query === '' ? (
-            <CommandEmpty>Type to search your Zotero library (title, author, year).</CommandEmpty>
-          ) : error !== null ? (
-            <CommandEmpty>{errorMessage(error)}</CommandEmpty>
-          ) : (
-            <CommandGroup>
-              {items?.map((item) => {
-                const summary = zoteroItemSummary(item)
-                const abstract = zoteroAbstractExcerpt(item)
-                return (
-                  <CommandItem
-                    key={item.key}
-                    value={`zotero-${item.key}`}
-                    onSelect={() => insert(item)}
-                    className="items-start gap-2"
-                  >
-                    <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-0.5">
-                      <span className="w-full truncate text-sm font-medium">
-                        {item.title.trim() === '' ? 'Untitled item' : item.title}
-                      </span>
-                      {summary !== '' ? (
-                        <span className="w-full truncate text-xs text-text-muted">{summary}</span>
-                      ) : null}
-                      {abstract !== '' ? (
-                        <span className="line-clamp-2 w-full text-xs text-text-secondary">
-                          {abstract}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Insert Zotero item"
+        className="w-full max-w-4xl"
+        onPointerDown={(event) => {
+          event.stopPropagation() // clicks inside must not close
+        }}
+      >
+        <Command
+          label="Insert Zotero item"
+          shouldFilter={false}
+          onKeyDown={handleKeyDown}
+          className="reflect-palette"
+        >
+          <Command.Input
+            autoFocus
+            value={draft}
+            onValueChange={setDraft}
+            placeholder="Search your Zotero library…"
+            className="reflect-palette-input"
+          />
+          <div className="flex h-[min(60vh,36rem)]">
+            <Command.List className="h-full min-h-0 w-full overflow-y-auto px-1.5 py-1.5">
+              {query === '' ? (
+                <Command.Empty className="reflect-palette-empty">
+                  Type to search your Zotero library (title, author, year).
+                </Command.Empty>
+              ) : error !== null ? (
+                <Command.Empty className="reflect-palette-empty">
+                  {errorMessage(error)}
+                </Command.Empty>
+              ) : (
+                <>
+                  {items?.map((item) => {
+                    const summary = zoteroItemSummary(item)
+                    const abstract = zoteroAbstractExcerpt(item)
+                    return (
+                      <Command.Item
+                        key={item.key}
+                        value={`zotero-${item.key}`}
+                        onSelect={() => insert(item)}
+                        className="reflect-palette-item"
+                      >
+                        <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-0.5">
+                          <span className="w-full truncate text-sm font-medium">
+                            {item.title.trim() === '' ? 'Untitled item' : item.title}
+                          </span>
+                          {summary !== '' ? (
+                            <span className="w-full truncate text-xs text-text-muted">
+                              {summary}
+                            </span>
+                          ) : null}
+                          {abstract !== '' ? (
+                            <span className="line-clamp-2 w-full text-xs text-text-secondary">
+                              {abstract}
+                            </span>
+                          ) : null}
+                          {item.url !== null && item.url.trim() !== '' ? (
+                            <span className="w-full truncate font-mono text-[11px] text-text-muted">
+                              {item.url}
+                            </span>
+                          ) : null}
                         </span>
-                      ) : null}
-                      {item.url !== null && item.url.trim() !== '' ? (
-                        <span className="w-full truncate font-mono text-[11px] text-text-muted">
-                          {item.url}
-                        </span>
-                      ) : null}
-                    </span>
-                  </CommandItem>
-                )
-              })}
-              {items === undefined ? (
-                <CommandItem disabled>Searching…</CommandItem>
-              ) : items.length === 0 ? (
-                <CommandItem disabled>No matching items.</CommandItem>
-              ) : null}
-            </CommandGroup>
-          )}
-        </CommandList>
-      </Command>
-    </CommandDialog>
+                      </Command.Item>
+                    )
+                  })}
+                  {items === undefined ? (
+                    <Command.Item disabled>Searching…</Command.Item>
+                  ) : items.length === 0 ? (
+                    <Command.Item disabled>No matching items.</Command.Item>
+                  ) : null}
+                </>
+              )}
+            </Command.List>
+          </div>
+          <div
+            aria-hidden
+            className="flex items-center gap-4 border-t border-border px-3.5 py-2 text-[11px] text-text-muted"
+          >
+            <span className="flex items-center gap-1.5">
+              <Kbd>↑</Kbd>
+              <Kbd>↓</Kbd> Navigate
+            </span>
+            <span className="flex items-center gap-1.5">
+              <Kbd>↩</Kbd> Insert
+            </span>
+            <span className="flex items-center gap-1.5">
+              <Kbd>esc</Kbd> Cancel
+            </span>
+          </div>
+        </Command>
+      </div>
+    </div>
   )
 }

--- a/apps/desktop/src/components/zotero/zotero-picker.tsx
+++ b/apps/desktop/src/components/zotero/zotero-picker.tsx
@@ -8,8 +8,15 @@ import {
   zoteroSearch,
   type ZoteroItem,
 } from '@reflect/core'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
+import {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
 import { closeZoteroPicker, useZoteroPicker } from '@/components/zotero/zotero-picker-store'
 import { noteEditorHandleFor } from '@/editor/editor-handle-registry'
 import { startOperation } from '@/lib/operations'
@@ -21,6 +28,11 @@ const SEARCH_DEBOUNCE_MS = 250
  * (title / author / year, via Zotero 7's Local API), then pick an item to
  * insert its `[Title](zotero://…)` deep link at the caret of the note the
  * opener targeted. Mirrors the zotero-link Obsidian plugin's flow.
+ *
+ * The dialog is cmdk-driven (the ⌘K palette's component), so the candidate
+ * list supports the same keyboard traversal — ↑/↓ to move, Enter to pick,
+ * Esc to dismiss. `shouldFilter` is off: the rows are server results, and
+ * ranking belongs to Zotero's own search, not client-side filtering.
  *
  * The target note is captured at open time (`targetPath`); at insert time it
  * resolves to the pane's live editor handle, so a protected or unloaded note
@@ -62,11 +74,7 @@ function ZoteroPickerDialog({
     return () => clearTimeout(timer)
   }, [draft])
 
-  const {
-    data: items,
-    isFetching,
-    error,
-  } = useQuery({
+  const { data: items, error } = useQuery({
     queryKey: ['zotero-search', query],
     queryFn: () => zoteroSearch(query),
     enabled: query !== '',
@@ -85,51 +93,42 @@ function ZoteroPickerDialog({
   }
 
   return (
-    <Dialog
+    <CommandDialog
+      title="Insert Zotero item"
+      description="Search your Zotero library and insert the selected item's link"
       open
       onOpenChange={(next) => {
         if (!next) {
           onClose()
         }
       }}
+      className="sm:max-w-3xl"
     >
-      <DialogContent
-        aria-describedby={undefined}
-        className="grid max-h-[calc(100dvh-2rem)] grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden sm:max-w-3xl"
-      >
-        <DialogHeader className="pr-8">
-          <DialogTitle>Insert Zotero item</DialogTitle>
-        </DialogHeader>
-        <Input
+      <Command shouldFilter={false} label="Search Zotero">
+        <CommandInput
           autoFocus
           value={draft}
-          onChange={(event) => setDraft(event.target.value)}
+          onValueChange={setDraft}
           placeholder="Search your Zotero library…"
-          aria-label="Search Zotero"
         />
-        <div className="min-h-0 overflow-y-auto pr-1">
+        <CommandList>
           {query === '' ? (
-            <p className="px-3 py-8 text-center text-sm text-text-muted">
-              Type to search your Zotero library (title, author, year).
-            </p>
+            <CommandEmpty>Type to search your Zotero library (title, author, year).</CommandEmpty>
           ) : error !== null ? (
-            <p className="px-3 py-8 text-center text-sm text-text-muted">{errorMessage(error)}</p>
-          ) : items !== undefined && items.length === 0 ? (
-            <p className="px-3 py-8 text-center text-sm text-text-muted">
-              {isFetching ? 'Searching…' : 'No matching items.'}
-            </p>
+            <CommandEmpty>{errorMessage(error)}</CommandEmpty>
           ) : (
-            <ul className="flex flex-col">
+            <CommandGroup>
               {items?.map((item) => {
                 const summary = zoteroItemSummary(item)
                 const abstract = zoteroAbstractExcerpt(item)
                 return (
-                  <li key={item.key}>
-                    <button
-                      type="button"
-                      onClick={() => insert(item)}
-                      className="flex w-full flex-col items-start gap-0.5 rounded-lg px-3 py-2 text-left transition-colors hover:bg-surface-hover focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
-                    >
+                  <CommandItem
+                    key={item.key}
+                    value={`zotero-${item.key}`}
+                    onSelect={() => insert(item)}
+                    className="items-start gap-2"
+                  >
+                    <span className="flex min-w-0 flex-1 flex-col gap-0.5 py-0.5">
                       <span className="w-full truncate text-sm font-medium">
                         {item.title.trim() === '' ? 'Untitled item' : item.title}
                       </span>
@@ -146,14 +145,19 @@ function ZoteroPickerDialog({
                           {item.url}
                         </span>
                       ) : null}
-                    </button>
-                  </li>
+                    </span>
+                  </CommandItem>
                 )
               })}
-            </ul>
+              {items === undefined ? (
+                <CommandItem disabled>Searching…</CommandItem>
+              ) : items.length === 0 ? (
+                <CommandItem disabled>No matching items.</CommandItem>
+              ) : null}
+            </CommandGroup>
           )}
-        </div>
-      </DialogContent>
-    </Dialog>
+        </CommandList>
+      </Command>
+    </CommandDialog>
   )
 }

--- a/apps/desktop/src/components/zotero/zotero-picker.tsx
+++ b/apps/desktop/src/components/zotero/zotero-picker.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState, type ReactElement } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  errorMessage,
+  zoteroItemLink,
+  zoteroItemSummary,
+  zoteroSearch,
+  type ZoteroItem,
+} from '@reflect/core'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { closeZoteroPicker, useZoteroPicker } from '@/components/zotero/zotero-picker-store'
+import { noteEditorHandleFor } from '@/editor/editor-handle-registry'
+import { startOperation } from '@/lib/operations'
+
+const SEARCH_DEBOUNCE_MS = 250
+
+/**
+ * The "Insert Zotero item" picker: type to search the local Zotero library
+ * (title / author / year, via Zotero 7's Local API), then pick an item to
+ * insert its `[Title](zotero://…)` deep link at the caret of the note the
+ * opener targeted. Mirrors the zotero-link Obsidian plugin's flow.
+ *
+ * The target note is captured at open time (`targetPath`); at insert time it
+ * resolves to the pane's live editor handle, so a protected or unloaded note
+ * surfaces as a failed operation instead of a silent nothing.
+ */
+
+export function ZoteroPicker(): ReactElement | null {
+  const picker = useZoteroPicker()
+
+  if (picker === null) {
+    return null
+  }
+
+  // Keyed by the open epoch: every invocation remounts a fresh dialog, so the
+  // search state below never needs a reset effect.
+  return (
+    <ZoteroPickerDialog
+      key={picker.epoch}
+      targetPath={picker.targetPath}
+      onClose={closeZoteroPicker}
+    />
+  )
+}
+
+function ZoteroPickerDialog({
+  targetPath,
+  onClose,
+}: {
+  targetPath: string | null
+  onClose: () => void
+}): ReactElement {
+  const [draft, setDraft] = useState('')
+  const [query, setQuery] = useState('')
+
+  // Debounce keystrokes into the react-query key so Zotero isn't queried per
+  // keypress.
+  useEffect(() => {
+    const timer = setTimeout(() => setQuery(draft.trim()), SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [draft])
+
+  const {
+    data: items,
+    isFetching,
+    error,
+  } = useQuery({
+    queryKey: ['zotero-search', query],
+    queryFn: () => zoteroSearch(query),
+    enabled: query !== '',
+    staleTime: 30_000,
+  })
+
+  const insert = (item: ZoteroItem): void => {
+    onClose()
+    const editor = targetPath !== null ? noteEditorHandleFor(targetPath) : null
+    if (editor === null) {
+      startOperation('Inserting Zotero link').fail('No open note to insert into')
+      return
+    }
+    editor.insertMarkdown(zoteroItemLink(item))
+    editor.focus()
+  }
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        if (!next) {
+          onClose()
+        }
+      }}
+    >
+      <DialogContent
+        aria-describedby={undefined}
+        className="grid max-h-[calc(100dvh-2rem)] grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden sm:max-w-lg"
+      >
+        <DialogHeader className="pr-8">
+          <DialogTitle>Insert Zotero item</DialogTitle>
+        </DialogHeader>
+        <Input
+          autoFocus
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          placeholder="Search your Zotero library…"
+          aria-label="Search Zotero"
+        />
+        <div className="min-h-0 overflow-y-auto pr-1">
+          {query === '' ? (
+            <p className="px-3 py-8 text-center text-sm text-text-muted">
+              Type to search your Zotero library (title, author, year).
+            </p>
+          ) : error !== null ? (
+            <p className="px-3 py-8 text-center text-sm text-text-muted">{errorMessage(error)}</p>
+          ) : items !== undefined && items.length === 0 ? (
+            <p className="px-3 py-8 text-center text-sm text-text-muted">
+              {isFetching ? 'Searching…' : 'No matching items.'}
+            </p>
+          ) : (
+            <ul className="flex flex-col">
+              {items?.map((item) => {
+                const summary = zoteroItemSummary(item)
+                return (
+                  <li key={item.key}>
+                    <button
+                      type="button"
+                      onClick={() => insert(item)}
+                      className="flex w-full flex-col items-start gap-0.5 rounded-lg px-3 py-2 text-left transition-colors hover:bg-surface-hover focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+                    >
+                      <span className="w-full truncate text-sm font-medium">
+                        {item.title.trim() === '' ? 'Untitled item' : item.title}
+                      </span>
+                      {summary !== '' ? (
+                        <span className="w-full truncate text-xs text-text-muted">{summary}</span>
+                      ) : null}
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/dev/dev-bridge.ts
+++ b/apps/desktop/src/dev/dev-bridge.ts
@@ -285,6 +285,7 @@ export function createDevBridge(backend: DevBridgeBackend): IpcBridge {
       case 'calendar_list_events':
       case 'contacts_lookup_by_email':
       case 'contacts_lookup_by_name':
+      case 'zotero_search':
         return []
 
       case 'chat_message_save': {

--- a/apps/desktop/src/editor/use-zotero-slash-item.ts
+++ b/apps/desktop/src/editor/use-zotero-slash-item.ts
@@ -1,0 +1,23 @@
+import { useCallback } from 'react'
+import type { SlashMenuItem, SlashMenuSearchHandler } from '@meowdown/react'
+import { openZoteroPicker } from '@/components/zotero/zotero-picker-store'
+
+/**
+ * The `/` menu's Zotero row: opens the Zotero item picker targeting this
+ * pane's own note. Same host-supplies-the-items pattern as the template rows
+ * (`useTemplateSlashItems`); meowdown filters against the typed query and
+ * removes the `/query` text before `onSelect` runs.
+ */
+export function useZoteroSlashItem(notePath: string): SlashMenuSearchHandler {
+  return useCallback(
+    async (_query: string): Promise<SlashMenuItem[]> => [
+      {
+        id: 'zotero-item',
+        label: 'Zotero item',
+        keywords: ['zotero', 'citation', 'reference', 'paper', 'literature'],
+        onSelect: () => openZoteroPicker(notePath),
+      },
+    ],
+    [notePath],
+  )
+}

--- a/apps/desktop/src/lib/attach-files.test.ts
+++ b/apps/desktop/src/lib/attach-files.test.ts
@@ -32,6 +32,7 @@ function contextFor(notePath: string | null, generation: number | null): Command
     openShortcuts: vi.fn(),
     openTemplatePicker: vi.fn(),
     openTemplateCreate: vi.fn(),
+    openZoteroPicker: vi.fn(),
     enableSemanticSearch: vi.fn(),
     clearScrollState: vi.fn(),
   }

--- a/apps/desktop/src/lib/commands/app-commands.test.ts
+++ b/apps/desktop/src/lib/commands/app-commands.test.ts
@@ -94,6 +94,7 @@ function fakeContext(overrides?: Partial<CommandContext>) {
     openShortcuts: vi.fn(),
     openTemplatePicker: vi.fn(),
     openTemplateCreate: vi.fn(),
+    openZoteroPicker: vi.fn(),
     enableSemanticSearch: vi.fn(),
     ...overrides,
   }

--- a/apps/desktop/src/lib/commands/app-commands.ts
+++ b/apps/desktop/src/lib/commands/app-commands.ts
@@ -314,6 +314,20 @@ const APP_COMMANDS: AppCommand[] = [
     },
   },
   {
+    id: 'zotero.insert',
+    title: 'Insert Zotero item…',
+    keywords: ['zotero', 'citation', 'paper', 'reference', 'literature', 'library'],
+    // Searches the local Zotero library (Zotero 7's Local API) and inserts a
+    // `[Title](zotero://…)` deep link at the caret of the note the current
+    // route edits. The picker surfaces the "Zotero is not running" state.
+    run: (context) => {
+      if (context.notePath() === null) {
+        return
+      }
+      context.openZoteroPicker()
+    },
+  },
+  {
     id: 'template.new',
     title: 'New template',
     keywords: ['template', 'snippet', 'boilerplate', 'create'],

--- a/apps/desktop/src/lib/commands/registry.test.ts
+++ b/apps/desktop/src/lib/commands/registry.test.ts
@@ -28,6 +28,7 @@ function fakeContext(overrides?: Partial<CommandContext>): CommandContext {
     openShortcuts: vi.fn(),
     openTemplatePicker: vi.fn(),
     openTemplateCreate: vi.fn(),
+    openZoteroPicker: vi.fn(),
     enableSemanticSearch: vi.fn(),
     ...overrides,
   }

--- a/apps/desktop/src/lib/commands/types.ts
+++ b/apps/desktop/src/lib/commands/types.ts
@@ -55,6 +55,11 @@ export interface CommandContext {
   /** Open the "New template" name dialog. */
   openTemplateCreate: () => void
   /**
+   * Open the "Insert Zotero item" picker (inserts into {@link notePath}'s
+   * editor; no-op when no note is being edited).
+   */
+  openZoteroPicker: () => void
+  /**
    * Persist the semantic-search opt-in (`semanticSearchEnabled`).
    * EmbeddingsSync reacts to the setting by loading — first time:
    * downloading — the model, so flipping the flag is the whole command.

--- a/apps/desktop/src/routing/app-shortcuts.ts
+++ b/apps/desktop/src/routing/app-shortcuts.ts
@@ -15,6 +15,7 @@ import { useChatSession } from '@/providers/chat-provider'
 import { useFocusedDailyDate } from '@/providers/focused-daily-provider'
 import { useGraph } from '@/providers/graph-provider'
 import { useNoteFindActions } from '@/providers/note-find-provider'
+import { openZoteroPicker, useZoteroPicker } from '@/components/zotero/zotero-picker-store'
 import { useNoteTemplates } from '@/providers/note-templates-provider'
 import { useSettings } from '@/providers/settings-provider'
 import { useShortcuts } from '@/providers/shortcuts-provider'
@@ -171,6 +172,8 @@ export function useAppShortcuts(): CommandContext {
     pickerOpen: templatePickerOpen,
     createOpen: templateCreateOpen,
   } = useNoteTemplates()
+  const zoteroPicker = useZoteroPicker()
+  const zoteroPickerOpen = zoteroPicker !== null
   const { toggleSidebar } = useSidebar()
   const { toggle: toggleAudioMemo } = useAudioMemo()
   const { newChat } = useChatSession()
@@ -191,6 +194,8 @@ export function useAppShortcuts(): CommandContext {
   // And for the template dialogs — both are Radix modals; nothing may
   // navigate behind them.
   const templatesOpenRef = useRef(templatePickerOpen || templateCreateOpen)
+  // The Zotero picker is a modal dialog too.
+  const zoteroPickerOpenRef = useRef(zoteroPickerOpen)
 
   // Read at run time, not captured: a command can fire long after the render
   // that created the context (palette open across an index rebuild, etc.).
@@ -204,6 +209,7 @@ export function useAppShortcuts(): CommandContext {
     paletteOpenRef.current = paletteOpen
     shortcutsOpenRef.current = shortcutsOpen
     templatesOpenRef.current = templatePickerOpen || templateCreateOpen
+    zoteroPickerOpenRef.current = zoteroPickerOpen
     generationRef.current = graph?.generation ?? null
     graphRootRef.current = graph?.root ?? null
     recentsRef.current = recents
@@ -248,6 +254,13 @@ export function useAppShortcuts(): CommandContext {
       openShortcuts,
       openTemplatePicker,
       openTemplateCreate,
+      // Resolve the target note at open time — the same path {@link notePath}
+      // yields, so the picker inserts where the command's other note-scoped
+      // siblings would.
+      openZoteroPicker: () =>
+        openZoteroPicker(
+          focusedNotePathForRoute(routeRef.current, todayIso(), focusedDailyDateRef.current),
+        ),
       enableSemanticSearch: () => {
         updateSettings({ semanticSearchEnabled: true })
         // EmbeddingsSync loads an untouched runtime; a `failed` one only
@@ -266,6 +279,7 @@ export function useAppShortcuts(): CommandContext {
       openShortcuts,
       openTemplatePicker,
       openTemplateCreate,
+      openZoteroPicker,
       toggleSidebar,
       newChat,
       openNoteFindForPath,
@@ -294,6 +308,9 @@ export function useAppShortcuts(): CommandContext {
       }
       if (templatesOpenRef.current) {
         return false // the template picker/create dialogs are modal too
+      }
+      if (zoteroPickerOpenRef.current) {
+        return false // the Zotero picker is modal too
       }
       void runCommand(id, context)
       return true

--- a/packages/core/src/exports/ai-actions.ts
+++ b/packages/core/src/exports/ai-actions.ts
@@ -245,6 +245,8 @@ export {
   zoteroSearch,
   zoteroItemLink,
   zoteroItemSummary,
+  zoteroAbstractExcerpt,
+  ZOTERO_ABSTRACT_MAX_LENGTH,
   zoteroItemSchema,
   type ZoteroItem,
 } from '../zotero/commands'

--- a/packages/core/src/exports/ai-actions.ts
+++ b/packages/core/src/exports/ai-actions.ts
@@ -241,3 +241,10 @@ export {
   type ReconcileAssetDescriptionsInput,
   type ReconcileAssetDescriptionsOutcome,
 } from '../actions/asset-description'
+export {
+  zoteroSearch,
+  zoteroItemLink,
+  zoteroItemSummary,
+  zoteroItemSchema,
+  type ZoteroItem,
+} from '../zotero/commands'

--- a/packages/core/src/zotero/commands.test.ts
+++ b/packages/core/src/zotero/commands.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { zoteroItemLink, zoteroItemSchema, zoteroItemSummary } from './commands'
+import {
+  zoteroAbstractExcerpt,
+  zoteroItemLink,
+  zoteroItemSchema,
+  zoteroItemSummary,
+} from './commands'
 
 const baseItem = {
   key: 'ABCD1234',
@@ -7,6 +12,8 @@ const baseItem = {
   creators: ['Vaswani, Ashish'],
   date: '2017-06-12',
   itemType: 'journalArticle',
+  abstractNote: 'We propose a new network architecture.',
+  url: 'https://arxiv.org/abs/1706.03762',
 }
 
 describe('zoteroItemLink', () => {
@@ -61,8 +68,34 @@ describe('zoteroItemSchema', () => {
     expect(zoteroItemSchema.parse({ ...baseItem, date: null })).toEqual({ ...baseItem, date: null })
   })
 
+  it('accepts items without an abstract or url', () => {
+    expect(zoteroItemSchema.parse({ ...baseItem, abstractNote: null, url: null })).toEqual({
+      ...baseItem,
+      abstractNote: null,
+      url: null,
+    })
+  })
+
   it('rejects a payload missing the item key', () => {
     const { key: _key, ...rest } = baseItem
     expect(zoteroItemSchema.safeParse(rest).success).toBe(false)
+  })
+})
+
+describe('zoteroAbstractExcerpt', () => {
+  it('keeps a short abstract whole', () => {
+    expect(zoteroAbstractExcerpt(baseItem)).toBe('We propose a new network architecture.')
+  })
+
+  it('collapses whitespace and truncates a long abstract with an ellipsis', () => {
+    const long = 'word '.repeat(100)
+    const excerpt = zoteroAbstractExcerpt({ ...baseItem, abstractNote: `  ${long}  ` })
+    expect(excerpt.endsWith('…')).toBe(true)
+    expect(excerpt).not.toContain('\n')
+    expect(excerpt.length).toBeLessThanOrEqual(201)
+  })
+
+  it('returns an empty string when the item has no abstract', () => {
+    expect(zoteroAbstractExcerpt({ ...baseItem, abstractNote: null })).toBe('')
   })
 })

--- a/packages/core/src/zotero/commands.test.ts
+++ b/packages/core/src/zotero/commands.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { zoteroItemLink, zoteroItemSchema, zoteroItemSummary } from './commands'
+
+const baseItem = {
+  key: 'ABCD1234',
+  title: 'Attention is all you need',
+  creators: ['Vaswani, Ashish'],
+  date: '2017-06-12',
+  itemType: 'journalArticle',
+}
+
+describe('zoteroItemLink', () => {
+  it('builds the zotero:// deep link from key and title', () => {
+    expect(zoteroItemLink(baseItem)).toBe(
+      '[Attention is all you need](zotero://select/library/items/ABCD1234)',
+    )
+  })
+
+  it('escapes brackets in the title so they cannot break the link text', () => {
+    const item = { ...baseItem, title: 'Brackets [in] title' }
+    expect(zoteroItemLink(item)).toBe(
+      String.raw`[Brackets \[in\] title](zotero://select/library/items/ABCD1234)`,
+    )
+  })
+
+  it('escapes backslashes before brackets', () => {
+    const item = { ...baseItem, title: String.raw`Back\slash` }
+    expect(zoteroItemLink(item)).toBe(
+      String.raw`[Back\\slash](zotero://select/library/items/ABCD1234)`,
+    )
+  })
+
+  it('falls back to a generic label for an empty title', () => {
+    const item = { ...baseItem, title: '   ' }
+    expect(zoteroItemLink(item)).toBe('[Zotero item](zotero://select/library/items/ABCD1234)')
+  })
+})
+
+describe('zoteroItemSummary', () => {
+  it('combines the first creator and the year', () => {
+    expect(zoteroItemSummary(baseItem)).toBe('Vaswani, Ashish, 2017')
+  })
+
+  it('drops the year when the date is absent or month-only', () => {
+    expect(zoteroItemSummary({ ...baseItem, date: null })).toBe('Vaswani, Ashish')
+    expect(zoteroItemSummary({ ...baseItem, date: 'n.d.' })).toBe('Vaswani, Ashish')
+  })
+
+  it('drops the creator when the item has none', () => {
+    expect(zoteroItemSummary({ ...baseItem, creators: [] })).toBe('2017')
+  })
+
+  it('is empty for an item with no creator and no date', () => {
+    expect(zoteroItemSummary({ ...baseItem, creators: [], date: null })).toBe('')
+  })
+})
+
+describe('zoteroItemSchema', () => {
+  it('accepts the Rust command payload shape', () => {
+    expect(zoteroItemSchema.parse(baseItem)).toEqual(baseItem)
+    expect(zoteroItemSchema.parse({ ...baseItem, date: null })).toEqual({ ...baseItem, date: null })
+  })
+
+  it('rejects a payload missing the item key', () => {
+    const { key: _key, ...rest } = baseItem
+    expect(zoteroItemSchema.safeParse(rest).success).toBe(false)
+  })
+})

--- a/packages/core/src/zotero/commands.ts
+++ b/packages/core/src/zotero/commands.ts
@@ -23,6 +23,10 @@ export const zoteroItemSchema = z.object({
   /** The item's `date` field as authored ("2020-01-01", "2020", "n.d."). */
   date: z.string().nullable(),
   itemType: z.string(),
+  /** The item's abstract as authored; truncate with {@link zoteroAbstractExcerpt}. */
+  abstractNote: z.string().nullable(),
+  /** The item's URL field, when the item carries one. */
+  url: z.string().nullable(),
 })
 
 export type ZoteroItem = z.infer<typeof zoteroItemSchema>
@@ -49,6 +53,25 @@ function yearOf(date: string | null): string | null {
   }
   const year = date.split('-')[0]?.trim() ?? ''
   return /^\d{4}$/.test(year) ? year : null
+}
+
+/** The longest excerpt the picker shows before truncating with an ellipsis. */
+export const ZOTERO_ABSTRACT_MAX_LENGTH = 200
+
+/**
+ * A short, whitespace-normalized excerpt of an item's abstract for the picker
+ * row — enough to tell two same-titled items apart, never the whole abstract.
+ * Returns an empty string when the item has no abstract.
+ */
+export function zoteroAbstractExcerpt(item: ZoteroItem): string {
+  if (item.abstractNote === null) {
+    return ''
+  }
+  const collapsed = item.abstractNote.replaceAll(/\s+/g, ' ').trim()
+  if (collapsed.length <= ZOTERO_ABSTRACT_MAX_LENGTH) {
+    return collapsed
+  }
+  return `${collapsed.slice(0, ZOTERO_ABSTRACT_MAX_LENGTH).trimEnd()}…`
 }
 
 /**

--- a/packages/core/src/zotero/commands.ts
+++ b/packages/core/src/zotero/commands.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod'
+import { call } from '../ipc/invoke'
+
+/**
+ * Typed bindings for the Zotero link picker (desktop): search the local
+ * Zotero library through Zotero 7's built-in Local API and turn a picked item
+ * into a markdown deep link.
+ *
+ * Rust owns the capability — `apps/desktop/src-tauri/src/zotero.rs` fetches
+ * `http://127.0.0.1:23119/api/users/0/items` and normalizes the response. This
+ * module owns the policy: which item fields compose the picker display, and
+ * which markdown an item becomes (`{@link zoteroItemLink}`). Nothing here
+ * touches the index and no data leaves the machine.
+ */
+
+/** One searchable Zotero library item, as normalized by the Rust command. */
+export const zoteroItemSchema = z.object({
+  /** The 8-character Zotero item key — the `zotero://` deep-link target. */
+  key: z.string(),
+  title: z.string(),
+  /** Creator display names in document order ("Smith, John"). */
+  creators: z.array(z.string()),
+  /** The item's `date` field as authored ("2020-01-01", "2020", "n.d."). */
+  date: z.string().nullable(),
+  itemType: z.string(),
+})
+
+export type ZoteroItem = z.infer<typeof zoteroItemSchema>
+
+/** Search the local Zotero library by title/creator/year. */
+export async function zoteroSearch(query: string): Promise<ZoteroItem[]> {
+  return await call('zotero_search', { query }, z.array(zoteroItemSchema))
+}
+
+/** A picker display summary: "Title — Smith, 2020" (empty parts dropped). */
+export function zoteroItemSummary(item: ZoteroItem): string {
+  const parts = [item.creators[0], yearOf(item.date)]
+  return parts.filter((part): part is string => part != null && part !== '').join(', ')
+}
+
+/**
+ * The year prefix of a Zotero `date` field ("2020-01-02" → "2020"). Non-year
+ * dates — "n.d.", "circa 1950", malformed values — yield nothing rather than
+ * a misleading display part.
+ */
+function yearOf(date: string | null): string | null {
+  if (date === null) {
+    return null
+  }
+  const year = date.split('-')[0]?.trim() ?? ''
+  return /^\d{4}$/.test(year) ? year : null
+}
+
+/**
+ * The markdown link an item inserts at the caret:
+ * `[Title](zotero://select/library/items/KEY)` — the deep link the Zotero
+ * desktop app registered for "select this item". Brackets in the title are
+ * escaped so an authored title can never break out of the link text.
+ */
+export function zoteroItemLink(item: ZoteroItem): string {
+  const label = item.title.trim() === '' ? 'Zotero item' : item.title.trim()
+  return `[${escapeLinkText(label)}](zotero://select/library/items/${item.key})`
+}
+
+/** Escape backslash and brackets — the characters that delimit link text. */
+function escapeLinkText(text: string): string {
+  return text
+    .replaceAll('\\', '\\\\')
+    .replaceAll('[', String.raw`\[`)
+    .replaceAll(']', String.raw`\]`)
+}


### PR DESCRIPTION
## What

Adds a Zotero link picker that searches the local Zotero library via Zotero 7's built-in Local API (`http://127.0.0.1:23119/api/users/0/items`) and inserts a `[Title](zotero://select/library/items/KEY)` deep link at the caret — the flow the [zotero-link](https://github.com/vanakat/zotero-link) Obsidian plugin popularized.

## How it works

- **`zotero_search` Rust command** (`apps/desktop/src-tauri/src/zotero.rs`): reqwest GET against Zotero's Local API with the `Zotero-Allowed-Request: true` guard header, 5s timeout, `Network` error when Zotero is closed or its local API is disabled. No credentials — anonymous localhost access.
- **`@reflect/core` bindings** (`packages/core/src/zotero/commands.ts`): Zod-validated `zoteroSearch`, the `zoteroItemLink` markdown formatter (escapes `[`/`]`/backslash in the title), an abstract excerpt helper, and a display summary. Rust owns the capability; core owns the markdown policy.
- **UI**:
  - ⌘K palette command **Insert Zotero item…** (`zotero.insert`)
  - Editor `/` menu row **Zotero item** (desktop only)
  - The picker dialog is cmdk-driven with the same frame as the ⌘K palette — same viewport position, width (`max-w-4xl`), list height (`min(60vh,36rem)`), and keyboard hint footer (↑/↓ Navigate, ↩ Insert, esc Cancel). Rows show title, first author + year, a 200-char abstract excerpt, and the item URL when present.
- **`zotero://` links open natively**: the scheme isn't blocked by `open-external-link.ts`, and markdown round-trips losslessly (meowdown keeps the href verbatim).

## Requirements

- Zotero 7 running with *Allow other applications on this computer to communicate with Zotero* enabled (Settings → Advanced)
- No API key or network access — everything is localhost

## Testing

- `pnpm check` (typecheck + lint) ✓
- Rust: clippy `-D warnings` ✓, `zotero` module unit tests ✓
- `@reflect/core`: `zotero/commands.test.ts` (link escaping, summary, excerpt, schema) ✓
- Desktop: node project 2169 tests ✓, picker browser tests (search → insert, arrow-key + Enter selection, hint footer, Esc) ✓
- Verified `zotero://` links parse, round-trip, and are openable via the OS protocol handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Zotero library search and a searchable item picker.
  * Insert Zotero items as links directly into notes.
  * Added slash-menu and command support for opening the picker.
  * Displays item creators, dates, summaries, and abstracts.

* **Bug Fixes**
  * Handles empty searches, unavailable libraries, invalid results, and missing note targets gracefully.

* **Tests**
  * Added coverage for searching, navigation, insertion, link formatting, and item metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->