### PR TITLE
refactor: add `openUrlSync` for fire-and-forget `openUrl` calls

### DIFF
--- a/apps/desktop/src/components/context-sidebar/published-url-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/published-url-section.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState, type MouseEvent, type ReactElement } from 'react'
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { Check, Copy, RefreshCw } from 'lucide-react'
 import { errorMessage } from '@reflect/core'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useNoteRow } from '@/hooks/use-note-row'
 import { runGistPublish } from '@/lib/note-gist'
+import { openUrlSync } from '@/lib/open-url'
 import { startOperation } from '@/lib/operations'
 import { cn } from '@/lib/utils'
 import { useGraph } from '@/providers/graph-provider'
@@ -63,7 +63,7 @@ export function PublishedUrlSection({ path }: PublishedUrlSectionProps): ReactEl
   const openPublishedUrl = (event: MouseEvent<HTMLAnchorElement>): void => {
     event.preventDefault()
     if (url.startsWith('https://') || url.startsWith('http://')) {
-      void openUrl(url)
+      openUrlSync(url)
     }
   }
 

--- a/apps/desktop/src/components/settings/calendar-integration-field.tsx
+++ b/apps/desktop/src/components/settings/calendar-integration-field.tsx
@@ -1,6 +1,5 @@
 import { useMemo, type ReactElement, type ReactNode } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { canReadCalendars, requestCalendarAccess, type CalendarInfo } from '@reflect/core'
 import { InlineAlert } from '@/components/inline-alert'
 import { Button } from '@/components/ui/button'
@@ -14,6 +13,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
+import { openUrlSync } from '@/lib/open-url'
 import { isMacosDesktop } from '@/lib/platform'
 import {
   CALENDAR_QUERY_PREFIX,
@@ -110,9 +110,7 @@ export function CalendarIntegrationField(): ReactElement | null {
             <button
               type="button"
               onClick={() => {
-                void openUrl(CALENDAR_PRIVACY_PANE).catch((cause: unknown) => {
-                  console.error('failed to open System Settings:', cause)
-                })
+                openUrlSync(CALENDAR_PRIVACY_PANE)
               }}
               className={ACTION_BUTTON_CLASS}
             >

--- a/apps/desktop/src/components/settings/integrations-section.tsx
+++ b/apps/desktop/src/components/settings/integrations-section.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState, type ReactElement } from 'react'
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { requestContactsAccess } from '@reflect/core'
 import { InlineAlert } from '@/components/inline-alert'
 import {
   useContactsAuthorization,
   useRefreshContactsAuthorization,
 } from '@/hooks/use-contacts-authorization'
+import { openUrlSync } from '@/lib/open-url'
 import { isMacosDesktop } from '@/lib/platform'
 import { useSettings } from '@/providers/settings-provider'
 import { CalendarIntegrationField } from './calendar-integration-field'
@@ -113,9 +113,7 @@ export function IntegrationsSection(): ReactElement | null {
                     // A rejection here is a capability-scope bug (the ACL must
                     // allow x-apple.systempreferences:*) — surface it, don't
                     // swallow it into a dead link.
-                    openUrl(CONTACTS_PRIVACY_PANE).catch((cause: unknown) => {
-                      console.error('failed to open System Settings', cause)
-                    })
+                    openUrlSync(CONTACTS_PRIVACY_PANE)
                   }}
                 >
                   Open System Settings

--- a/apps/desktop/src/editor/note-editor.tsx
+++ b/apps/desktop/src/editor/note-editor.tsx
@@ -7,7 +7,6 @@ import {
   type ReactNode,
   type Ref,
 } from 'react'
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { errorMessage, type TimeFormat } from '@reflect/core'
 import type {
   AcceptPendingReplacementOptions,
@@ -42,6 +41,7 @@ import { isTouchEditorSurface } from '@/lib/platform-surface'
 import { useLightboxTransition } from '@/editor/use-lightbox-transition'
 import { isDeepLinkUrl } from '@/lib/deep-links/parse'
 import { useFollowDeepLink } from '@/lib/deep-links/use-follow-deep-link'
+import { openUrlSync } from '@/lib/open-url'
 import { cn } from '@/lib/utils'
 
 type WikilinkHoverRenderer = (hit: WikilinkHoverHit) => ReactNode | Promise<ReactNode>
@@ -370,9 +370,7 @@ export function NoteEditor({
         onNoteLinkClickRef.current?.({ href, openInNewWindow: mod })
         return
       }
-      void openUrl(href).catch((cause) => {
-        console.error('open link failed:', errorMessage(cause))
-      })
+      openUrlSync(href)
     },
     [followDeepLink],
   )

