### PR TITLE
feat: add swipe actions to iOS task list

### DIFF
--- a/apps/desktop/src/mobile/note-row-list.test.tsx
+++ b/apps/desktop/src/mobile/note-row-list.test.tsx
@@ -1,6 +1,7 @@
-import { act, useState, type ReactElement } from 'react'
+import { useState, type ReactElement } from 'react'
 import { render } from 'vitest-browser-react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { pointer, swipe, translateX } from '@/test-utils/swipe'
 import { NoteRowList } from './note-row-list'
 import { SwipeableNoteRow, type NoteRowModel } from './swipeable-note-row'
 
@@ -44,45 +45,6 @@ function SwipeHarness({ note = row() }: { note?: NoteRowModel }): ReactElement {
       />
     </div>
   )
-}
-
-function pointer(
-  node: Element,
-  type: 'pointerdown' | 'pointermove' | 'pointerup',
-  clientX: number,
-  clientY: number,
-): void {
-  act(() => {
-    node.dispatchEvent(
-      new PointerEvent(type, {
-        bubbles: true,
-        cancelable: true,
-        pointerType: 'touch',
-        isPrimary: true,
-        pointerId: 1,
-        clientX,
-        clientY,
-      }),
-    )
-  })
-}
-
-function swipe(
-  surface: Element,
-  from: { x: number; y: number },
-  to: { x: number; y: number },
-): void {
-  pointer(surface, 'pointerdown', from.x, from.y)
-  pointer(surface, 'pointermove', to.x, to.y)
-  pointer(surface, 'pointerup', to.x, to.y)
-  // A real touch sequence synthesizes a click after pointerup; dispatchEvent
-  // does not, so mirror it to exercise the row's drag-click suppression.
-  const touchSurface = surface as HTMLElement
-  touchSurface.click()
-}
-
-function translateX(element: Element): number {
-  return new DOMMatrixReadOnly(getComputedStyle(element).transform).m41
 }
 
 beforeEach(() => {

--- a/apps/desktop/src/mobile/screens/tasks.test.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.test.tsx
@@ -8,6 +8,7 @@ import { makeOpenTask as task } from '@/lib/tasks/open-task-fixture'
 import { resetRecentlyCompleted } from '@/lib/tasks/recently-completed'
 import { RouterProvider, useRouter } from '@/routing/router'
 import '@/test-utils/locator'
+import { swipe, translateX } from '@/test-utils/swipe'
 import { MobileTasks } from './tasks'
 
 /**
@@ -64,6 +65,8 @@ vi.mock('@/editor/use-editor-autocomplete', () => ({
 vi.mock('@/mobile/haptics', () => ({
   hapticImpactLight,
 }))
+// Instant settle, so row transforms can be asserted synchronously.
+vi.mock('@/mobile/use-reduced-motion', () => ({ usePrefersReducedMotion: () => true }))
 
 const editorProbe = vi.hoisted(() => ({ focusCalls: 0 }))
 
@@ -228,6 +231,22 @@ function renderScreen() {
 }
 
 const waitFor = vi.waitFor
+
+/** Swipe a row far enough left that its release settles open, and return its moving surface. */
+async function revealSwipeActions(
+  view: Awaited<ReturnType<typeof renderScreen>>,
+  label: string,
+): Promise<HTMLElement> {
+  const body = await view.findByRole('button', { name: `Edit: ${label}` })
+  const surface = body.parentElement!
+  const rect = surface.getBoundingClientRect()
+  swipe(
+    surface,
+    { x: rect.right - 20, y: rect.top + 16 },
+    { x: rect.right - 160, y: rect.top + 16 },
+  )
+  return surface
+}
 
 beforeEach(async () => {
   await page.viewport(375, 700)
@@ -798,6 +817,77 @@ describe('MobileTasks', () => {
     const view = await renderScreen()
 
     await view.findByRole('alert')
+    await view.unmount()
+  })
+
+  it('reveals note and delete actions with a leftward swipe', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const view = await renderScreen()
+
+    const surface = await revealSwipeActions(view, 'buy milk')
+
+    await expect
+      .element(view.getByRole('button', { name: 'Open note: buy milk' }))
+      .toBeInTheDocument()
+    await expect.element(view.getByRole('button', { name: 'Delete: buy milk' })).toBeInTheDocument()
+    expect(translateX(surface)).toBe(-136)
+    // The drag's synthetic click was swallowed; the sheet did not open.
+    expect(view.queryByText('dismiss-drawer')).toBeNull()
+    await view.unmount()
+  })
+
+  it('deletes a task from its swipe action without a dialog', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const view = await renderScreen()
+
+    await revealSwipeActions(view, 'buy milk')
+    await view.getByRole('button', { name: 'Delete: buy milk' }).click()
+
+    await waitFor(() => expect(deleteTask).toHaveBeenCalledTimes(1))
+    // Optimistic removal: the row leaves the list before the reindex.
+    await waitFor(() => expect(view.queryByRole('button', { name: 'Edit: buy milk' })).toBeNull())
+    expect(view.queryByText('dismiss-drawer')).toBeNull()
+    await view.unmount()
+  })
+
+  it('opens the source note from its swipe action', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const view = await renderScreen()
+
+    await revealSwipeActions(view, 'buy milk')
+    await view.getByRole('button', { name: 'Open note: buy milk' }).click()
+
+    await waitFor(() =>
+      expect(view.getByTestId('route').element().textContent).toContain('notes/n.md'),
+    )
+    expect(view.queryByText('dismiss-drawer')).toBeNull()
+    await view.unmount()
+  })
+
+  it('closes a revealed row on tap instead of opening the sheet', async () => {
+    getOpenTasks.mockResolvedValue([task({ text: 'buy milk' })])
+    const view = await renderScreen()
+
+    await revealSwipeActions(view, 'buy milk')
+    await view.getByRole('button', { name: 'Edit: buy milk' }).click()
+
+    await waitFor(() => expect(view.queryByRole('button', { name: 'Delete: buy milk' })).toBeNull())
+    expect(view.queryByText('dismiss-drawer')).toBeNull()
+    await view.unmount()
+  })
+
+  it('reveals one row at a time across groups', async () => {
+    getOpenTasks.mockResolvedValue([
+      task({ text: 'buy milk' }),
+      task({ text: 'walk dog', notePath: 'notes/dog.md' }),
+    ])
+    const view = await renderScreen()
+
+    await revealSwipeActions(view, 'buy milk')
+    await revealSwipeActions(view, 'walk dog')
+
+    await expect.element(view.getByRole('button', { name: 'Delete: walk dog' })).toBeInTheDocument()
+    await waitFor(() => expect(view.queryByRole('button', { name: 'Delete: buy milk' })).toBeNull())
     await view.unmount()
   })
 })

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -33,9 +33,11 @@ import { useRouter } from '@/routing/router'
  * touch surface. Task taps, toggles, adds, filters, scheduling, and archival
  * get light haptics; tapping a row opens the quick-edit sheet (edit / schedule /
  * complete / convert / open note) instead of desktop's multi-select; the filter
