### PR TITLE
fix: lift mobile bottom sheets above the software keyboard

### DIFF
--- a/apps/desktop/src/components/ui/drawer.test.tsx
+++ b/apps/desktop/src/components/ui/drawer.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, render } from 'vitest-browser-react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Drawer, DrawerContent, DrawerTitle } from './drawer'
+
+/**
+ * The bottom sheet's keyboard contract: the popup is `position: fixed`, so the
+ * mobile shell's shrunken height can't lift it above the software keyboard —
+ * it must read `--keyboard-height` itself (the shell's rule for fixed
+ * elements). Vaul repositioned above the keyboard on its own; the Base UI
+ * rebuild left avoidance to us, and losing this offset put the task sheet's
+ * add flow underneath the keyboard.
+ */
+
+afterEach(() => {
+  cleanup()
+  document.documentElement.style.removeProperty('--keyboard-height')
+})
+
+async function mountOpenDrawer(): Promise<HTMLElement> {
+  await render(
+    <Drawer open onOpenChange={() => {}}>
+      <DrawerContent aria-label="Sheet">
+        <DrawerTitle>Sheet</DrawerTitle>
+        <p>Sheet body</p>
+      </DrawerContent>
+    </Drawer>,
+  )
+  return await vi.waitFor(() => {
+    const popup = document.querySelector<HTMLElement>('[data-slot="drawer-popup"]')
+    if (popup === null) {
+      throw new Error('drawer popup did not mount')
+    }
+    return popup
+  })
+}
+
+describe('Drawer keyboard avoidance', () => {
+  it('sits at the viewport bottom while no keyboard is up', async () => {
+    const popup = await mountOpenDrawer()
+
+    expect(getComputedStyle(popup).bottom).toBe('0px')
+  })
+
+  it('rides on the software keyboard’s top edge via --keyboard-height', async () => {
+    document.documentElement.style.setProperty('--keyboard-height', '300px')
+    const popup = await mountOpenDrawer()
+
+    expect(getComputedStyle(popup).bottom).toBe('300px')
+  })
+
+  it('caps its height to what the keyboard leaves visible', async () => {
+    document.documentElement.style.setProperty('--keyboard-height', '300px')
+    const popup = await mountOpenDrawer()
+
+    const maxHeight = Number.parseFloat(getComputedStyle(popup).maxHeight)
+    const expected = Math.min(window.innerHeight * 0.85, window.innerHeight - 300)
+    expect(maxHeight).toBeCloseTo(expected, 0)
+  })
+})

