### PR TITLE
feat: refresh the AI model catalog

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,21 +12,21 @@
     "test": "vitest run --config ../../vitest.config.ts --project core-browser --project core-node"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^4.0.20",
-    "@ai-sdk/google": "^4.0.24",
-    "@ai-sdk/openai": "^4.0.20",
-    "@ai-sdk/openai-compatible": "^3.0.12",
+    "@ai-sdk/anthropic": "^4.0.39",
+    "@ai-sdk/google": "^4.0.44",
+    "@ai-sdk/openai": "^4.0.42",
+    "@ai-sdk/openai-compatible": "^3.0.30",
     "@meowdown/markdown": "^0.65.5",
     "@reflect/db": "workspace:*",
     "@reflect/utils": "workspace:*",
-    "ai": "^7.0.37",
+    "ai": "^7.0.66",
     "kysely": "^0.28.17",
     "ulidx": "^2.4.1",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@ai-sdk/provider": "^4.0.3",
+    "@ai-sdk/provider": "^4.0.7",
     "@ocavue/tsconfig": "^0.7.1",
     "@vitest/browser-playwright": "^4.1.10",
     "playwright": "^1.62.1",

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -10,8 +10,8 @@ describe('AI_PROVIDERS', () => {
   it('offers the current Claude lineup in capability order', () => {
     expect(aiProvider('anthropic').models.slice(0, 3)).toEqual([
       { id: 'claude-fable-5', label: 'Claude Fable 5', contextWindow: 1_000_000 },
+      { id: 'claude-opus-5', label: 'Claude Opus 5', contextWindow: 1_000_000 },
       { id: 'claude-opus-4-8', label: 'Claude Opus 4.8', contextWindow: 1_000_000 },
-      { id: 'claude-sonnet-5', label: 'Claude Sonnet 5', contextWindow: 1_000_000 },
     ])
   })
 

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -54,7 +54,7 @@ describe('modelContextWindow', () => {
 
   it('resolves a curated model and falls back for unknown ids', () => {
     expect(modelContextWindow('anthropic', 'claude-haiku-4-5')).toBe(200_000)
-    expect(modelContextWindow('openrouter', 'openrouter/auto')).toBe(128_000)
+    expect(modelContextWindow('openrouter', 'openrouter/auto')).toBe(2_000_000)
     // Settings may carry ids added by a newer app version.
     expect(modelContextWindow('anthropic', 'claude-fable-6')).toBe(DEFAULT_CONTEXT_WINDOW)
   })

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -76,7 +76,10 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
     keyPlaceholder: 'AIza…',
     models: [
       { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
+      { id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash', contextWindow: 1_000_000 },
+      { id: 'gemini-3.6-flash', label: 'Gemini 3.6 Flash', contextWindow: 1_000_000 },
       { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', contextWindow: 1_000_000 },
+      { id: 'gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite', contextWindow: 1_000_000 },
       { id: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite', contextWindow: 1_000_000 },
       { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', contextWindow: 1_000_000 },
     ],

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -90,14 +90,14 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
     apiKeyRequired: true,
     keyPlaceholder: 'sk-or-v1-…',
     models: [
-      { id: 'openrouter/auto', label: 'Auto Router', contextWindow: 128_000 },
-      { id: '~openai/gpt-latest', label: 'OpenAI GPT Latest', contextWindow: 128_000 },
+      { id: 'openrouter/auto', label: 'Auto Router', contextWindow: 2_000_000 },
+      { id: '~openai/gpt-latest', label: 'OpenAI GPT Latest', contextWindow: 1_000_000 },
       {
         id: '~anthropic/claude-sonnet-latest',
         label: 'Claude Sonnet Latest',
-        contextWindow: 128_000,
+        contextWindow: 1_000_000,
       },
-      { id: 'openai/gpt-5.6-sol', label: 'GPT-5.6 Sol', contextWindow: 400_000 },
+      { id: 'openai/gpt-5.6-sol', label: 'GPT-5.6 Sol', contextWindow: 1_000_000 },
     ],
   },
   {

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -5,7 +5,6 @@ import type { AnthropicProvider } from '@ai-sdk/anthropic'
 import type { GoogleProvider } from '@ai-sdk/google'
 import type { OpenAIProvider } from '@ai-sdk/openai'
 
-
 /** A compile-time guarantee that an array has at least one element. */
 type NonEmptyArray<ElementType> = [ElementType, ...ElementType[]]
 
@@ -29,7 +28,7 @@ type OpenAIModelId = KnownId<Parameters<OpenAIProvider>[0]>
 /** One selectable model in a provider's curated list. */
 export interface AiModelOption<Id extends string = string> {
   /** The provider's model identifier, sent verbatim on API calls. */
-  id: Id,
+  id: Id
   /** Human-readable name shown in pickers. */
   label: string
   /**
@@ -60,7 +59,7 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
     label: 'OpenAI',
     apiKeyRequired: true,
     keyPlaceholder: 'sk-…',
-    models: ((([
+    models: [
       { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', contextWindow: 1_000_000 },
       { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', contextWindow: 1_000_000 },
       { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', contextWindow: 1_000_000 },
@@ -68,35 +67,35 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
       { id: 'gpt-5.4', label: 'GPT-5.4', contextWindow: 1_000_000 },
       { id: 'gpt-5.4-mini', label: 'GPT-5.4 mini', contextWindow: 400_000 },
       { id: 'gpt-5.4-nano', label: 'GPT-5.4 nano', contextWindow: 400_000 },
-    ]) as const) satisfies  AiModelOption<OpenAIModelId>[]),
+    ] as const satisfies AiModelOption<OpenAIModelId>[],
   },
   {
     id: 'anthropic',
     label: 'Anthropic',
     apiKeyRequired: true,
     keyPlaceholder: 'sk-ant-…',
-    models: ((([
+    models: [
       { id: 'claude-fable-5', label: 'Claude Fable 5', contextWindow: 1_000_000 },
       { id: 'claude-opus-5', label: 'Claude Opus 5', contextWindow: 1_000_000 },
       { id: 'claude-opus-4-8', label: 'Claude Opus 4.8', contextWindow: 1_000_000 },
       { id: 'claude-sonnet-5', label: 'Claude Sonnet 5', contextWindow: 1_000_000 },
       { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', contextWindow: 1_000_000 },
       { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5', contextWindow: 200_000 },
-    ] as const )) satisfies  AiModelOption<AnthropicModelId>[] ),
+    ] as const satisfies AiModelOption<AnthropicModelId>[],
   },
   {
     id: 'google',
     label: 'Google Gemini',
     apiKeyRequired: true,
     keyPlaceholder: 'AIza…',
-    models: ((([
+    models: [
       { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
       { id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash', contextWindow: 1_000_000 },
       { id: 'gemini-3.6-flash', label: 'Gemini 3.6 Flash', contextWindow: 1_000_000 },
       { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', contextWindow: 1_000_000 },
       { id: 'gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite', contextWindow: 1_000_000 },
       { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', contextWindow: 1_000_000 },
-    ] as const)) satisfies AiModelOption<GoogleModelId>[]),
+    ] as const satisfies AiModelOption<GoogleModelId>[],
   },
   {
     id: 'openrouter',

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -12,8 +12,11 @@ type NonEmptyArray<ElementType> = [ElementType, ...ElementType[]]
 /** Drop the `(string & {})` escape hatch, leaving only the known literals. */
 type KnownId<T> = T extends string ? (string extends T ? never : T) : never
 
+// https://github.com/vercel/ai/blob/ai@7.0.66/packages/anthropic/src/anthropic-language-model-options.ts#L4
 type AnthropicModelId = KnownId<Parameters<AnthropicProvider>[0]>
+// https://github.com/vercel/ai/blob/ai@7.0.66/packages/google/src/google-language-model-options.ts#L8
 type GoogleModelId = KnownId<Parameters<GoogleProvider>[0]>
+// https://github.com/vercel/ai/blob/ai@7.0.66/packages/openai/src/responses/openai-responses-language-model-options.ts#L88
 type OpenAIModelId = KnownId<Parameters<OpenAIProvider>[0]>
 
 /**

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -97,7 +97,7 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
         label: 'Claude Sonnet Latest',
         contextWindow: 128_000,
       },
-      { id: 'openai/gpt-5.2', label: 'GPT-5.2', contextWindow: 400_000 },
+      { id: 'openai/gpt-5.6-sol', label: 'GPT-5.6 Sol', contextWindow: 400_000 },
     ],
   },
   {

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -1,9 +1,11 @@
-import type { AiProviderId } from '../settings/schema'
-import { DEFAULT_OPENAI_COMPATIBLE_MODEL } from './openai-compatible'
-
 import type { AnthropicProvider } from '@ai-sdk/anthropic'
 import type { GoogleProvider } from '@ai-sdk/google'
 import type { OpenAIProvider } from '@ai-sdk/openai'
+import type { AiProviderId } from '../settings/schema'
+
+import { DEFAULT_OPENAI_COMPATIBLE_MODEL } from './openai-compatible'
+
+
 
 /** A compile-time guarantee that an array has at least one element. */
 type NonEmptyArray<ElementType> = [ElementType, ...ElementType[]]

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -77,7 +77,8 @@ const ANTHROPIC_MODELS: NonEmptyArray<AiModelOption<AnthropicModelId>> = [
 ]
 
 // https://github.com/vercel/ai/blob/ai@7.0.66/packages/google/src/google-language-model-options.ts#L8
-const GOOGLE_MODELS: NonEmptyArray<AiModelOption<GoogleModelId>> = [  { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
+const GOOGLE_MODELS: NonEmptyArray<AiModelOption<GoogleModelId>> = [
+{ id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
 { id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash', contextWindow: 1_000_000 },
 { id: 'gemini-3.6-flash', label: 'Gemini 3.6 Flash', contextWindow: 1_000_000 },
 { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', contextWindow: 1_000_000 },

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -5,12 +5,8 @@ import type { AiProviderId } from '../settings/schema'
 
 import { DEFAULT_OPENAI_COMPATIBLE_MODEL } from './openai-compatible'
 
-
-
 /** A compile-time guarantee that an array has at least one element. */
 type NonEmptyArray<ElementType> = [ElementType, ...ElementType[]]
-
-
 
 /**
  * The static BYOK provider catalog (Plan 10): display names, key hints, and
@@ -47,7 +43,6 @@ export interface AiProviderInfo {
   models: NonEmptyArray<AiModelOption>
 }
 
-
 /** Drop the `(string & {})` escape hatch, leaving only the known literals. */
 type KnownId<T> = T extends string ? (string extends T ? never : T) : never
 
@@ -78,12 +73,13 @@ const ANTHROPIC_MODELS: NonEmptyArray<AiModelOption<AnthropicModelId>> = [
 
 // https://github.com/vercel/ai/blob/ai@7.0.66/packages/google/src/google-language-model-options.ts#L8
 const GOOGLE_MODELS: NonEmptyArray<AiModelOption<GoogleModelId>> = [
-{ id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
-{ id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash', contextWindow: 1_000_000 },
-{ id: 'gemini-3.6-flash', label: 'Gemini 3.6 Flash', contextWindow: 1_000_000 },
-{ id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', contextWindow: 1_000_000 },
-{ id: 'gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite', contextWindow: 1_000_000 },
-{ id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', contextWindow: 1_000_000 },]
+  { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
+  { id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash', contextWindow: 1_000_000 },
+  { id: 'gemini-3.6-flash', label: 'Gemini 3.6 Flash', contextWindow: 1_000_000 },
+  { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', contextWindow: 1_000_000 },
+  { id: 'gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite', contextWindow: 1_000_000 },
+  { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', contextWindow: 1_000_000 },
+]
 
 export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
   {
@@ -91,21 +87,21 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
     label: 'OpenAI',
     apiKeyRequired: true,
     keyPlaceholder: 'sk-…',
-    models: OPENAI_MODELS
+    models: OPENAI_MODELS,
   },
   {
     id: 'anthropic',
     label: 'Anthropic',
     apiKeyRequired: true,
     keyPlaceholder: 'sk-ant-…',
-    models: ANTHROPIC_MODELS
+    models: ANTHROPIC_MODELS,
   },
   {
     id: 'google',
     label: 'Google Gemini',
     apiKeyRequired: true,
     keyPlaceholder: 'AIza…',
-    models:GOOGLE_MODELS
+    models: GOOGLE_MODELS,
   },
   {
     id: 'openrouter',

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -8,12 +8,7 @@ import type { OpenAIProvider } from '@ai-sdk/openai'
 /** A compile-time guarantee that an array has at least one element. */
 type NonEmptyArray<ElementType> = [ElementType, ...ElementType[]]
 
-/** Drop the `(string & {})` escape hatch, leaving only the known literals. */
-type KnownId<T> = T extends string ? (string extends T ? never : T) : never
 
-type AnthropicModelId = KnownId<Parameters<AnthropicProvider>[0]>
-type GoogleModelId = KnownId<Parameters<GoogleProvider>[0]>
-type OpenAIModelId = KnownId<Parameters<OpenAIProvider>[0]>
 
 /**
  * The static BYOK provider catalog (Plan 10): display names, key hints, and
@@ -49,6 +44,14 @@ export interface AiProviderInfo {
   /** Curated models, most capable first (the first is the picker default). */
   models: NonEmptyArray<AiModelOption>
 }
+
+
+/** Drop the `(string & {})` escape hatch, leaving only the known literals. */
+type KnownId<T> = T extends string ? (string extends T ? never : T) : never
+
+type AnthropicModelId = KnownId<Parameters<AnthropicProvider>[0]>
+type GoogleModelId = KnownId<Parameters<GoogleProvider>[0]>
+type OpenAIModelId = KnownId<Parameters<OpenAIProvider>[0]>
 
 // https://github.com/vercel/ai/blob/ai@7.0.66/packages/openai/src/responses/openai-responses-language-model-options.ts#L88
 const OPENAI_MODELS: NonEmptyArray<AiModelOption<OpenAIModelId>> = [

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -62,6 +62,7 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
     keyPlaceholder: 'sk-ant-…',
     models: [
       { id: 'claude-fable-5', label: 'Claude Fable 5', contextWindow: 1_000_000 },
+      { id: 'claude-opus-5', label: 'Claude Opus 5', contextWindow: 1_000_000 },
       { id: 'claude-opus-4-8', label: 'Claude Opus 4.8', contextWindow: 1_000_000 },
       { id: 'claude-sonnet-5', label: 'Claude Sonnet 5', contextWindow: 1_000_000 },
       { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', contextWindow: 1_000_000 },

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -1,8 +1,20 @@
 import type { AiProviderId } from '../settings/schema'
 import { DEFAULT_OPENAI_COMPATIBLE_MODEL } from './openai-compatible'
 
+import type { AnthropicProvider } from '@ai-sdk/anthropic'
+import type { GoogleProvider } from '@ai-sdk/google'
+import type { OpenAIProvider } from '@ai-sdk/openai'
+
+
 /** A compile-time guarantee that an array has at least one element. */
 type NonEmptyArray<ElementType> = [ElementType, ...ElementType[]]
+
+/** Drop the `(string & {})` escape hatch, leaving only the known literals. */
+type KnownId<T> = T extends string ? (string extends T ? never : T) : never
+
+type AnthropicModelId = KnownId<Parameters<AnthropicProvider>[0]>
+type GoogleModelId = KnownId<Parameters<GoogleProvider>[0]>
+type OpenAIModelId = KnownId<Parameters<OpenAIProvider>[0]>
 
 /**
  * The static BYOK provider catalog (Plan 10): display names, key hints, and
@@ -12,9 +24,9 @@ type NonEmptyArray<ElementType> = [ElementType, ...ElementType[]]
  */
 
 /** One selectable model in a provider's curated list. */
-export interface AiModelOption {
+export interface AiModelOption<Id extends string = string> {
   /** The provider's model identifier, sent verbatim on API calls. */
-  id: string
+  id: Id,
   /** Human-readable name shown in pickers. */
   label: string
   /**
@@ -45,7 +57,7 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
     label: 'OpenAI',
     apiKeyRequired: true,
     keyPlaceholder: 'sk-…',
-    models: [
+    models: ((([
       { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', contextWindow: 1_000_000 },
       { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', contextWindow: 1_000_000 },
       { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', contextWindow: 1_000_000 },
@@ -53,36 +65,35 @@ export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
       { id: 'gpt-5.4', label: 'GPT-5.4', contextWindow: 1_000_000 },
       { id: 'gpt-5.4-mini', label: 'GPT-5.4 mini', contextWindow: 400_000 },
       { id: 'gpt-5.4-nano', label: 'GPT-5.4 nano', contextWindow: 400_000 },
-    ],
+    ]) as const) satisfies  AiModelOption<OpenAIModelId>[]),
   },
   {
     id: 'anthropic',
     label: 'Anthropic',
     apiKeyRequired: true,
     keyPlaceholder: 'sk-ant-…',
-    models: [
+    models: ((([
       { id: 'claude-fable-5', label: 'Claude Fable 5', contextWindow: 1_000_000 },
       { id: 'claude-opus-5', label: 'Claude Opus 5', contextWindow: 1_000_000 },
       { id: 'claude-opus-4-8', label: 'Claude Opus 4.8', contextWindow: 1_000_000 },
       { id: 'claude-sonnet-5', label: 'Claude Sonnet 5', contextWindow: 1_000_000 },
       { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', contextWindow: 1_000_000 },
       { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5', contextWindow: 200_000 },
-    ],
+    ] as const )) satisfies  AiModelOption<AnthropicModelId>[] ),
   },
   {
     id: 'google',
     label: 'Google Gemini',
     apiKeyRequired: true,
     keyPlaceholder: 'AIza…',
-    models: [
+    models: ((([
       { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
       { id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash', contextWindow: 1_000_000 },
       { id: 'gemini-3.6-flash', label: 'Gemini 3.6 Flash', contextWindow: 1_000_000 },
       { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', contextWindow: 1_000_000 },
       { id: 'gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite', contextWindow: 1_000_000 },
-      { id: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite', contextWindow: 1_000_000 },
       { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', contextWindow: 1_000_000 },
-    ],
+    ] as const)) satisfies AiModelOption<GoogleModelId>[]),
   },
   {
     id: 'openrouter',

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -11,11 +11,8 @@ type NonEmptyArray<ElementType> = [ElementType, ...ElementType[]]
 /** Drop the `(string & {})` escape hatch, leaving only the known literals. */
 type KnownId<T> = T extends string ? (string extends T ? never : T) : never
 
-// https://github.com/vercel/ai/blob/ai@7.0.66/packages/anthropic/src/anthropic-language-model-options.ts#L4
 type AnthropicModelId = KnownId<Parameters<AnthropicProvider>[0]>
-// https://github.com/vercel/ai/blob/ai@7.0.66/packages/google/src/google-language-model-options.ts#L8
 type GoogleModelId = KnownId<Parameters<GoogleProvider>[0]>
-// https://github.com/vercel/ai/blob/ai@7.0.66/packages/openai/src/responses/openai-responses-language-model-options.ts#L88
 type OpenAIModelId = KnownId<Parameters<OpenAIProvider>[0]>
 
 /**
@@ -53,49 +50,56 @@ export interface AiProviderInfo {
   models: NonEmptyArray<AiModelOption>
 }
 
+// https://github.com/vercel/ai/blob/ai@7.0.66/packages/openai/src/responses/openai-responses-language-model-options.ts#L88
+const OPENAI_MODELS: NonEmptyArray<AiModelOption<OpenAIModelId>> = [
+  { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', contextWindow: 1_000_000 },
+  { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', contextWindow: 1_000_000 },
+  { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', contextWindow: 1_000_000 },
+  { id: 'gpt-5.5', label: 'GPT-5.5', contextWindow: 1_000_000 },
+  { id: 'gpt-5.4', label: 'GPT-5.4', contextWindow: 1_000_000 },
+  { id: 'gpt-5.4-mini', label: 'GPT-5.4 mini', contextWindow: 400_000 },
+  { id: 'gpt-5.4-nano', label: 'GPT-5.4 nano', contextWindow: 400_000 },
+]
+
+// https://github.com/vercel/ai/blob/ai@7.0.66/packages/anthropic/src/anthropic-language-model-options.ts#L4
+const ANTHROPIC_MODELS: NonEmptyArray<AiModelOption<AnthropicModelId>> = [
+  { id: 'claude-fable-5', label: 'Claude Fable 5', contextWindow: 1_000_000 },
+  { id: 'claude-opus-5', label: 'Claude Opus 5', contextWindow: 1_000_000 },
+  { id: 'claude-opus-4-8', label: 'Claude Opus 4.8', contextWindow: 1_000_000 },
+  { id: 'claude-sonnet-5', label: 'Claude Sonnet 5', contextWindow: 1_000_000 },
+  { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', contextWindow: 1_000_000 },
+  { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5', contextWindow: 200_000 },
+]
+
+// https://github.com/vercel/ai/blob/ai@7.0.66/packages/google/src/google-language-model-options.ts#L8
+const GOOGLE_MODELS: NonEmptyArray<AiModelOption<GoogleModelId>> = [  { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
+{ id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash', contextWindow: 1_000_000 },
+{ id: 'gemini-3.6-flash', label: 'Gemini 3.6 Flash', contextWindow: 1_000_000 },
+{ id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', contextWindow: 1_000_000 },
+{ id: 'gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite', contextWindow: 1_000_000 },
+{ id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', contextWindow: 1_000_000 },]
+
 export const AI_PROVIDERS: NonEmptyArray<AiProviderInfo> = [
   {
     id: 'openai',
     label: 'OpenAI',
     apiKeyRequired: true,
     keyPlaceholder: 'sk-…',
-    models: [
-      { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', contextWindow: 1_000_000 },
-      { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', contextWindow: 1_000_000 },
-      { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', contextWindow: 1_000_000 },
-      { id: 'gpt-5.5', label: 'GPT-5.5', contextWindow: 1_000_000 },
-      { id: 'gpt-5.4', label: 'GPT-5.4', contextWindow: 1_000_000 },
-      { id: 'gpt-5.4-mini', label: 'GPT-5.4 mini', contextWindow: 400_000 },
-      { id: 'gpt-5.4-nano', label: 'GPT-5.4 nano', contextWindow: 400_000 },
-    ] as const satisfies AiModelOption<OpenAIModelId>[],
+    models: OPENAI_MODELS
   },
   {
     id: 'anthropic',
     label: 'Anthropic',
     apiKeyRequired: true,
     keyPlaceholder: 'sk-ant-…',
-    models: [
-      { id: 'claude-fable-5', label: 'Claude Fable 5', contextWindow: 1_000_000 },
-      { id: 'claude-opus-5', label: 'Claude Opus 5', contextWindow: 1_000_000 },
-      { id: 'claude-opus-4-8', label: 'Claude Opus 4.8', contextWindow: 1_000_000 },
-      { id: 'claude-sonnet-5', label: 'Claude Sonnet 5', contextWindow: 1_000_000 },
-      { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', contextWindow: 1_000_000 },
-      { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5', contextWindow: 200_000 },
-    ] as const satisfies AiModelOption<AnthropicModelId>[],
+    models: ANTHROPIC_MODELS
   },
   {
     id: 'google',
     label: 'Google Gemini',
     apiKeyRequired: true,
     keyPlaceholder: 'AIza…',
-    models: [
-      { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
-      { id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash', contextWindow: 1_000_000 },
-      { id: 'gemini-3.6-flash', label: 'Gemini 3.6 Flash', contextWindow: 1_000_000 },
-      { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', contextWindow: 1_000_000 },
-      { id: 'gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite', contextWindow: 1_000_000 },
-      { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', contextWindow: 1_000_000 },
-    ] as const satisfies AiModelOption<GoogleModelId>[],
+    models:GOOGLE_MODELS
   },
   {
     id: 'openrouter',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,17 +269,17 @@ importers:
   packages/core:
     dependencies:
       '@ai-sdk/anthropic':
-        specifier: ^4.0.20
-        version: 4.0.20(zod@4.4.3)
+        specifier: ^4.0.39
+        version: 4.0.39(zod@4.4.3)
       '@ai-sdk/google':
-        specifier: ^4.0.24
-        version: 4.0.24(zod@4.4.3)
+        specifier: ^4.0.44
+        version: 4.0.44(zod@4.4.3)
       '@ai-sdk/openai':
-        specifier: ^4.0.20
-        version: 4.0.20(zod@4.4.3)
+        specifier: ^4.0.42
+        version: 4.0.42(zod@4.4.3)
       '@ai-sdk/openai-compatible':
-        specifier: ^3.0.12
-        version: 3.0.16(zod@4.4.3)
+        specifier: ^3.0.30
+        version: 3.0.30(zod@4.4.3)
       '@meowdown/markdown':
         specifier: ^0.65.5
         version: 0.65.5
@@ -290,8 +290,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       ai:
-        specifier: ^7.0.37
-        version: 7.0.37(zod@4.4.3)
+        specifier: ^7.0.66
+        version: 7.0.66(zod@4.4.3)
       kysely:
         specifier: ^0.28.17
         version: 0.28.17
@@ -306,8 +306,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@ai-sdk/provider':
-        specifier: ^4.0.3
-        version: 4.0.4
+        specifier: ^4.0.7
+        version: 4.0.7
       '@ocavue/tsconfig':
         specifier: ^0.7.1
         version: 0.7.1
@@ -372,54 +372,44 @@ packages:
   '@1natsu/wait-element@4.2.0':
     resolution: {integrity: sha512-Om0Q+WE9mNrpY4AwMTvkFiYHv8VM7TML3PvOqXy+w6kAjLjKhGYHYX+305+a6J8RVpds9s7IF2Z5aOPYwULFNw==}
 
-  '@ai-sdk/anthropic@4.0.20':
-    resolution: {integrity: sha512-5QdZt6AkWIKIKuwRSjAQIBhN0JSSvthaIcAJKTHP7HPCvWMcNJFF6rz0uKfUlpI3h7nVbY+1Cy5dNl5zjzJ6qA==}
+  '@ai-sdk/anthropic@4.0.39':
+    resolution: {integrity: sha512-JAMGtYeEuaBzqbsPO4fkho6vQyNoVhsHASM4o59wmJRU6Vh7prjOp490Kmc7YQTY+ioU1/xYzXvWOtxZBup0Xw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@4.0.28':
-    resolution: {integrity: sha512-ee9TsNO3mkgHDWmTmJ8Fvltr6PFh52zhrV2+FaKJY3F3iu7kWZi5tCRJCR1HVhhlpj6lHniUb28nLQdPHkA/1Q==}
+  '@ai-sdk/gateway@4.0.52':
+    resolution: {integrity: sha512-SXUM8jzzuTUJRq+EOgPd5to6DSx0EKslVn+IVZHbUEX6k/3vCPNrvjckbK26HnNxHU/STxm+zTSJteqrO+7Z0w==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@4.0.24':
-    resolution: {integrity: sha512-W+kTGb/RRe2SEYwbKcKYM3N2EQryS2Iqjgou6wPsyP/2BwBU7Q23CF6/YWE8k7xtseDLcSY59jsR2MDpY4azRg==}
+  '@ai-sdk/google@4.0.44':
+    resolution: {integrity: sha512-bmRTDg06jQD+eX8nf214pET9+Oe8O1+lUIRGbWsGXj9IN2UJkpl1O1x7cvtiboyTtKSLvSRdVtItUfSl8sQ2GA==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@3.0.16':
-    resolution: {integrity: sha512-beXoYtlCnI02BYZU6oGfOPI40xC8MJx+Ek0SM8XZ8RcBBP7SaQ0qIV5DO3Y1euHMLMD92zE7nNHM0WcnnnX58A==}
+  '@ai-sdk/openai-compatible@3.0.30':
+    resolution: {integrity: sha512-BB35G4fS/Ey5OHbWrVLxRLX1gkTlO+9I4YhlmdH1skNVoPaFXZlR6bQ+1C76d/ug7O6ocbIw4qcd2G4+GPdWEA==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@4.0.20':
-    resolution: {integrity: sha512-/Hu+btLIO2zuYqCp//vBBAGdM/BeN4gds+NWrlv7Y9WrcTXwnEEwh6P3QZIWh2Tt1I1lswuDIpAJ4t/c/rws3Q==}
+  '@ai-sdk/openai@4.0.42':
+    resolution: {integrity: sha512-ZxDca6jJalYuXrIGVrw6dnkpz1Io9AWy+/b/wVWIbjigHCbd+zWLpPi8NnK0OFU+U3YCpP+KWfUvEnG5pFhltA==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@5.0.12':
-    resolution: {integrity: sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA==}
+  '@ai-sdk/provider-utils@5.0.27':
+    resolution: {integrity: sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@5.0.14':
-    resolution: {integrity: sha512-HW+Ys98cr2BRQzP6jTlp2bRKIqt+oAjYNLm9gqUUQkLz7QERtaPgDZOoXHz9IXSXoOtz175p4Q17qKQdEX0Hag==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider@4.0.3':
-    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
-    engines: {node: '>=22'}
-
-  '@ai-sdk/provider@4.0.4':
-    resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
+  '@ai-sdk/provider@4.0.7':
+    resolution: {integrity: sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==}
     engines: {node: '>=22'}
 
   '@aklinker1/rollup-plugin-visualizer@5.12.0':
@@ -2482,8 +2472,8 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
-  ai@7.0.37:
-    resolution: {integrity: sha512-stF+SEQJgKY3Qfe3FwNzqUrehHviOp2l7LemoI8YMOa0Zk5PxKsRNgUk3cHXz0RAue9RRyCAis2fz6LSCP6EKw==}
+  ai@7.0.66:
+    resolution: {integrity: sha512-wBUyoCYF3GVr+62nelBgR8YbpTSsMZrzFyOOjiwijylNSM2TFCW35C+Pml2vc59/WLMpyhS/LWZ55M+B9DAcSg==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -6343,58 +6333,47 @@ snapshots:
       defu: 6.1.7
       many-keys-map: 3.0.3
 
-  '@ai-sdk/anthropic@4.0.20(zod@4.4.3)':
+  '@ai-sdk/anthropic@4.0.39(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.3
-      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/gateway@4.0.28(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.52(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.3
-      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/google@4.0.24(zod@4.4.3)':
+  '@ai-sdk/google@4.0.44(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.3
-      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai-compatible@3.0.16(zod@4.4.3)':
+  '@ai-sdk/openai-compatible@3.0.30(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.4
-      '@ai-sdk/provider-utils': 5.0.14(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai@4.0.20(zod@4.4.3)':
+  '@ai-sdk/openai@4.0.42(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.3
-      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@5.0.12(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.27(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider': 4.0.7
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
+      undici: 7.28.0
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@5.0.14(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.4
-      '@standard-schema/spec': 1.1.0
-      '@workflow/serde': 4.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.4.3
-
-  '@ai-sdk/provider@4.0.3':
-    dependencies:
-      json-schema: 0.4.0
-
-  '@ai-sdk/provider@4.0.4':
+  '@ai-sdk/provider@4.0.7':
     dependencies:
       json-schema: 0.4.0
 
@@ -8682,11 +8661,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ai@7.0.37(zod@4.4.3):
+  ai@7.0.66(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 4.0.28(zod@4.4.3)
-      '@ai-sdk/provider': 4.0.3
-      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
+      '@ai-sdk/gateway': 4.0.52(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
       zod: 4.4.3
 
   ajv-formats@2.1.1(ajv@8.20.0):


### PR DESCRIPTION
Adds Claude Opus 5, Gemini 3.7/3.6 Flash and 3.5 Flash Lite, and a current OpenRouter GPT entry to the model picker, and corrects the OpenRouter context windows that were declared ~8x too small.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the available AI provider model catalog with the latest Anthropic and Google models.
  * Added improved model metadata and stronger compatibility across supported AI providers.
  * Expanded OpenRouter model information, including updated model availability and context-window limits.

* **Bug Fixes**
  * Corrected the listed context window for OpenRouter’s automatic model selection.
  * Updated provider information to reflect current model offerings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->