### PR TITLE
fix(mobile): add member paywall button

### DIFF
--- a/apps/desktop/src/mobile/mobile-root.tsx
+++ b/apps/desktop/src/mobile/mobile-root.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react'
 import { setLocalWriteEcho, type AppPlatform } from '@reflect/core'
+import { Toaster } from '@/components/ui/sonner'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { setPlatformSurface } from '@/lib/platform-surface'
 import { MobileApp } from '@/mobile/mobile-app'
@@ -26,6 +27,7 @@ export function MobileRoot({ platform }: { platform: AppPlatform }): ReactElemen
     <GraphProvider platform={platform}>
       <TooltipProvider>
         <MobileApp />
+        <Toaster position="top-center" />
       </TooltipProvider>
     </GraphProvider>
   )

--- a/apps/desktop/src/mobile/paywall-screen.tsx
+++ b/apps/desktop/src/mobile/paywall-screen.tsx
@@ -79,7 +79,7 @@ export function PaywallScreen(): ReactElement {
   // out free weeks once the real flow exists.
   const memberContinue = () => {
     if (Date.now() > MEMBER_STOPGAP_UNTIL) {
-      void openUrl(CLAIM_FREE_YEAR_URL).catch(() => {})
+      openUrlSync(CLAIM_FREE_YEAR_URL)
       return
     }
     toast('Enjoy Reflect free for now', {

--- a/apps/desktop/src/mobile/paywall-screen.tsx
+++ b/apps/desktop/src/mobile/paywall-screen.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactElement } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { Check } from 'lucide-react'
+import { toast } from 'sonner'
 import { IAP_PRODUCT_IDS, iapGetProducts, iapPurchase, iapRestorePurchases } from '@reflect/core'
 import appIcon from '@/assets/app-icon.png'
 import { Button } from '@/components/ui/button'
@@ -18,8 +19,9 @@ type PendingAction = 'monthly' | 'yearly' | 'restore' | null
 /** How long "Remind me later" keeps the paywall dismissed. */
 const SNOOZE_MS = 24 * 60 * 60 * 1000
 
-/** V1 web page that hands a paying Reflect member their free-year offer code. */
-const CLAIM_FREE_YEAR_URL = 'https://reflect.app/claim-reflect-open'
+/** How long the member button keeps the paywall dismissed while the
+ * free-year claim flow is not live yet. */
+const MEMBER_SNOOZE_MS = 7 * 24 * 60 * 60 * 1000
 
 export function PaywallScreen(): ReactElement {
   const queryClient = useQueryClient()
@@ -60,6 +62,18 @@ export function PaywallScreen(): ReactElement {
     } finally {
       setPending(null)
     }
+  }
+
+  // Stopgap while reflect.app/claim-reflect-open is not live: members get a
+  // week free and the paywall asks again when it lapses. The toast outlives
+  // this screen (its Toaster mounts in mobile-root.tsx, outside the gate),
+  // and the snooze write unmounts the paywall immediately.
+  const memberContinue = () => {
+    toast('Enjoy Reflect free for now', {
+      description: "We'll ask about your free year again once codes are ready.",
+      duration: 6000,
+    })
+    updateSettings({ paywallSnoozeUntil: Date.now() + MEMBER_SNOOZE_MS })
   }
 
   const restore = async () => {
@@ -160,7 +174,7 @@ export function PaywallScreen(): ReactElement {
             type="button"
             className="text-sm text-text-secondary underline disabled:opacity-50"
             disabled={pending !== null}
-            onClick={() => void openUrl(CLAIM_FREE_YEAR_URL).catch(() => {})}
+            onClick={memberContinue}
           >
             Already a Reflect member? Get your first year free
           </button>

--- a/apps/desktop/src/mobile/paywall-screen.tsx
+++ b/apps/desktop/src/mobile/paywall-screen.tsx
@@ -23,6 +23,13 @@ const SNOOZE_MS = 24 * 60 * 60 * 1000
  * free-year claim flow is not live yet. */
 const MEMBER_SNOOZE_MS = 7 * 24 * 60 * 60 * 1000
 
+/** V1 web page that hands a paying Reflect member their free-year offer code. */
+const CLAIM_FREE_YEAR_URL = 'https://reflect.app/claim-reflect-open'
+
+/** When the free-week stopgap self-expires (30 days after it was written,
+ * 2026-08-12). After this the member button opens the claim page instead. */
+const MEMBER_STOPGAP_UNTIL = Date.parse('2026-09-11')
+
 export function PaywallScreen(): ReactElement {
   const queryClient = useQueryClient()
   const { updateSettings } = useSettings()
@@ -67,8 +74,14 @@ export function PaywallScreen(): ReactElement {
   // Stopgap while reflect.app/claim-reflect-open is not live: members get a
   // week free and the paywall asks again when it lapses. The toast outlives
   // this screen (its Toaster mounts in mobile-root.tsx, outside the gate),
-  // and the snooze write unmounts the paywall immediately.
+  // and the snooze write unmounts the paywall immediately. Past the stopgap
+  // deadline the button opens the claim page, so a stale build stops handing
+  // out free weeks once the real flow exists.
   const memberContinue = () => {
+    if (Date.now() > MEMBER_STOPGAP_UNTIL) {
+      void openUrl(CLAIM_FREE_YEAR_URL).catch(() => {})
+      return
+    }
     toast('Enjoy Reflect free for now', {
       description: "We'll ask about your free year again once codes are ready.",
       duration: 6000,

--- a/apps/desktop/src/mobile/paywall-screen.tsx
+++ b/apps/desktop/src/mobile/paywall-screen.tsx
@@ -18,6 +18,9 @@ type PendingAction = 'monthly' | 'yearly' | 'restore' | null
 /** How long "Remind me later" keeps the paywall dismissed. */
 const SNOOZE_MS = 24 * 60 * 60 * 1000
 
+/** V1 web page that hands a paying Reflect member their free-year offer code. */
+const CLAIM_FREE_YEAR_URL = 'https://reflect.app/claim-reflect-open'
+
 export function PaywallScreen(): ReactElement {
   const queryClient = useQueryClient()
   const { updateSettings } = useSettings()
@@ -153,6 +156,14 @@ export function PaywallScreen(): ReactElement {
         ) : null}
 
         <div className="flex flex-col items-center gap-4">
+          <button
+            type="button"
+            className="text-sm text-text-secondary underline disabled:opacity-50"
+            disabled={pending !== null}
+            onClick={() => void openUrl(CLAIM_FREE_YEAR_URL).catch(() => {})}
+          >
+            Already a Reflect member? Get your first year free
+          </button>
           {/* First-rollout escape hatch: dismissing writes a snooze timestamp
               and the gate in mobile-app.tsx unmounts this screen, so a broken
               store never locks anyone out of their notes. */}


### PR DESCRIPTION
One tap on the member button shows a toast and lets the user into the app for 7 days; the link to reflect.app/claim-reflect-open returns once that page is ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a member-specific paywall experience with a seven-day snooze period.
  - Members receive an on-screen notification during the temporary snooze period.
  - After the deadline, members can open the free-year claim page directly from the paywall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->