--- a/apps/desktop/src/editor/open-external-link.ts
+++ b/apps/desktop/src/editor/open-external-link.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react'
 import type { LinkClickHandler } from '@meowdown/core'
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { isDeepLinkUrl } from '@/lib/deep-links/parse'
 import { useFollowDeepLink } from '@/lib/deep-links/use-follow-deep-link'
+import { openUrlSync } from '@/lib/open-url'
 
 /**
  * Schemes that must never reach the OS opener: script and data URIs carry
@@ -47,7 +47,7 @@ export function useOpenExternalLink(): LinkClickHandler {
         return
       }
       if (isOpenableExternalUrl(href)) {
-        void openUrl(href)
+        openUrlSync(href)
       }
     },
     [followDeepLink],

--- a/apps/desktop/src/lib/open-url.test.ts
+++ b/apps/desktop/src/lib/open-url.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { openUrlSync } from './open-url'
+
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl: vi.fn(async () => {}) }))
+
+describe('openUrlSync', () => {
+  it('forwards the url to the opener', () => {
+    openUrlSync('https://example.com')
+    expect(openUrl).toHaveBeenCalledWith('https://example.com')
+  })
+
+  it('logs instead of throwing when the opener rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(openUrl).mockRejectedValueOnce(new Error('no handler'))
+    expect(() => openUrlSync('https://example.com')).not.toThrow()
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        'failed to open https://example.com:',
+        'no handler',
+      )
+    })
+    consoleError.mockRestore()
+  })
+})

--- a/apps/desktop/src/lib/open-url.test.ts
+++ b/apps/desktop/src/lib/open-url.test.ts
@@ -15,10 +15,7 @@ describe('openUrlSync', () => {
     vi.mocked(openUrl).mockRejectedValueOnce(new Error('no handler'))
     expect(() => openUrlSync('https://example.com')).not.toThrow()
     await vi.waitFor(() => {
-      expect(consoleError).toHaveBeenCalledWith(
-        'failed to open https://example.com:',
-        'no handler',
-      )
+      expect(consoleError).toHaveBeenCalledWith('failed to open https://example.com:', 'no handler')
     })
     consoleError.mockRestore()
   })

--- a/apps/desktop/src/lib/open-url.ts
+++ b/apps/desktop/src/lib/open-url.ts
@@ -1,0 +1,14 @@
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { errorMessage } from '@reflect/core'
+
+/**
+ * Fire-and-forget `openUrl` for sync UI handlers that have no use for the
+ * promise. A rejection (no handler for the scheme, or the opener capability
+ * denies it) is logged instead of becoming an unhandled rejection; callers
+ * that surface failures in the UI call `openUrl` directly.
+ */
+export function openUrlSync(url: string): void {
+  void openUrl(url).catch((cause: unknown) => {
+    console.error(`failed to open ${url}:`, errorMessage(cause))
+  })
+}

--- a/apps/desktop/src/mobile/ai-provider-consent.tsx
+++ b/apps/desktop/src/mobile/ai-provider-consent.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { TRANSCRIPTION_PROVIDERS, type AiProviderInfo } from '@reflect/core'
+import { openUrlSync } from '@/lib/open-url'
 import { PRIVACY_POLICY_URL } from '@/mobile/legal-urls'
 
 const TRANSCRIBING_PROVIDER_IDS: readonly string[] = TRANSCRIPTION_PROVIDERS
