### PR TITLE
feat: add OrcaRouter as a hosted AI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ another git remote are connected directly by the user.
 - **Local search:** `⌘K` searches notes, backlinks, and tags. Optional semantic
   search can be enabled locally.
 - **Ask your notes:** `⌘J` can query notes through user-provided OpenAI,
-  Anthropic, Google, or OpenRouter keys. Answers cite source notes.
+  Anthropic, Google, OpenRouter, or OrcaRouter keys. Answers cite source notes.
 - **Private notes:** `private: true` excludes a note's content from AI and
   other external services.
 - **Audio memos:** record audio and transcribe it into the daily note with a

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: reflect-asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://github.com https://api.github.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.ingest.de.sentry.io"
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: reflect-asset: https:; font-src 'self' data:; frame-src 'self' https://platform.twitter.com https://platform.x.com https://syndication.twitter.com https://www.youtube-nocookie.com https://www.youtube.com; connect-src 'self' ipc: http://ipc.localhost https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://openrouter.ai https://api.orcarouter.ai https://github.com https://api.github.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.ingest.de.sentry.io"
     }
   },
   "plugins": {

--- a/apps/desktop/src/capability-http-scope.test.ts
+++ b/apps/desktop/src/capability-http-scope.test.ts
@@ -53,6 +53,7 @@ describe('http:default capability scope', () => {
     expect(allowed('https://api.anthropic.com/v1/messages')).toBe(true)
     expect(allowed('https://generativelanguage.googleapis.com/v1beta/models')).toBe(true)
     expect(allowed('https://openrouter.ai/api/v1/chat/completions')).toBe(true)
+    expect(allowed('https://api.orcarouter.ai/v1/chat/completions')).toBe(true)
     expect(allowed('https://github.com/login/device/code')).toBe(true)
     expect(allowed('https://api.github.com/user')).toBe(true)
   })

--- a/packages/core/src/ai/audio-memo-title.test.ts
+++ b/packages/core/src/ai/audio-memo-title.test.ts
@@ -44,6 +44,13 @@ const OPENROUTER_CONFIG: AiProviderConfig = {
   keyHint: 'wxyz1',
 }
 
+const ORCAROUTER_CONFIG: AiProviderConfig = {
+  id: 'cfg-orcarouter',
+  provider: 'orcarouter',
+  model: 'openai/gpt-5.5',
+  keyHint: 'wxyz1',
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
 })