--- a/apps/desktop/src/components/ui/drawer.tsx
+++ b/apps/desktop/src/components/ui/drawer.tsx
@@ -113,13 +113,17 @@ function DrawerContent({ className, children, ...props }: DrawerPrimitive.Popup.
           data-snap-points={hasSnapPoints ? '' : undefined}
           className={cn(
             // Base.
-            'group/drawer-popup pointer-events-auto fixed z-50 m-(--drawer-inset,0px) flex h-(--drawer-content-height) max-h-(--drawer-content-max-height,none) min-h-0 w-(--drawer-content-width,auto) transform-[translate3d(var(--translate-x,0px),var(--translate-y,0px),0)_scale(var(--stack-scale))] flex-col bg-popover text-sm text-popover-foreground ring-1 ring-foreground/10 transition-[transform,height,opacity,filter] duration-450 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform outline-none select-none [interpolate-size:allow-keywords] data-[swipe-direction=down]:rounded-t-xl data-[swipe-direction=left]:rounded-r-xl data-[swipe-direction=right]:rounded-l-xl data-[swipe-direction=up]:rounded-b-xl',
+            'group/drawer-popup pointer-events-auto fixed z-50 m-(--drawer-inset,0px) flex h-(--drawer-content-height) max-h-(--drawer-content-max-height,none) min-h-0 w-(--drawer-content-width,auto) transform-[translate3d(var(--translate-x,0px),var(--translate-y,0px),0)_scale(var(--stack-scale))] flex-col bg-popover text-sm text-popover-foreground ring-1 ring-foreground/10 transition-[transform,height,bottom,opacity,filter] duration-450 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform outline-none select-none [interpolate-size:allow-keywords] data-[swipe-direction=down]:rounded-t-xl data-[swipe-direction=left]:rounded-r-xl data-[swipe-direction=right]:rounded-l-xl data-[swipe-direction=up]:rounded-b-xl',
             // Nested.
             'data-nested-drawer-open:overflow-hidden data-nested-drawer-open:brightness-95',
             // Bleed.
             'after:pointer-events-none after:absolute after:bg-(--drawer-bleed-background,var(--color-popover)) data-[swipe-axis=x]:after:inset-y-0 data-[swipe-axis=x]:after:w-(--bleed) data-[swipe-axis=y]:after:inset-x-0 data-[swipe-axis=y]:after:h-(--bleed) data-[swipe-direction=down]:after:top-full data-[swipe-direction=left]:after:right-full data-[swipe-direction=right]:after:left-full data-[swipe-direction=up]:after:bottom-full',
-            // Sizing.
-            '[--drawer-content-height:var(--drawer-height,auto)] data-[swipe-axis=x]:[--drawer-content-width:75%] data-[swipe-axis=y]:[--drawer-content-max-height:85vh] data-[swipe-axis=y]:data-snap-points:[--drawer-content-height:100dvh] data-[swipe-axis=x]:sm:[--drawer-content-width:24rem]',
+            // Sizing. The y-axis max height also yields to the software keyboard
+            // (`--keyboard-height`, the mobile shell's keyboard contract): the
+            // popup rides on the keyboard's top edge, so its box must fit in
+            // what the keyboard leaves visible or the sheet's top slides off
+            // the screen.
+            '[--drawer-content-height:var(--drawer-height,auto)] data-[swipe-axis=x]:[--drawer-content-width:75%] data-[swipe-axis=y]:[--drawer-content-max-height:min(85vh,100dvh-var(--keyboard-height,0px)-env(safe-area-inset-top))] data-[swipe-axis=y]:data-snap-points:[--drawer-content-height:100dvh] data-[swipe-axis=x]:sm:[--drawer-content-width:24rem]',
             // Stack.
             '[--bleed:3rem] [--peek:1rem] [--stack-height:var(--drawer-frontmost-height,var(--drawer-height,0px))] [--stack-peek-offset:max(0px,calc((var(--nested-drawers)-var(--stack-progress))*var(--peek)))] [--stack-progress:clamp(0,var(--drawer-swipe-progress),1)] [--stack-scale-base:max(0,calc(1-(var(--nested-drawers)*var(--stack-step))))] [--stack-scale:clamp(0,calc(var(--stack-scale-base)+(var(--stack-step)*var(--stack-progress))),1)] [--stack-shrink:calc(1-var(--stack-scale))] [--stack-step:0.05]',
             // Transitions.
@@ -128,8 +132,11 @@ function DrawerContent({ className, children, ...props }: DrawerPrimitive.Popup.
             'data-[swipe-axis=y]:inset-x-0 data-[swipe-axis=y]:data-nested-drawer-open:h-(--stack-height)',
             // Axis: x.
             'data-[swipe-axis=x]:inset-y-0 data-[swipe-axis=x]:flex-row',
-            // Direction: down.
-            'data-[swipe-direction=down]:bottom-0 data-[swipe-direction=down]:origin-bottom data-[swipe-direction=down]:[--closed-transform:translate3d(0,calc(100%+var(--drawer-inset,0px)+2px),0)] data-[swipe-direction=down]:[--translate-y:calc(var(--drawer-snap-point-offset,0px)+var(--drawer-swipe-movement-y)-var(--stack-peek-offset)-(var(--stack-shrink)*var(--stack-height)))]',
+            // Direction: down. The bottom edge sits on the software keyboard
+            // when one is up (vaul repositioned above the keyboard itself; Base
+            // UI leaves keyboard avoidance to us, and this popup is `fixed`, so
+            // the shell's shrunken height can't carry it).
+            'data-[swipe-direction=down]:bottom-(--keyboard-height,0px) data-[swipe-direction=down]:origin-bottom data-[swipe-direction=down]:[--closed-transform:translate3d(0,calc(100%+var(--drawer-inset,0px)+2px),0)] data-[swipe-direction=down]:[--translate-y:calc(var(--drawer-snap-point-offset,0px)+var(--drawer-swipe-movement-y)-var(--stack-peek-offset)-(var(--stack-shrink)*var(--stack-height)))]',
             // Direction: up.
             'data-[swipe-direction=up]:top-0 data-[swipe-direction=up]:origin-top data-[swipe-direction=up]:[--closed-transform:translate3d(0,calc(-100%-var(--drawer-inset,0px)-2px),0)] data-[swipe-direction=up]:[--translate-y:calc(var(--drawer-snap-point-offset,0px)+var(--drawer-swipe-movement-y)+var(--stack-peek-offset)+(var(--stack-shrink)*var(--stack-height)))]',
             // Direction: left.

--- a/apps/desktop/src/dev/dev-bridge.ts
+++ b/apps/desktop/src/dev/dev-bridge.ts
@@ -86,6 +86,10 @@ export function createDevBridge(backend: DevBridgeBackend): IpcBridge {
         return { height: 0, duration: 0 }
       case 'plugin:keyboard|impact_light':
         return null
+      case 'plugin:iap|get_product_status':
+        // No StoreKit in a browser: answer as a subscribed device so the iOS
+        // tree's paywall gate lifts and the harness boots into the shell.
+        return { isOwned: true }
       case 'mobile_storage':
         // No iCloud in a plain browser — the dev harness exercises the
         // local-storage path (and, via `mobileOnboarded` above, skips


### PR DESCRIPTION
## Problem

On the iOS Tasks tab, tapping **+** opens the quick-edit sheet with the editor autofocused — the keyboard comes up, and the sheet stays pinned to the physical bottom of the screen, so the keyboard covers everything but the input strip:

The regression came in with the Base UI Drawer rebuild (#1075): vaul repositioned its drawer above the keyboard on its own (`repositionInputs` via `visualViewport`), while Base UI leaves keyboard avoidance to an opt-in provider that was never wired up. Row taps don't raise the keyboard, which is why the sheet only looked broken on the add flow ("sometimes").

## Fix

The mobile shell's keyboard contract (Plan 19, decision 8) is that `position: fixed` elements read `--keyboard-height` themselves — the FAB already does; the drawer now does too:

- The popup's bottom edge sits at `var(--keyboard-height, 0px)`, so every bottom sheet rides on the keyboard's top edge. `bottom` joins the popup's transition list so the ride up/down animates with the existing spring curve.
- The y-axis max height yields to the keyboard (`min(85vh, 100dvh − keyboard − safe-area-top)`) so a tall sheet's top can't slide off the screen behind the notch.

Also stubs `plugin:iap|get_product_status` in the browser dev bridge as "subscribed" — since the paywall landed, the `?platform=ios` harness stranded on the loading screen because the entitlement gate had no answer.

## Testing

- New browser-mode test `drawer.test.tsx`: popup sits at bottom 0 with no keyboard, rides at `--keyboard-height` when set, and caps its height to the visible area.
- Verified in the `?platform=ios` harness: opened the Tasks "+" sheet, simulated a 300px/450px keyboard via `--keyboard-height` — the full sheet (editor, schedule chips, actions) sits above the keyboard line, clamps on tall keyboards, and returns to the bottom when the keyboard hides.
- `pnpm check` green; tasks/drawer-consuming suites pass (48 tests).
- Owed: a device pass on the real add flow (programmatic-focus keyboard raise + sheet enter animating together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fixed positioning and sizing for all mobile bottom sheets; behavior is localized to drawer CSS and dev harness, but it affects a core mobile input flow.
> 
> **Overview**
> Fixes a **Base UI drawer** regression where bottom sheets stayed at the physical viewport bottom when the software keyboard opened (e.g. Tasks **+** quick-edit), so content sat under the keyboard. Vaul handled this automatically; the rebuild expects **`--keyboard-height`** on fixed popups, matching the mobile shell contract.
> 
> **Drawer popup** now anchors its bottom edge to `var(--keyboard-height, 0px)`, animates **`bottom`** with the existing spring, and caps y-axis **max-height** with `min(85vh, 100dvh − keyboard − safe-area-top)` so tall sheets don’t clip past the notch.
> 
> Adds **`drawer.test.tsx`** browser tests for bottom offset and max-height when `--keyboard-height` is set. Stubs **`plugin:iap|get_product_status`** in the dev bridge as subscribed so the `?platform=ios` harness can pass the paywall and exercise the sheet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 593fcfa58ee2834169ed0f25fb0c7c189c65d879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drawer positioning and sizing when the on-screen keyboard is open.
  * Drawers now remain above the keyboard and respect the visible viewport and safe-area spacing.
  * Added smoother drawer movement during keyboard-related transitions.

* **Development**
  * Added development support for reporting in-app purchase products as subscribed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->