@@ -34,7 +34,7 @@ export function AiProviderConsent({
           type="button"
           className="underline"
           onClick={() => {
-            void openUrl(PRIVACY_POLICY_URL).catch(() => {})
+            openUrlSync(PRIVACY_POLICY_URL)
           }}
         >
           Privacy policy

--- a/apps/desktop/src/mobile/paywall-screen.tsx
+++ b/apps/desktop/src/mobile/paywall-screen.tsx
@@ -178,11 +178,7 @@ export function PaywallScreen(): ReactElement {
         </div>
 
         <footer className="mt-auto flex justify-center gap-4 text-[13px] text-text-muted">
-          <button
-            type="button"
-            className="underline"
-            onClick={() => openUrlSync(TERMS_OF_USE_URL)}
-          >
+          <button type="button" className="underline" onClick={() => openUrlSync(TERMS_OF_USE_URL)}>
             Terms of Use
           </button>
           <button

--- a/apps/desktop/src/mobile/paywall-screen.tsx
+++ b/apps/desktop/src/mobile/paywall-screen.tsx
@@ -1,11 +1,11 @@
 import { useState, type ReactElement } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { Check } from 'lucide-react'
 import { IAP_PRODUCT_IDS, iapGetProducts, iapPurchase, iapRestorePurchases } from '@reflect/core'
 import appIcon from '@/assets/app-icon.png'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
+import { openUrlSync } from '@/lib/open-url'
 import { cn } from '@/lib/utils'
 import { PRIVACY_POLICY_URL, TERMS_OF_USE_URL } from '@/mobile/legal-urls'
 import { invalidateEntitlementQueries } from '@/mobile/use-active-subscription'
@@ -181,14 +181,14 @@ export function PaywallScreen(): ReactElement {
           <button
             type="button"
             className="underline"
-            onClick={() => void openUrl(TERMS_OF_USE_URL).catch(() => {})}
+            onClick={() => openUrlSync(TERMS_OF_USE_URL)}
           >
             Terms of Use
           </button>
           <button
             type="button"
             className="underline"
-            onClick={() => void openUrl(PRIVACY_POLICY_URL).catch(() => {})}
+            onClick={() => openUrlSync(PRIVACY_POLICY_URL)}
           >
             Privacy Policy
           </button>

--- a/apps/desktop/src/mobile/screens/settings.tsx
+++ b/apps/desktop/src/mobile/screens/settings.tsx
@@ -12,12 +12,12 @@ import {
   type EditorTextSize,
   type ThemePreference,
 } from '@reflect/core'
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { useAiPrompts } from '@/hooks/use-ai-prompts'
 import { useAiProviders } from '@/hooks/use-ai-providers'
 import { useAppVersion } from '@/hooks/use-app-version'
 import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { marketingVersion } from '@/lib/marketing-version'
+import { openUrlSync } from '@/lib/open-url'
 import { INDEX_QUERY_SCOPE } from '@/lib/query-client'
 import { AddAiProviderDrawer } from '@/mobile/add-ai-provider-drawer'
 import { AiPromptDrawer } from '@/mobile/ai-prompt-drawer'
@@ -334,7 +334,7 @@ export function MobileSettings(): ReactElement {
                 <SettingsActionRow
                   label="Manage Subscription"
                   onPress={() => {
-                    void openUrl('https://apps.apple.com/account/subscriptions').catch(() => {})
+                    openUrlSync('https://apps.apple.com/account/subscriptions')
                   }}
                 />
               )}
@@ -348,7 +348,7 @@ export function MobileSettings(): ReactElement {
               <SettingsActionRow
                 label="Terms of Use"
                 onPress={() => {
-                  void openUrl(TERMS_OF_USE_URL).catch(() => {})
+                  openUrlSync(TERMS_OF_USE_URL)
                 }}
               />
             </SettingsGroup>
@@ -366,7 +366,7 @@ export function MobileSettings(): ReactElement {
             <SettingsActionRow
               label="Privacy Policy"
               onPress={() => {
-                void openUrl(PRIVACY_POLICY_URL).catch(() => {})
+                openUrlSync(PRIVACY_POLICY_URL)
               }}
             />
           </SettingsGroup>


### PR DESCRIPTION
Add an `openUrlSync()` wrapper that absorbs the promise and logs opener failures, and use it at the fire-and-forget `openUrl` call sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when opening published links, external links, privacy policies, terms, and system settings.
  * Prevented link-opening failures from causing unhandled errors while recording them for diagnostics.

* **Tests**
  * Added coverage verifying links open correctly and failures are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->