@@ -158,6 +165,19 @@ describe('generateAudioMemoTitle', () => {
       pickAudioMemoEnrichmentConfig({
         providers: [OPENROUTER_CONFIG, GOOGLE_CONFIG],
         defaultProviderId: OPENROUTER_CONFIG.id,
+      }),
+    ).toMatchObject({
+      id: GOOGLE_CONFIG.id,
+      provider: 'google',
+      model: 'gemini-3.1-flash-lite',
+    })
+  })
+
+  it('skips OrcaRouter because it does not guarantee a small model', () => {
+    expect(
+      pickAudioMemoEnrichmentConfig({
+        providers: [ORCAROUTER_CONFIG, GOOGLE_CONFIG],
+        defaultProviderId: ORCAROUTER_CONFIG.id,
       }),
     ).toMatchObject({
       id: GOOGLE_CONFIG.id,

--- a/packages/core/src/ai/audio-memo-title.ts
+++ b/packages/core/src/ai/audio-memo-title.ts
@@ -47,6 +47,8 @@ export function audioMemoEnrichmentConfig(config: AiProviderConfig): AiProviderC
       return { ...config, model: GOOGLE_AUDIO_MEMO_ENRICHMENT_MODEL }
     case 'openrouter':
       return null
+    case 'orcarouter':
+      return null
     case 'openai-compatible':
       return config
   }
@@ -55,9 +57,10 @@ export function audioMemoEnrichmentConfig(config: AiProviderConfig): AiProviderC
 /**
  * Pick the small-model provider for audio memo enrichment. The user's
  * default provider wins when it has a fixed small model; otherwise the
- * first supported configured provider is used. OpenRouter is skipped because
- * `openrouter/auto` is not a small-model guarantee; OpenAI-compatible entries
- * use the model the user configured for that endpoint.
+ * first supported configured provider is used. OpenRouter and OrcaRouter are
+ * skipped because their auto-routing is not a small-model guarantee;
+ * OpenAI-compatible entries use the model the user configured for that
+ * endpoint.
  */
 export function pickAudioMemoEnrichmentConfig(state: AiProvidersState): AiProviderConfig | null {
   const preferred = state.providers.find((provider) => provider.id === state.defaultProviderId)

--- a/packages/core/src/ai/language-model.test.ts
+++ b/packages/core/src/ai/language-model.test.ts
@@ -34,6 +34,13 @@ const OPENROUTER_CONFIG: AiProviderConfig = {
   keyHint: 'wxyz1',
 }
 
+const ORCAROUTER_CONFIG: AiProviderConfig = {
+  id: 'cfg-orcarouter',
+  provider: 'orcarouter',
+  model: 'openai/gpt-5.5',
+  keyHint: 'wxyz1',
+}
+
 const OPENAI_COMPATIBLE_CONFIG: AiProviderConfig = {
   id: 'cfg-local',
   provider: 'openai-compatible',
@@ -104,6 +111,33 @@ function recordingOpenRouterFetch(calls: RecordedCall[]): typeof fetch {
         object: 'chat.completion',
         created: 0,
         model: OPENROUTER_CONFIG.model,
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+}
+
+function recordingOrcaRouterFetch(calls: RecordedCall[]): typeof fetch {
+  return async (input, init) => {
+    calls.push({
+      url: String(input),
+      headers: new Headers(init?.headers),
+      body: typeof init?.body === 'string' ? init.body : null,
+    })
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl_123',
+        object: 'chat.completion',
+        created: 0,
+        model: ORCAROUTER_CONFIG.model,
         choices: [
           {
             index: 0,
@@ -193,6 +227,21 @@ describe('languageModel', () => {
     expect(calls[0]!.headers.get('Authorization')).toBe('Bearer sk-or-v1-test')
     expect(calls[0]!.headers.get('HTTP-Referer')).toBe('https://reflect.app')
     expect(calls[0]!.headers.get('X-OpenRouter-Title')).toBe('Reflect')
+  })
+
+  it('routes OrcaRouter through its OpenAI-compatible chat endpoint', async () => {
+    const calls: RecordedCall[] = []
+
+    await generateText({
+      model: languageModel(ORCAROUTER_CONFIG, 'sk-orca-test', recordingOrcaRouterFetch(calls)),
+      prompt: 'hello',
+      maxRetries: 0,
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.url).toBe('https://api.orcarouter.ai/v1/chat/completions')
+    expect(calls[0]!.headers.get('Authorization')).toBe('Bearer sk-orca-test')
+    expect(calls[0]!.body).toContain('"model":"openai/gpt-5.5"')
   })
 
   it('routes custom OpenAI-compatible providers through their configured endpoint', async () => {

--- a/packages/core/src/ai/language-model.ts
+++ b/packages/core/src/ai/language-model.ts
@@ -6,6 +6,7 @@ import type { LanguageModel } from 'ai'
 import type { AiProviderConfig } from '../settings/schema'
 import { anthropicDirectBrowserAccessHeaders } from './anthropic-headers'
 import { OPENAI_COMPATIBLE_PROVIDER_ID } from './openai-compatible'
+import { ORCAROUTER_BASE_URL } from './orcarouter'
 import { OPENROUTER_BASE_URL, openRouterAttributionHeaders } from './openrouter'
 
 /**
@@ -37,6 +38,13 @@ export function languageModel(
         baseURL: OPENROUTER_BASE_URL,
         headers: openRouterAttributionHeaders(),
         name: 'openrouter',
+      }).chat(config.model)
+    case 'orcarouter':
+      return createOpenAI({
+        apiKey,
+        fetch: fetchFn,
+        baseURL: ORCAROUTER_BASE_URL,
+        name: 'orcarouter',
       }).chat(config.model)
     case 'openai-compatible':
       return createOpenAICompatible({

--- a/packages/core/src/ai/orcarouter.ts
+++ b/packages/core/src/ai/orcarouter.ts
@@ -1,0 +1,2 @@
+/** The OpenAI-compatible OrcaRouter API root. */
+export const ORCAROUTER_BASE_URL = 'https://api.orcarouter.ai/v1'

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -31,6 +31,14 @@ describe('AI_PROVIDERS', () => {
     })
   })
 
+  it('includes OrcaRouter in the settings catalog', () => {
+    expect(aiProvider('orcarouter')).toMatchObject({
+      id: 'orcarouter',
+      label: 'OrcaRouter',
+      keyPlaceholder: 'sk-orca-…',
+    })
+  })
+
   it('includes OpenAI-compatible endpoints with optional keys', () => {
     expect(aiProvider('openai-compatible')).toMatchObject({
       id: 'openai-compatible',

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -97,6 +97,18 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
     ],
   },
   {
+    id: 'orcarouter',
+    label: 'OrcaRouter',
+    apiKeyRequired: true,
+    keyPlaceholder: 'sk-orca-…',
+    models: [
+      { id: 'openai/gpt-5.5', label: 'GPT-5.5', contextWindow: 400_000 },
+      { id: 'anthropic/claude-sonnet-5', label: 'Claude Sonnet 5', contextWindow: 1_000_000 },
+      { id: 'google/gemini-3.5-flash', label: 'Gemini 3.5 Flash', contextWindow: 1_000_000 },
+      { id: 'orcarouter/auto', label: 'Auto Router', contextWindow: 128_000 },
+    ],
+  },
+  {
     id: 'openai-compatible',
     label: 'OpenAI-compatible',
     apiKeyRequired: false,

--- a/packages/core/src/ai/validate-key.test.ts
+++ b/packages/core/src/ai/validate-key.test.ts
@@ -25,6 +25,7 @@ describe('validateApiKey', () => {
     await validateApiKey({ provider: 'anthropic', apiKey: 'sk-ant-test' }, recordingFetch)
     await validateApiKey({ provider: 'google', apiKey: 'AIza-test' }, recordingFetch)
     await validateApiKey({ provider: 'openrouter', apiKey: 'sk-or-v1-test' }, recordingFetch)
+    await validateApiKey({ provider: 'orcarouter', apiKey: 'sk-orca-test' }, recordingFetch)
     await validateApiKey(
       {
         provider: 'openai-compatible',
@@ -47,10 +48,12 @@ describe('validateApiKey', () => {
     expect(calls[2]!.headers['x-goog-api-key']).toBe('AIza-test')
     expect(calls[3]!.url).toBe('https://openrouter.ai/api/v1/key')
     expect(calls[3]!.headers['Authorization']).toBe('Bearer sk-or-v1-test')
-    expect(calls[4]!.url).toBe('http://localhost:1234/v1/models')
-    expect(calls[4]!.headers['Authorization']).toBe('Bearer local-secret')
+    expect(calls[4]!.url).toBe('https://api.orcarouter.ai/v1/models')
+    expect(calls[4]!.headers['Authorization']).toBe('Bearer sk-orca-test')
     expect(calls[5]!.url).toBe('http://localhost:1234/v1/models')
-    expect(calls[5]!.headers['Authorization']).toBeUndefined()
+    expect(calls[5]!.headers['Authorization']).toBe('Bearer local-secret')
+    expect(calls[6]!.url).toBe('http://localhost:1234/v1/models')
+    expect(calls[6]!.headers['Authorization']).toBeUndefined()
   })
 
   it('reads an ok response as valid', async () => {
@@ -81,6 +84,9 @@ describe('validateApiKey', () => {
         { provider: 'openrouter', apiKey: 'sk-or-v1-test' },
         fetchReturning(401),
       ),
+    ).toBe('invalid')
+    expect(
+      await validateApiKey({ provider: 'orcarouter', apiKey: 'sk-orca-test' }, fetchReturning(401)),
     ).toBe('invalid')
     expect(
       await validateApiKey(

--- a/packages/core/src/ai/validate-key.ts
+++ b/packages/core/src/ai/validate-key.ts
@@ -2,6 +2,7 @@ import type { AiProviderId, HostedAiProviderId } from '../settings/schema'
 import { anthropicDirectBrowserAccessHeaders } from './anthropic-headers'
 import { APP_REVIEW_STUB_KEY } from './audio-memo-review-stub'
 import { isHttpBaseUrl, normalizeOpenAICompatibleBaseUrl } from './openai-compatible'
+import { ORCAROUTER_BASE_URL } from './orcarouter'
 import { OPENROUTER_BASE_URL } from './openrouter'
 
 /**
@@ -54,6 +55,11 @@ const PROBES: Record<HostedAiProviderId, KeyProbe> = {
   },
   openrouter: {
     url: `${OPENROUTER_BASE_URL}/key`,
+    headers: (key) => ({ Authorization: `Bearer ${key}` }),
+    invalidStatuses: [401, 403],
+  },
+  orcarouter: {
+    url: `${ORCAROUTER_BASE_URL}/models`,
     headers: (key) => ({ Authorization: `Bearer ${key}` }),
     invalidStatuses: [401, 403],
   },

--- a/packages/core/src/settings/schema.test.ts
+++ b/packages/core/src/settings/schema.test.ts
@@ -296,6 +296,16 @@ describe('settingsSchema', () => {
       expect(settingsSchema.parse({ aiProviders: [entry] }).aiProviders).toEqual([entry])
     })
 
+    it('accepts OrcaRouter entries', () => {
+      const entry = {
+        id: 'orcarouter',
+        provider: 'orcarouter',
+        model: 'openai/gpt-5.5',
+        keyHint: 'wxyz1',
+      }
+      expect(settingsSchema.parse({ aiProviders: [entry] }).aiProviders).toEqual([entry])
+    })
+
     it('accepts OpenAI-compatible entries with an http base URL', () => {
       const entry = {
         id: 'local',

--- a/packages/core/src/settings/schema.ts
+++ b/packages/core/src/settings/schema.ts
@@ -329,12 +329,19 @@ export const aiProviderIdSchema = z.enum([
   'anthropic',
   'google',
   'openrouter',
+  'orcarouter',
   'openai-compatible',
 ])
 
 export type AiProviderId = z.infer<typeof aiProviderIdSchema>
 
-const hostedAiProviderIdSchema = z.enum(['openai', 'anthropic', 'google', 'openrouter'])
+const hostedAiProviderIdSchema = z.enum([
+  'openai',
+  'anthropic',
+  'google',
+  'openrouter',
+  'orcarouter',
+])
 
 export type HostedAiProviderId = z.infer<typeof hostedAiProviderIdSchema>
 
@@ -377,11 +384,16 @@ const openRouterProviderConfigSchema = aiProviderConfigBaseSchema.extend({
   provider: z.literal('openrouter'),
 })
 
+const orcaRouterProviderConfigSchema = aiProviderConfigBaseSchema.extend({
+  provider: z.literal('orcarouter'),
+})
+
 const hostedAiProviderConfigSchema = z.union([
   openAiProviderConfigSchema,
   anthropicProviderConfigSchema,
   googleProviderConfigSchema,
   openRouterProviderConfigSchema,
+  orcaRouterProviderConfigSchema,
 ])
 
 export type HostedAiProviderConfig = z.infer<typeof hostedAiProviderConfigSchema>
@@ -398,6 +410,7 @@ export const aiProviderConfigSchema = z.discriminatedUnion('provider', [
   anthropicProviderConfigSchema,
   googleProviderConfigSchema,
   openRouterProviderConfigSchema,
+  orcaRouterProviderConfigSchema,
   openAiCompatibleProviderConfigSchema,
 ])
 


### PR DESCRIPTION
Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class hosted AI provider alongside OpenRouter. OrcaRouter is an OpenAI-compatible gateway to 190+ models from OpenAI, Anthropic, Google, and others through a single namespaced key (`sk-orca-...`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint, screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

What this PR wires up:

- `packages/core/src/ai/orcarouter.ts` - new provider module exporting `ORCAROUTER_BASE_URL` (`https://api.orcarouter.ai/v1`).
- `packages/core/src/settings/schema.ts` - `orcarouter` added to the provider id enum and the hosted provider config union so settings round-trip and validate.
- `packages/core/src/ai/language-model.ts` - dispatches `orcarouter` configs through the OpenAI-compatible chat endpoint (same factory used by OpenRouter).
- `packages/core/src/ai/provider-catalog.ts` - catalog entry with namespaced models (`openai/gpt-5.5`, `anthropic/claude-sonnet-5`, `google/gemini-3.5-flash`, `orcarouter/auto`).
- `packages/core/src/ai/validate-key.ts` - key probe against `GET /v1/models` (OrcaRouter has no `/key` endpoint), with `401`/`403` treated as invalid.
- `packages/core/src/ai/audio-memo-title.ts` - skips OrcaRouter for the fixed small-model enrichment pass, matching the OpenRouter behavior.
- `apps/desktop/src-tauri/tauri.conf.json` - adds `https://api.orcarouter.ai` to the CSP `connect-src` allow-list.
- `README.md` - feature list now mentions OrcaRouter keys.
- Tests for the schema, catalog, key validation, model routing, and capability scope.

Verification: `pnpm typecheck`, `pnpm lint`, and the affected vitest suites all pass (55 tests).

I'm an engineer on the OrcaRouter team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as a supported AI provider for “Ask your notes.”
  * Added four curated OrcaRouter models with API-key configuration and validation.
  * Enabled compatible language-model requests through OrcaRouter.

* **Bug Fixes**
  * Audio memo enrichment now skips unsupported routed providers and uses a compatible fallback model.

* **Documentation**
  * Updated provider documentation to include OrcaRouter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->