- * sheet carries desktop's bucket toggles and "Show archived". Completing keeps
- * the row struck (V1's middle state) until Archive hides this session's completed
- * tasks.
+ * sheet carries desktop's bucket toggles and "Show archived". Swiping a row
+ * left reveals the note list's two actions, open the source note and delete the
+ * task; one row's actions show at a time and scrolling closes them. Completing
+ * keeps the row struck (V1's middle state) until Archive hides this session's
+ * completed tasks.
  */
 export function MobileTasks(): ReactElement {
   const { graph } = useGraph()
@@ -45,6 +47,8 @@ export function MobileTasks(): ReactElement {
   const [query, setQuery] = useState('')
   const searchInputRef = useRef<HTMLInputElement>(null)
   const [filtersOpen, setFiltersOpen] = useState(false)
+  // The one row whose swipe actions are showing (its taskKey), across all groups.
+  const [revealedTaskKey, setRevealedTaskKey] = useState<string | null>(null)
   // The sheet's task sticks around after close so the exit animation has
   // content; `sheetOpen` alone drives visibility.
   const [editingTask, setEditingTask] = useState<OpenTask | null>(null)
@@ -191,7 +195,10 @@ export function MobileTasks(): ReactElement {
           ) : null}
         </div>
       ) : (
-        <div className="min-h-0 flex-1 overflow-y-auto pb-24">
+        <div
+          className="min-h-0 flex-1 overflow-y-auto pb-24"
+          onScroll={() => setRevealedTaskKey(null)}
+        >
           {groups.map((group) => (
             <MobileTaskGroup
               key={group.kind === 'note' ? `note:${group.notePath}` : group.kind}
@@ -200,6 +207,9 @@ export function MobileTasks(): ReactElement {
               onAdd={onAdd}
               onEdit={editTask}
               onOpen={(path) => navigate(routeForPath(path))}
+              onDelete={(task) => actions.remove([task])}
+              revealedTaskKey={revealedTaskKey}
+              setRevealedTaskKey={setRevealedTaskKey}
             />
           ))}
         </div>

--- a/apps/desktop/src/mobile/swipe-action-button.tsx
+++ b/apps/desktop/src/mobile/swipe-action-button.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement, ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+/** Width (px) of one action button under a swipeable list row. */
+export const SWIPE_ACTION_WIDTH = 68
+
+interface SwipeActionButtonProps {
+  icon: ReactNode
+  /** The short visible caption under the icon (the full name goes in `ariaLabel`). */
+  label: string
+  ariaLabel: string
+  /** Mirror of the row's revealed state: hidden actions leave the tab order. */
+  revealed: boolean
+  /** The action's background, e.g. `bg-accent` or `bg-destructive`. */
+  className: string
+  onClick: () => void
+}
+
+/** One icon-over-caption action button revealed underneath a swiped list row. */
+export function SwipeActionButton({
+  icon,
+  label,
+  ariaLabel,
+  revealed,
+  className,
+  onClick,
+}: SwipeActionButtonProps): ReactElement {
+  return (
+    <button
+      type="button"
+      tabIndex={revealed ? 0 : -1}
+      className={cn(
+        'flex h-full flex-col items-center justify-center gap-1 text-[10px] font-medium text-text-on-brand active:opacity-70',
+        className,
+      )}
+      style={{ width: SWIPE_ACTION_WIDTH }}
+      aria-label={ariaLabel}
+      onClick={onClick}
+    >
+      {icon}
+      <span aria-hidden>{label}</span>
+    </button>
+  )
+}

--- a/apps/desktop/src/mobile/swipeable-note-row.tsx
+++ b/apps/desktop/src/mobile/swipeable-note-row.tsx
@@ -2,13 +2,12 @@ import type { ReactElement, ReactNode } from 'react'
 import { Pin, PinOff, Trash2 } from 'lucide-react'
 import type { HighlightSegment } from '@reflect/core'
 import { formatRecencyLabel } from '@/lib/dates'
+import { SWIPE_ACTION_WIDTH, SwipeActionButton } from '@/mobile/swipe-action-button'
 import { useRowSwipe } from '@/mobile/use-row-swipe'
 import { useSettings } from '@/providers/settings-provider'
 
 /** V1's fixed row height (px) — placeholder resolution never causes jumps. */
 export const NOTE_ROW_HEIGHT = 64
-
-const ACTION_BUTTON_WIDTH = 68
 
 /** One rendered row with query-aware title and snippet segments. */
 export interface NoteRowModel {
@@ -63,7 +62,7 @@ export function SwipeableNoteRow({
   onDelete,
 }: SwipeableNoteRowProps): ReactElement {
   const { settings } = useSettings()
-  const actionWidth = ACTION_BUTTON_WIDTH * (row.canDelete ? 2 : 1)
+  const actionWidth = SWIPE_ACTION_WIDTH * (row.canDelete ? 2 : 1)
   const title = row.titleSegments.map((segment) => segment.text).join('')
   const swipe = useRowSwipe({
     actionWidth,
@@ -84,32 +83,26 @@ export function SwipeableNoteRow({
         aria-hidden={!revealed || undefined}
         inert={!revealed}
       >
-        <button
-          type="button"
-          tabIndex={revealed ? 0 : -1}
-          className="flex h-full flex-col items-center justify-center gap-1 bg-accent text-[10px] font-medium text-text-on-brand active:opacity-70"
-          style={{ width: ACTION_BUTTON_WIDTH }}
-          aria-label={`${row.isPinned ? 'Unpin' : 'Pin'} ${title}`}
+        <SwipeActionButton
+          icon={row.isPinned ? <PinOff className="size-4" /> : <Pin className="size-4" />}
+          label={row.isPinned ? 'Unpin' : 'Pin'}
+          ariaLabel={`${row.isPinned ? 'Unpin' : 'Pin'} ${title}`}
+          revealed={revealed}
+          className="bg-accent"
           onClick={() => {
             onClose()
             onTogglePin()
           }}
-        >
-          {row.isPinned ? <PinOff className="size-4" /> : <Pin className="size-4" />}
-          <span aria-hidden>{row.isPinned ? 'Unpin' : 'Pin'}</span>
-        </button>
+        />
         {row.canDelete ? (
-          <button
-            type="button"
-            tabIndex={revealed ? 0 : -1}
-            className="flex h-full flex-col items-center justify-center gap-1 bg-destructive text-[10px] font-medium text-text-on-brand active:opacity-70"
-            style={{ width: ACTION_BUTTON_WIDTH }}
-            aria-label={`Delete ${title}`}
+          <SwipeActionButton
+            icon={<Trash2 className="size-4" />}
+            label="Delete"
+            ariaLabel={`Delete ${title}`}
+            revealed={revealed}
+            className="bg-destructive"
             onClick={onDelete}
-          >
-            <Trash2 className="size-4" />
-            <span aria-hidden>Delete</span>
-          </button>
+          />
         ) : null}
       </div>
       <button

--- a/apps/desktop/src/mobile/swipeable-note-row.tsx
+++ b/apps/desktop/src/mobile/swipeable-note-row.tsx
@@ -2,7 +2,7 @@ import type { ReactElement, ReactNode } from 'react'
 import { Pin, PinOff, Trash2 } from 'lucide-react'
 import type { HighlightSegment } from '@reflect/core'
 import { formatRecencyLabel } from '@/lib/dates'
-import { useNoteRowSwipe } from '@/mobile/use-note-row-swipe'
+import { useRowSwipe } from '@/mobile/use-row-swipe'
 import { useSettings } from '@/providers/settings-provider'
 
 /** V1's fixed row height (px) — placeholder resolution never causes jumps. */
@@ -49,7 +49,7 @@ function renderHighlightedSegments(segments: HighlightSegment[]): ReactNode {
 
 /**
  * One note row over its iOS-style reveal actions. The gesture physics live in
- * {@link useNoteRowSwipe}; this component owns the note-specific content and
+ * {@link useRowSwipe}; this component owns the note-specific content and
  * accessible action controls.
  */
 export function SwipeableNoteRow({
@@ -65,7 +65,7 @@ export function SwipeableNoteRow({
   const { settings } = useSettings()
   const actionWidth = ACTION_BUTTON_WIDTH * (row.canDelete ? 2 : 1)
   const title = row.titleSegments.map((segment) => segment.text).join('')
-  const swipe = useNoteRowSwipe({
+  const swipe = useRowSwipe({
     actionWidth,
     revealed,
     onReveal,

--- a/apps/desktop/src/mobile/task-group.tsx
+++ b/apps/desktop/src/mobile/task-group.tsx
@@ -1,4 +1,4 @@
-import { Fragment, type ReactElement } from 'react'
+import { Fragment, type Dispatch, type ReactElement, type SetStateAction } from 'react'
 import { Plus } from 'lucide-react'
 import { groupTaskContexts, type OpenTask, type TaskGroup } from '@reflect/core'
 import { TaskBreadcrumbs } from '@/components/tasks/task-breadcrumbs'
@@ -17,8 +17,13 @@ interface MobileTaskGroupProps {
   onAdd: (target: InsertTaskTarget) => void
   /** Open the quick-edit sheet for a tapped row. */
   onEdit: (task: OpenTask) => void
-  /** Open a note group's source note from its header. */
+  /** Open a note group's source note from its header, or a row's from its swipe action. */
   onOpen: (notePath: string) => void
+  /** Delete a task from its swipe action. */
+  onDelete: (task: OpenTask) => void
+  /** The `taskKey` of the one row whose swipe actions are showing, across all groups. */
+  revealedTaskKey: string | null
+  setRevealedTaskKey: Dispatch<SetStateAction<string | null>>
 }
 
 /**
@@ -35,6 +40,9 @@ export function MobileTaskGroup({
   onAdd,
   onEdit,
   onOpen,
+  onDelete,
+  revealedTaskKey,
+  setRevealedTaskKey,
 }: MobileTaskGroupProps): ReactElement {
   const showSource = group.kind !== 'note'
   const { notePath } = group
@@ -82,14 +90,25 @@ export function MobileTaskGroup({
         {contexts.map((context) => (
           <Fragment key={taskKey(context.tasks[0]!)}>
             <TaskBreadcrumbs breadcrumbs={context.visibleBreadcrumbs} className="px-4 pb-1 pt-3" />
-            {context.tasks.map((task) => (
-              <MobileTaskRow
-                key={taskKey(task)}
-                task={task}
-                showSource={showSource}
-                onEdit={onEdit}
-              />
-            ))}
+            {context.tasks.map((task) => {
+              const key = taskKey(task)
+              return (
+                <MobileTaskRow
+                  key={key}
+                  task={task}
+                  showSource={showSource}
+                  onEdit={onEdit}
+                  revealed={revealedTaskKey === key}
+                  onReveal={() => setRevealedTaskKey(key)}
+                  onClose={() => setRevealedTaskKey(null)}
+                  onBeginInteraction={() =>
+                    setRevealedTaskKey((current) => (current === key ? current : null))
+                  }
+                  onOpenNote={() => onOpen(task.notePath)}
+                  onDelete={() => onDelete(task)}
+                />
+              )
+            })}
           </Fragment>
         ))}
       </ul>

--- a/apps/desktop/src/mobile/task-row.tsx
+++ b/apps/desktop/src/mobile/task-row.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import { Circle, CircleCheck } from 'lucide-react'
+import { ArrowRight, Circle, CircleCheck, Trash2 } from 'lucide-react'
 import type { OpenTask } from '@reflect/core'
 import { getIsComposing } from '@meowdown/core'
 import { TaskText } from '@/components/tasks/task-text'
@@ -8,7 +8,12 @@ import { taskKey } from '@/lib/tasks/task-identity'
 import { useTaskCheckboxToggle } from '@/lib/tasks/use-task-checkbox-toggle'
 import { cn } from '@/lib/utils'
 import { hapticImpactLight } from '@/mobile/haptics'
+import { SWIPE_ACTION_WIDTH, SwipeActionButton } from '@/mobile/swipe-action-button'
+import { useRowSwipe } from '@/mobile/use-row-swipe'
 import { useSettings } from '@/providers/settings-provider'
+
+/** Total width of the two actions (open note, delete) under every task row. */
+const ACTION_WIDTH = SWIPE_ACTION_WIDTH * 2
 
 interface MobileTaskRowProps {
   task: OpenTask
@@ -16,6 +21,14 @@ interface MobileTaskRowProps {
   showSource: boolean
   /** Open the quick-edit sheet for this task (V1 mobile: tap edits in place). */
   onEdit: (task: OpenTask) => void
+  revealed: boolean
+  onReveal: () => void
+  onClose: () => void
+  onBeginInteraction: () => void
+  /** Navigate to the task's source note (the revealed Note action). */
+  onOpenNote: () => void
+  /** Delete the task outright; no confirmation, matching the sheet's Delete. */
+  onDelete: () => void
 }
 
 /**
@@ -25,72 +38,139 @@ interface MobileTaskRowProps {
  * rendered as markdown. A completed (struck) row stays visible until archived.
  * Tapping the row body gives the same light confirmation and opens the
  * quick-edit sheet instead of desktop's multi-select; there is no inline editor
- * on touch.
+ * on touch. Swiping the row left reveals the note list's gesture on tasks: an
+ * open-note action and a delete action ({@link useRowSwipe} owns the physics).
  */
-export function MobileTaskRow({ task, showSource, onEdit }: MobileTaskRowProps): ReactElement {
+export function MobileTaskRow({
+  task,
+  showSource,
+  onEdit,
+  revealed,
+  onReveal,
+  onClose,
+  onBeginInteraction,
+  onOpenNote,
+  onDelete,
+}: MobileTaskRowProps): ReactElement {
   const { settings } = useSettings()
   const { toggle, isPending } = useTaskCheckboxToggle(task)
   const label = task.text || 'Empty task'
   const edit = (): void => onEdit(task)
+  const swipe = useRowSwipe({
+    actionWidth: ACTION_WIDTH,
+    revealed,
+    onReveal,
+    onClose,
+    onBeginInteraction,
+  })
 
   return (
-    <li
-      data-task-key={taskKey(task)}
-      className="flex min-h-12 items-start border-b border-border bg-surface"
-    >
-      <button
-        type="button"
-        aria-label={task.checked ? `Reopen: ${label}` : `Complete: ${label}`}
-        disabled={isPending}
-        onClick={() => {
-          hapticImpactLight()
-          toggle()
-        }}
-        // A generous touch target around the small glyph; self-stretch keeps
-        // the circle vertically centered in the row as task text wraps.
-        className="flex shrink-0 self-stretch items-center pl-4 pr-3 text-text-muted disabled:opacity-50"
-      >
-        {task.checked ? (
-          <CircleCheck aria-hidden className="size-5 text-accent" strokeWidth={2} />
-        ) : (
-          <Circle aria-hidden className="size-5" strokeWidth={2} />
-        )}
-      </button>
-      {/* A div with the button role, not a real <button>: the markdown inside
-          can contain links, and interactive content can't nest in a button
-          (desktop's row body makes the same trade). TaskText itself is
-          pointer-events-none, so taps land here. */}
+    <li data-task-key={taskKey(task)} className="relative overflow-hidden border-b border-border">
       <div
-        role="button"
-        tabIndex={0}
-        aria-label={`Edit: ${label}`}
-        onClick={edit}
-        onKeyDown={(event) => {
-          if (getIsComposing()) {
+        className="absolute inset-y-0 right-0 flex"
+        style={{ width: ACTION_WIDTH }}
+        aria-hidden={!revealed || undefined}
+        inert={!revealed}
+      >
+        <SwipeActionButton
+          icon={<ArrowRight className="size-4" />}
+          label="Note"
+          ariaLabel={`Open note: ${label}`}
+          revealed={revealed}
+          className="bg-accent"
+          onClick={() => {
+            hapticImpactLight()
+            onClose()
+            onOpenNote()
+          }}
+        />
+        <SwipeActionButton
+          icon={<Trash2 className="size-4" />}
+          label="Delete"
+          ariaLabel={`Delete: ${label}`}
+          revealed={revealed}
+          className="bg-destructive"
+          onClick={() => {
+            hapticImpactLight()
+            onClose()
+            onDelete()
+          }}
+        />
+      </div>
+      <div
+        ref={swipe.ref}
+        {...swipe.handlers}
+        // One capture handler covers both interactive children: swallow the
+        // synthetic click a completed drag leaves behind, and turn a tap on a
+        // revealed row into a plain close (iOS list behavior).
+        onClickCapture={(event) => {
+          if (swipe.consumeDragClick()) {
+            event.preventDefault()
+            event.stopPropagation()
             return
           }
-          if (event.key === 'Enter' || event.key === ' ') {
+          if (revealed) {
             event.preventDefault()
-            edit()
+            event.stopPropagation()
+            onClose()
           }
         }}
-        className="flex min-w-0 flex-1 cursor-pointer items-start gap-3 py-3 pr-4 text-left focus-visible:outline-none"
+        className="relative flex min-h-12 items-start bg-surface"
       >
-        <span
-          className={cn(
-            'min-w-0 flex-1 break-words text-sm leading-6 text-text',
-            task.checked && 'text-text-muted line-through',
-          )}
+        <button
+          type="button"
+          aria-label={task.checked ? `Reopen: ${label}` : `Complete: ${label}`}
+          disabled={isPending}
+          onClick={() => {
+            hapticImpactLight()
+            toggle()
+          }}
+          // A generous touch target around the small glyph; self-stretch keeps
+          // the circle vertically centered in the row as task text wraps.
+          className="flex shrink-0 self-stretch items-center pl-4 pr-3 text-text-muted disabled:opacity-50"
         >
-          <TaskText task={task} />
-        </span>
-        {showSource && task.dailyDate !== null ? (
-          // The compact date, not desktop's long day label — a phone row can't
-          // spare "Mon, June 1st, 2026" (V1 mobile's small gray source label).
-          <span className="mt-0.5 shrink-0 whitespace-nowrap text-xs text-text-muted">
-            {formatShortDate(task.dailyDate, settings.dateFormat)}
+          {task.checked ? (
+            <CircleCheck aria-hidden className="size-5 text-accent" strokeWidth={2} />
+          ) : (
+            <Circle aria-hidden className="size-5" strokeWidth={2} />
+          )}
+        </button>
+        {/* A div with the button role, not a real <button>: the markdown inside
+            can contain links, and interactive content can't nest in a button
+            (desktop's row body makes the same trade). TaskText itself is
+            pointer-events-none, so taps land here. */}
+        <div
+          role="button"
+          tabIndex={0}
+          aria-label={`Edit: ${label}`}
+          onClick={edit}
+          onKeyDown={(event) => {
+            if (getIsComposing()) {
+              return
+            }
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault()
+              edit()
+            }
+          }}
+          className="flex min-w-0 flex-1 cursor-pointer items-start gap-3 py-3 pr-4 text-left focus-visible:outline-none"
+        >
+          <span
+            className={cn(
+              'min-w-0 flex-1 break-words text-sm leading-6 text-text',
+              task.checked && 'text-text-muted line-through',
+            )}
+          >
+            <TaskText task={task} />
           </span>
-        ) : null}
+          {showSource && task.dailyDate !== null ? (
+            // The compact date, not desktop's long day label — a phone row can't
+            // spare "Mon, June 1st, 2026" (V1 mobile's small gray source label).
+            <span className="mt-0.5 shrink-0 whitespace-nowrap text-xs text-text-muted">
+              {formatShortDate(task.dailyDate, settings.dateFormat)}
+            </span>
+          ) : null}
+        </div>
       </div>
     </li>
   )

--- a/apps/desktop/src/mobile/use-row-swipe.ts
+++ b/apps/desktop/src/mobile/use-row-swipe.ts
@@ -46,7 +46,7 @@ interface DraggingGesture extends GestureBase {
 
 type RowGesture = ArmedGesture | DraggingGesture
 
-interface NoteRowSwipeOptions {
+interface RowSwipeOptions {
   /** Total width of the actions underneath the row. */
   actionWidth: number
   revealed: boolean
@@ -62,21 +62,21 @@ interface NoteRowSwipeOptions {
   onBeginInteraction: () => void
 }
 
-interface NoteRowSwipeHandlers {
-  onPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void
-  onPointerMove: (event: ReactPointerEvent<HTMLButtonElement>) => void
-  onPointerUp: (event: ReactPointerEvent<HTMLButtonElement>) => void
-  onPointerCancel: (event: ReactPointerEvent<HTMLButtonElement>) => void
+interface RowSwipeHandlers {
+  onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void
+  onPointerMove: (event: ReactPointerEvent<HTMLElement>) => void
+  onPointerUp: (event: ReactPointerEvent<HTMLElement>) => void
+  onPointerCancel: (event: ReactPointerEvent<HTMLElement>) => void
 }
 
-export interface NoteRowSwipe {
-  handlers: NoteRowSwipeHandlers
+export interface RowSwipe {
+  handlers: RowSwipeHandlers
   /**
-   * Attach to the moving note surface. The hook writes its presentation
+   * Attach to the moving row surface. The hook writes its presentation
    * (`touch-action`, `transform`, `transition`, `will-change`) imperatively,
    * so pointer moves never re-render React.
    */
-  ref: (element: HTMLButtonElement | null) => void
+  ref: (element: HTMLElement | null) => void
   /**
    * Consume the synthetic click that WebKit emits after a completed drag.
    * Call it first inside the row's click handler: it returns true exactly once
@@ -87,19 +87,19 @@ export interface NoteRowSwipe {
 }
 
 /**
- * The iOS-style swipe-action gesture for a note row. Touch follows the finger
+ * The iOS-style swipe-action gesture for a list row. Touch follows the finger
  * 1:1 after a small direction threshold, hands recent velocity into the
  * open/closed decision, and stays interruptible while settling.
  * `touch-action: pan-y` leaves list scrolling native until horizontal intent
- * wins; the hook applies that property through {@link NoteRowSwipe.ref}.
+ * wins; the hook applies that property through {@link RowSwipe.ref}.
  */
-export function useNoteRowSwipe({
+export function useRowSwipe({
   actionWidth,
   revealed,
   onReveal,
   onClose,
   onBeginInteraction,
-}: NoteRowSwipeOptions): NoteRowSwipe {
+}: RowSwipeOptions): RowSwipe {
   const reducedMotion = usePrefersReducedMotion()
   const gestureRef = useRef<RowGesture | null>(null)
   const suppressClickRef = useRef(false)
@@ -108,7 +108,7 @@ export function useNoteRowSwipe({
 
   // A fresh callback every render, so React re-runs it each commit and the
   // resting presentation follows `revealed` without any hook state.
-  const ref = (element: HTMLButtonElement | null): void => {
+  const ref = (element: HTMLElement | null): void => {
     if (element === null || gestureRef.current !== null) {
       return
     }
@@ -116,7 +116,7 @@ export function useNoteRowSwipe({
     presentSettled(element, restingOffset, reducedMotion)
   }
 
-  const onPointerDown = (event: ReactPointerEvent<HTMLButtonElement>): void => {
+  const onPointerDown = (event: ReactPointerEvent<HTMLElement>): void => {
     if (event.pointerType !== 'touch' || !event.isPrimary) {
       return
     }
@@ -146,7 +146,7 @@ export function useNoteRowSwipe({
     presentDragging(surface, startOffset)
   }
 
-  const onPointerMove = (event: ReactPointerEvent<HTMLButtonElement>): void => {
+  const onPointerMove = (event: ReactPointerEvent<HTMLElement>): void => {
     const gesture = gestureRef.current
     if (gesture === null || gesture.pointerId !== event.pointerId) {
       return
@@ -208,7 +208,7 @@ export function useNoteRowSwipe({
     event.currentTarget.style.transform = `translate3d(${nextOffset}px, 0, 0)`
   }
 
-  const release = (event: ReactPointerEvent<HTMLButtonElement>, interrupted: boolean): void => {
+  const release = (event: ReactPointerEvent<HTMLElement>, interrupted: boolean): void => {
     const gesture = gestureRef.current
     if (gesture === null || gesture.pointerId !== event.pointerId) {
       return

--- a/apps/desktop/src/test-utils/swipe.ts
+++ b/apps/desktop/src/test-utils/swipe.ts
@@ -1,0 +1,43 @@
+import { act } from 'react'
+
+/** Dispatch one primary-touch pointer event on `node`. */
+export function pointer(
+  node: Element,
+  type: 'pointerdown' | 'pointermove' | 'pointerup',
+  clientX: number,
+  clientY: number,
+): void {
+  act(() => {
+    node.dispatchEvent(
+      new PointerEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        pointerType: 'touch',
+        isPrimary: true,
+        pointerId: 1,
+        clientX,
+        clientY,
+      }),
+    )
+  })
+}
+
+/** One touch swipe: down, move, up, then the click a real touch adds. */
+export function swipe(
+  surface: Element,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+): void {
+  pointer(surface, 'pointerdown', from.x, from.y)
+  pointer(surface, 'pointermove', to.x, to.y)
+  pointer(surface, 'pointerup', to.x, to.y)
+  // A real touch sequence synthesizes a click after pointerup; dispatchEvent
+  // does not, so mirror it to exercise the row's drag-click suppression.
+  const touchSurface = surface as HTMLElement
+  touchSurface.click()
+}
+
+/** The element's live compositor X translation. */
+export function translateX(element: Element): number {
+  return new DOMMatrixReadOnly(getComputedStyle(element).transform).m41
+}


### PR DESCRIPTION
Swiping a task row left on iOS reveals open-note and delete actions, matching the note list's swipe gesture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mobile task rows now support swipe gestures to reveal actions for opening the source note and deleting tasks.
  - Only one task row can have actions revealed at a time.
  - Revealed actions close when scrolling or tapping elsewhere.
  - Added haptic feedback and improved accessibility for swipe actions.

- **Bug Fixes**
  - Prevented unintended task activation after dragging.

- **Tests**
  - Added coverage for swipe actions, deletion, note opening, row closing, and action positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->