### PR TITLE
ci: add experimental Windows x64 build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,81 @@
+name: Windows
+
+# Experimental: builds an unsigned Windows x64 NSIS installer. The installer
+# is kept as a workflow artifact only — it is never uploaded to a GitHub
+# release. See docs/windows-builds.md.
+
+on:
+  workflow_dispatch:
+  # Validate changes to the Windows build itself before merging; regular PRs
+  # never trigger this.
+  pull_request:
+    paths:
+      - .github/workflows/windows.yml
+      - apps/desktop/scripts/release-windows.mjs
+  # Called by release-please.yml so every release also produces a Windows
+  # build for testing.
+  workflow_call:
+    inputs:
+      commit:
+        description: Immutable commit targeted by the release tag.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  windows:
+    name: Build Windows x64 (unsigned)
+    runs-on: windows-latest
+    timeout-minutes: 120
+    steps:
+      # The runner image enables OS-level long paths but not git's own
+      # support; deep pnpm paths can fail checkout without it.
+      - name: Enable git long paths
+        run: git config --system core.longpaths true
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.commit || github.sha }}
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Install Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      # The default toolchain's host triple is x86_64-pc-windows-msvc, which
+      # is exactly the build target — no extra rustup target needed.
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          cache-on-failure: true
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # No secrets on purpose: without SENTRY_AUTH_TOKEN the Sentry vite
+      # plugin skips source-map upload, and without VITE_SENTRY_DSN the
+      # experimental build carries no telemetry.
+      - name: Build Windows installer
+        shell: bash
+        run: pnpm release:windows build --artifact-dir="$RUNNER_TEMP/windows-artifacts"
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: reflect-windows-x64
+          path: ${{ runner.temp }}/windows-artifacts/*
+          if-no-files-found: error
+          # The NSIS installer is already lzma-compressed; zipping it again
+          # wastes minutes for nothing.
+          compression-level: 0
+          retention-days: 90

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,6 +11,7 @@
     "postinstall": "node src-tauri/xcode-scripts/generate-xcode-env.mjs",
     "release:ios": "node scripts/release-ios.mjs",
     "release:macos": "node scripts/release-macos.mjs",
+    "release:windows": "node scripts/release-windows.mjs",
     "test": "vitest run --config ../../vitest.config.ts --project browser --project node",
     "test:install": "playwright install chromium webkit",
     "tauri": "tauri",

--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -41,7 +41,7 @@ const KEYCHAIN_SERVICE = 'reflect-notary'
 const UPDATER_KEYCHAIN_SERVICE = 'reflect-updater'
 const APP_SPECIFIC_PASSWORD_URL = 'https://account.apple.com'
 const BETA_UPDATER_FEED_TAG = 'updater-beta'
-const STABLE_UPDATER_ENDPOINT =
+export const STABLE_UPDATER_ENDPOINT =
   'https://github.com/team-reflect/reflect-open/releases/latest/download/latest.json'
 const APPLE_SILICON_MAC_TARGET = 'aarch64-apple-darwin'
 const INTEL_MAC_TARGET = 'x86_64-apple-darwin'
@@ -385,7 +385,7 @@ function readPlatformConf(platform) {
 }
 
 /** Apply an RFC 7396 JSON Merge Patch — the same algorithm Tauri uses for `--config`. */
