### PR TITLE
ci: build the Windows installer on every release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -105,3 +105,23 @@ jobs:
     with:
       commit: ${{ needs.release-please.outputs.beta_commit }}
     secrets: inherit
+
+  # The experimental Windows build rides every release too, but stays off the
+  # GitHub release: windows.yml only uploads a workflow artifact. An
+  # independent job — a Windows failure never blocks the macOS release or
+  # the TestFlight upload. No secrets: the build is unsigned by design.
+  build-windows-stable:
+    name: Build the Windows installer (stable)
+    needs: release-please
+    if: needs.release-please.outputs.stable_created == 'true'
+    uses: ./.github/workflows/windows.yml
+    with:
+      commit: ${{ needs.release-please.outputs.stable_commit }}
+
+  build-windows-beta:
+    name: Build the Windows installer (beta)
+    needs: release-please
+    if: needs.release-please.outputs.beta_created == 'true'
+    uses: ./.github/workflows/windows.yml
+    with:
+      commit: ${{ needs.release-please.outputs.beta_commit }}

--- a/apps/desktop/scripts/release-please-workflow.test.mjs
+++ b/apps/desktop/scripts/release-please-workflow.test.mjs
@@ -62,6 +62,7 @@ test('each channel chains its release into delivery', () => {
   }
   expect(workflow).toContain('uses: ./.github/workflows/release.yml')
   expect(workflow).toContain('uses: ./.github/workflows/testflight.yml')
+  expect(workflow).toContain('uses: ./.github/workflows/windows.yml')
 })
 
 test('release runs queue instead of cancelling', () => {


### PR DESCRIPTION
Chains the experimental Windows build into release-please so each release also produces a workflow-artifact-only Windows installer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Windows installer builds for stable releases.
  * Added automated Windows installer builds for beta releases.
  * Windows builds now receive the matching release version and commit.

* **Tests**
  * Added coverage to verify Windows packaging is included in the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->