-function mergePatch(target, patch) {
+export function mergePatch(target, patch) {
   if (patch === null || typeof patch !== 'object' || Array.isArray(patch)) return patch
   const out = target && typeof target === 'object' && !Array.isArray(target) ? { ...target } : {}
   for (const [key, value] of Object.entries(patch)) {

--- a/apps/desktop/scripts/release-windows.mjs
+++ b/apps/desktop/scripts/release-windows.mjs
@@ -1,0 +1,185 @@
+// Build the Windows NSIS installer (experimental: unsigned, x64 only).
+//
+// Usage:
+//   pnpm release:windows build [--artifact-dir=<path>]
+//
+// The installer is not signed and is never uploaded to a GitHub release; CI
+// keeps it as a workflow artifact only. See docs/windows-builds.md.
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { mergePatch, STABLE_UPDATER_ENDPOINT } from './release-macos.mjs'
+
+const WINDOWS_TARGET = 'x86_64-pc-windows-msvc'
+const BETA_OVERLAY = 'src-tauri/tauri.beta.conf.json'
+
+const here = import.meta.dirname
+const appDir = join(here, '..')
+const repoRoot = join(here, '..', '..', '..')
+
+function log(message) {
+  console.log(`release-windows: ${message}`)
+}
+
+function fail(message) {
+  console.error(`release-windows: error: ${message}`)
+  process.exit(1)
+}
+
+/** The app version, from apps/desktop/package.json — the single version source. */
+function readAppVersion() {
+  const pkg = JSON.parse(readFileSync(join(appDir, 'package.json'), 'utf8'))
+  if (typeof pkg.version !== 'string' || pkg.version === '') {
+    fail('apps/desktop/package.json has no "version"')
+  }
+  return pkg.version
+}
+
+/** Prerelease versions build the beta flavor, mirroring release-macos.mjs. */
+export function resolveWindowsFlavor(version) {
+  return version.includes('-') ? 'beta' : 'stable'
+}
+
+/**
+ * Tauri CLI args for the Windows build. NSIS only: WiX rejects prerelease
+ * versions like 0.11.0-beta, and the MSI template is per-machine anyway.
+ */
+export function createWindowsBuildArgs({ flavor }) {
+  const args = ['build', '--target', WINDOWS_TARGET, '--bundles', 'nsis']
+  if (flavor === 'beta') args.push('--config', BETA_OVERLAY)
+  // Same reasoning as release-macos.mjs: the base config commits the beta
+  // updater endpoint, so stable builds pin the stable feed at build time.
+  if (flavor === 'stable') {
+    args.push(
+      '--config',
+      JSON.stringify({ plugins: { updater: { endpoints: [STABLE_UPDATER_ENDPOINT] } } }),
+    )
+  }
+  return args
+}
+
+/**
+ * The resolved config for a flavor on Windows: base + tauri.windows.conf.json
+ * + flavor overlay, merged like `tauri build --config` does. Only used for
+ * the productName in logs and artifact metadata.
+ */
+function readWindowsFlavorConf(flavor) {
+  const read = (name) => {
+    const path = join(appDir, 'src-tauri', name)
+    return existsSync(path) ? JSON.parse(readFileSync(path, 'utf8')) : {}
+  }
+  let conf = mergePatch(read('tauri.conf.json'), read('tauri.windows.conf.json'))
+  if (flavor === 'beta') conf = mergePatch(conf, read('tauri.beta.conf.json'))
+  conf.version = readAppVersion()
+  return conf
+}
+
+/** Find the single NSIS installer in a bundle directory listing. */
+export function findSetupExe(fileNames) {
+  const installers = fileNames.filter((name) => name.endsWith('-setup.exe'))
+  if (installers.length !== 1) {
+    throw new Error(
+      `expected exactly one *-setup.exe in the NSIS bundle dir, found ${installers.length}`,
+    )
+  }
+  return installers[0]
+}
+
+function nsisBundleDir() {
+  const metadata = JSON.parse(
+    execFileSync('cargo', ['metadata', '--format-version', '1', '--no-deps'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    }),
+  )
+  return join(metadata.target_directory, WINDOWS_TARGET, 'release', 'bundle', 'nsis')
+}
+
+function build({ artifactDir }) {
+  if (process.platform !== 'win32') fail('this command only runs on Windows')
+  const version = readAppVersion()
+  const flavor = resolveWindowsFlavor(version)
+  const conf = readWindowsFlavorConf(flavor)
+  log(`building ${conf.productName} ${version} (${flavor}, ${WINDOWS_TARGET}, NSIS, unsigned)`)
+
+  // node_modules/.bin shims are .cmd files on Windows; Node refuses to spawn
+  // them without a shell (CVE-2024-27980), and a shell would mangle the JSON
+  // --config argument. Invoke the Tauri CLI's JS entry point directly.
+  const tauriCli = join(appDir, 'node_modules', '@tauri-apps', 'cli', 'tauri.js')
+  const result = spawnSync(process.execPath, [tauriCli, ...createWindowsBuildArgs({ flavor })], {
+    cwd: appDir,
+    stdio: 'inherit',
+  })
+  if (result.status !== 0) fail('tauri build failed')
+
+  const bundleDir = nsisBundleDir()
+  let installer
+  try {
+    installer = findSetupExe(readdirSync(bundleDir))
+  } catch (error) {
+    fail(`${error instanceof Error ? error.message : error} (${bundleDir})`)
+  }
+  log(`installer: ${join(bundleDir, installer)}`)
+
+  if (artifactDir) {
+    mkdirSync(artifactDir, { recursive: true })
+    copyFileSync(join(bundleDir, installer), join(artifactDir, installer))
+    writeFileSync(
+      join(artifactDir, 'windows-x64.json'),
+      `${JSON.stringify(
+        {
+          version,
+          productName: conf.productName,
+          flavor,
+          target: WINDOWS_TARGET,
+          installer,
+          signed: false,
+        },
+        null,
+        2,
+      )}\n`,
+    )
+    log(`exported release artifacts to ${artifactDir}`)
+  }
+}
+
+const USAGE = `Usage: pnpm release:windows [command] [flags]
+
+Commands:
+  build       Build the unsigned Windows x64 NSIS installer (default)
+
+Flags:
+  --artifact-dir=<path>  Export the installer and metadata after build
+  --help                 Show this help
+
+Docs: docs/windows-builds.md`
+
+async function main() {
+  const argv = process.argv.slice(2)
+  const flags = argv.filter((arg) => arg.startsWith('--'))
+  const command = argv.find((arg) => !arg.startsWith('--')) ?? 'build'
+  const artifactDir = flags
+    .find((flag) => flag.startsWith('--artifact-dir='))
+    ?.slice('--artifact-dir='.length)
+  const unknownFlag = flags.find((flag) => flag !== '--help' && !flag.startsWith('--artifact-dir='))
+  if (unknownFlag) fail(`unknown flag "${unknownFlag}"\n\n${USAGE}`)
+  if (flags.includes('--help')) {
+    console.log(USAGE)
+    return
+  }
+  if (command !== 'build') fail(`unknown command "${command}"\n\n${USAGE}`)
+  build({ artifactDir })
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main()
+}

--- a/apps/desktop/scripts/release-windows.test.mjs
+++ b/apps/desktop/scripts/release-windows.test.mjs
@@ -1,0 +1,38 @@
+import { expect, test } from 'vitest'
+import { STABLE_UPDATER_ENDPOINT } from './release-macos.mjs'
+import { createWindowsBuildArgs, findSetupExe, resolveWindowsFlavor } from './release-windows.mjs'
+
+test('prerelease versions build the beta flavor', () => {
+  expect(resolveWindowsFlavor('0.11.0-beta')).toBe('beta')
+  expect(resolveWindowsFlavor('0.11.0-beta.2')).toBe('beta')
+  expect(resolveWindowsFlavor('0.11.0')).toBe('stable')
+})
+
+test('the build produces only the x64 NSIS bundle', () => {
+  for (const flavor of ['stable', 'beta']) {
+    const args = createWindowsBuildArgs({ flavor })
+    expect(args).toContain('x86_64-pc-windows-msvc')
+    expect(args).toContain('nsis')
+    expect(args).not.toContain('msi')
+  }
+})
+
+test('the beta flavor builds with the beta overlay', () => {
+  expect(createWindowsBuildArgs({ flavor: 'beta' })).toContain('src-tauri/tauri.beta.conf.json')
+})
+
+test('stable builds pin the stable updater endpoint', () => {
+  const inline = createWindowsBuildArgs({ flavor: 'stable' }).filter((arg) => arg.startsWith('{'))
+  expect(inline).toHaveLength(1)
+  expect(JSON.parse(inline[0])).toEqual({
+    plugins: { updater: { endpoints: [STABLE_UPDATER_ENDPOINT] } },
+  })
+})
+
+test('findSetupExe requires exactly one installer', () => {
+  expect(findSetupExe(['Reflect Beta_0.11.0-beta_x64-setup.exe', 'other.txt'])).toBe(
+    'Reflect Beta_0.11.0-beta_x64-setup.exe',
+  )
+  expect(() => findSetupExe([])).toThrow('found 0')
+  expect(() => findSetupExe(['a-setup.exe', 'b-setup.exe'])).toThrow('found 2')
+})

--- a/docs/windows-builds.md
+++ b/docs/windows-builds.md
@@ -1,0 +1,39 @@
+# Windows Builds (Experimental)
+
+Reflect ships an experimental, **unsigned** Windows x64 build. It is not
+listed on any GitHub release: the only way to get it is from GitHub Actions.
+
+## Getting the installer
+
+1. Open the repo's **Actions** tab and select the **Windows** workflow.
+2. Open the newest successful run (releases trigger one automatically; anyone
+   with write access can also start one with **Run workflow**).
+3. Download the `reflect-windows-x64` artifact and unzip it. It contains the
+   NSIS installer (`*-setup.exe`) plus a `windows-x64.json` metadata file.
+
+Artifacts expire after 90 days.
+
+## What to expect
+
+- **Supported OS:** Windows 10 22H2 or Windows 11, x64. The app is a Tauri 2
+  shell over WebView2; Windows 11 ships the runtime, and the installer
+  downloads it on the few Windows 10 machines that lack it.
+- **SmartScreen will warn.** The build is not code-signed yet, so the first
+  launch shows "Windows protected your PC" — click **More info → Run
+  anyway**. Microsoft Defender may also flag unsigned Rust binaries
+  (a known false-positive pattern); machines with Smart App Control enabled
+  cannot run unsigned apps at all.
+- **Per-user install, no admin prompt.** The installer uses NSIS in
+  `currentUser` mode and installs under `%LOCALAPPDATA%`.
+- **No auto-update.** The updater feed carries no Windows entries yet, so the
+  built-in updater finds nothing; install newer builds manually.
+- **No MSI.** Reflect's beta versions carry a prerelease suffix, which the
+  MSI toolchain rejects; only the NSIS installer is produced.
+
+## Roadmap
+
+1. Unsigned CI builds (this document).
+2. Free code signing (e.g. SignPath Foundation for open source), which
+   removes the SmartScreen friction. Applying requires existing CI-built
+   artifacts, which is why signing lands second.
+3. Only after real testing: updater support and listing on GitHub releases.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "release:ios": "pnpm --filter @reflect/desktop release:ios",
     "release:macos": "pnpm --filter @reflect/desktop release:macos",
     "release:testflight": "pnpm --filter @reflect/desktop release:ios testflight",
+    "release:windows": "pnpm --filter @reflect/desktop release:windows",
     "tauri:dev": "pnpm --filter @reflect/desktop tauri:dev",
     "tauri:ios:dev": "pnpm --filter @reflect/desktop tauri:ios:dev",
     "tauri:ios:dev:sim": "pnpm --filter @reflect/desktop tauri:ios:dev:sim",


### PR DESCRIPTION
Adds an experimental unsigned Windows x64 NSIS build, kept as a workflow artifact only.