### PR TITLE
fix: reload open note sessions after each index reconcile

### DIFF
--- a/apps/desktop/src/editor/open-documents.test.ts
+++ b/apps/desktop/src/editor/open-documents.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest'
-import type { NoteSession } from './note-session'
-import { flushOpenDocuments, openSession, registerOpenDocument } from './open-documents'
+import { describe, expect, it, vi } from 'vitest'
+import { createNoteSession, type NoteSession, type NoteSessionSnapshot } from './note-session'
+import {
+  flushOpenDocuments,
+  openSession,
+  registerOpenDocument,
+  reloadOpenDocuments,
+} from './open-documents'
 
 function fakeSession(path: string, log: string[]): NoteSession {
   return {
@@ -8,7 +13,9 @@ function fakeSession(path: string, log: string[]): NoteSession {
     retarget: () => {},
     load: () => {},
     editorChanged: () => {},
-    externalChanged: () => {},
+    externalChanged: () => {
+      log.push(`externalChanged:${path}`)
+    },
     flush: async () => {
       log.push(`flush:${path}`)
     },
@@ -68,6 +75,19 @@ describe('open documents', () => {
     }
   })
 
+  it('reloadOpenDocuments asks every open session to reconcile against disk', () => {
+    const log: string[] = []
+    const unregisterA = registerOpenDocument({ session: fakeSession('notes/a.md', log) })
+    const unregisterB = registerOpenDocument({ session: fakeSession('notes/b.md', log) })
+    try {
+      reloadOpenDocuments()
+      expect(log).toEqual(['externalChanged:notes/a.md', 'externalChanged:notes/b.md'])
+    } finally {
+      unregisterA()
+      unregisterB()
+    }
+  })
+
   it('one failing document does not block the others, and nothing rejects', async () => {
     const log: string[] = []
     const failing = fakeSession('notes/bad.md', log)
@@ -118,6 +138,97 @@ describe('retargetOpenDocument (Plan 17)', () => {
       expect(openSession('notes/old.md')).toBeNull()
     } finally {
       unregister()
+    }
+  })
+})
+
+describe('reloadOpenDocuments with live sessions', () => {
+  // The iOS resume bug: the index reconcile re-reads a remotely edited note
+  // into the index but emits no `index:changed`, so nothing ever told the open
+  // session and it kept showing stale content until the app was relaunched.
+  // These pin the whole path with real sessions: content changes on disk, no
+  // file event fires, the reload converges the editor.
+
+  function liveSession(
+    read: () => string,
+    applied: string[],
+    snapshots: NoteSessionSnapshot[],
+  ): NoteSession {
+    return createNoteSession({
+      path: 'notes/stale.md',
+      // No writer: the session tracks dirtiness but never writes, so a dirty
+      // buffer can't race a debounced save into the assertions.
+      io: { read: async () => read(), write: null },
+      classify: () => 'exact',
+      onSnapshot: (snapshot) => {
+        snapshots.push(snapshot)
+      },
+      applyContent: (markdown) => {
+        applied.push(markdown)
+      },
+    })
+  }
+
+  it('a clean open note adopts the new disk content silently', async () => {
+    let disk = '# Old\n'
+    const applied: string[] = []
+    const snapshots: NoteSessionSnapshot[] = []
+    const session = liveSession(() => disk, applied, snapshots)
+    const unregister = registerOpenDocument({ session })
+    try {
+      session.load()
+      await vi.waitFor(() => expect(snapshots.at(-1)?.status).toBe('ready'))
+
+      disk = '# New from the Mac\n' // the reconcile saw this; no index:changed fired
+      reloadOpenDocuments()
+
+      await vi.waitFor(() => expect(applied).toContain('# New from the Mac\n'))
+      expect(snapshots.at(-1)?.conflict).toBeNull()
+    } finally {
+      unregister()
+      session.dispose()
+    }
+  })
+
+  it('a dirty open note parks the conflict banner instead of losing edits', async () => {
+    let disk = '# Old\n'
+    const snapshots: NoteSessionSnapshot[] = []
+    const session = liveSession(() => disk, [], snapshots)
+    const unregister = registerOpenDocument({ session })
+    try {
+      session.load()
+      await vi.waitFor(() => expect(snapshots.at(-1)?.status).toBe('ready'))
+      session.editorChanged('# Old\nmy unsaved line\n')
+
+      disk = '# New from the Mac\n'
+      reloadOpenDocuments()
+
+      await vi.waitFor(() => expect(snapshots.at(-1)?.conflict).toBe('# New from the Mac\n'))
+      expect(snapshots.at(-1)?.dirty).toBe(true)
+    } finally {
+      unregister()
+      session.discard() // never flush the deliberately-dirty buffer
+    }
+  })
+
+  it('an unchanged file is a no-op read: no editor push, no conflict', async () => {
+    const applied: string[] = []
+    const snapshots: NoteSessionSnapshot[] = []
+    const session = liveSession(() => '# Old\n', applied, snapshots)
+    const unregister = registerOpenDocument({ session })
+    try {
+      session.load()
+      await vi.waitFor(() => expect(snapshots.at(-1)?.status).toBe('ready'))
+      const settled = snapshots.length
+
+      reloadOpenDocuments()
+      await new Promise((resolve) => setTimeout(resolve, 0)) // drain the reconcile read
+
+      expect(applied).toEqual([])
+      expect(snapshots).toHaveLength(settled) // the echo guard emitted nothing
+    } finally {
+      unregister()
+      session.dispose()
     }
   })
 })

--- a/apps/desktop/src/editor/open-documents.ts
+++ b/apps/desktop/src/editor/open-documents.ts
@@ -63,6 +63,21 @@ export function dirtyOpenPaths(): string[] {
 }
 
 /**
+ * Ask every open document to reconcile against disk, exactly as if a watcher
+ * upsert had arrived for its path: an unchanged file is a no-op, a clean
+ * buffer adopts silently, a dirty buffer parks the conflict banner. The index
+ * lifecycle calls this after each completed reconcile pass, because the pass
+ * reads changed files into the index without emitting per-file events. On iOS
+ * there is no file watcher, so a resume reconcile is the only signal a remote
+ * edit produces: without this, an open note keeps stale content until relaunch.
+ */
+export function reloadOpenDocuments(): void {
+  for (const document of documents.values()) {
+    document.session.externalChanged()
+  }
+}
+
+/**
  * Re-key an open document after its note file moved (Plan 17), so
  * {@link openSession} lookups under the new path find the live session. The
  * entry moves only when it actually holds `session` — a failed move's

--- a/apps/desktop/src/providers/graph-index.test.ts
+++ b/apps/desktop/src/providers/graph-index.test.ts
@@ -80,6 +80,36 @@ describe('createGraphIndex', () => {
     expect(unlisten).not.toHaveBeenCalled() // retained as the active subscription
   })
 
+  it('reports a completed pass via onReconciled, after onApplied', async () => {
+    // The pass reads changed files into the index without emitting per-file
+    // events; open note sessions re-read off this callback.
+    const order: string[] = []
+    const index = createGraphIndex({
+      onApplied: () => {
+        order.push('applied')
+      },
+      onReconciled: () => {
+        order.push('reconciled')
+      },
+    })
+    index.sync(5, () => false)
+    await index.stop()
+    expect(order).toEqual(['applied', 'reconciled'])
+  })
+
+  it('a superseded or failed pass never fires onReconciled', async () => {
+    const onReconciled = vi.fn()
+    const index = createGraphIndex({ onReconciled })
+    index.sync(5, () => true) // stale right after the reconcile
+    await index.stop()
+    expect(onReconciled).not.toHaveBeenCalled()
+
+    mockSync.mockRejectedValue(new Error('boom'))
+    index.sync(5, () => false)
+    await index.stop()
+    expect(onReconciled).not.toHaveBeenCalled()
+  })
+
   it('reports progress: reconciling → live; idle when closed', async () => {
     const onProgress = vi.fn<(progress: GraphIndexProgress) => void>()
     const index = createGraphIndex({ onProgress })

--- a/apps/desktop/src/providers/graph-index.test.ts
+++ b/apps/desktop/src/providers/graph-index.test.ts
@@ -93,7 +93,7 @@ describe('createGraphIndex', () => {
       },
     })
     index.sync(5, () => false)
-    await index.stop()
+    await index.settled() // settle without aborting: `stop()` would suppress it
     expect(order).toEqual(['applied', 'reconciled'])
   })
 
@@ -108,6 +108,21 @@ describe('createGraphIndex', () => {
     index.sync(5, () => false)
     await index.stop()
     expect(onReconciled).not.toHaveBeenCalled()
+  })
+
+  it('an aborted pass never fires onReconciled', async () => {
+    // `stop()` aborts without making `isStale()` true, so the pass a refresh
+    // interrupted would otherwise reload every open note off disk moments
+    // before the replacement pass does it again.
+    const onApplied = vi.fn()
+    const onReconciled = vi.fn()
+    const index = createGraphIndex({ onApplied, onReconciled })
+    index.sync(5, () => false)
+    await index.stop()
+    expect(onReconciled).not.toHaveBeenCalled()
+    // The cheap idempotent callback keeps its existing behavior; only the one
+    // that touches the filesystem is withheld.
+    expect(onApplied).toHaveBeenCalledTimes(1)
   })
 
   it('reports progress: reconciling → live; idle when closed', async () => {

--- a/apps/desktop/src/providers/graph-index.ts
+++ b/apps/desktop/src/providers/graph-index.ts
@@ -92,6 +92,15 @@ export interface GraphIndexOptions {
    */
   onApplied?: () => void
   /**
+   * Called once per completed, un-superseded sync pass, right after
+   * {@link GraphIndexOptions.onApplied}. The pass reads changed files straight
+   * into the index but emits no per-file `index:changed` events, so holders of
+   * in-memory file content (open note sessions) must be told to re-read here;
+   * on iOS the resume reconcile is the only signal a remote edit ever produces
+   * for an already-open note.
+   */
+  onReconciled?: () => void
+  /**
    * Called when id-based healing relocates a note's rows (Plan 17): an
    * external rename observed by the reconcile or a watcher batch. The app
    * carries live sessions and rewrites routes off this, exactly as for an
@@ -130,6 +139,7 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
     onError,
     onProgress,
     onApplied,
+    onReconciled,
     onMoved,
     onFileProgress,
     onStalePlaceholders,
@@ -255,6 +265,7 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
           return
         }
         onApplied?.()
+        onReconciled?.()
         pending = await subscribeIndexChanges(
           generation,
           onApplied,

--- a/apps/desktop/src/providers/graph-index.ts
+++ b/apps/desktop/src/providers/graph-index.ts
@@ -92,8 +92,9 @@ export interface GraphIndexOptions {
    */
   onApplied?: () => void
   /**
-   * Called once per completed, un-superseded sync pass, right after
-   * {@link GraphIndexOptions.onApplied}. The pass reads changed files straight
+   * Called once per sync pass that runs to completion, right after
+   * {@link GraphIndexOptions.onApplied}. A pass that was aborted, superseded,
+   * or suspended never reports. The pass reads changed files straight
    * into the index but emits no per-file `index:changed` events, so holders of
    * in-memory file content (open note sessions) must be told to re-read here;
    * on iOS the resume reconcile is the only signal a remote edit ever produces
@@ -265,7 +266,14 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
           return
         }
         onApplied?.()
-        onReconciled?.()
+        // Aborted passes are excluded (`stop()` aborts without making
+        // `isStale()` true, so the checks above let one through): this reads
+        // every open note off disk, and the refresh that stopped this pass
+        // runs its own to completion. Same reasoning as the `aborted` leg of
+        // the `onStalePlaceholders` guard above.
+        if (!controller.signal.aborted) {
+          onReconciled?.()
+        }
         pending = await subscribeIndexChanges(
           generation,
           onApplied,

--- a/apps/desktop/src/providers/graph-provider.tsx
+++ b/apps/desktop/src/providers/graph-provider.tsx
@@ -26,6 +26,7 @@ import {
   type RecentGraph,
 } from '@reflect/core'
 import { followHealedMove } from '@/editor/move-note'
+import { reloadOpenDocuments } from '@/editor/open-documents'
 import { resetNoteRowOverlays } from '@/hooks/note-row-overlay'
 import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { setIndexProgress } from '@/lib/index-progress'
@@ -172,6 +173,10 @@ export function GraphProvider({
       // sync — the throttled variant collapses them to one refetch round per
       // window (an isolated batch still invalidates immediately).
       onApplied: throttledInvalidateIndexQueries,
+      // A completed reconcile read changed files into the index without
+      // per-file events; open sessions re-read so the visible note converges
+      // with the index (unchanged files are no-op reads).
+      onReconciled: reloadOpenDocuments,
       onFileProgress: (done, total, worked) => setIndexProgress({ done, total, worked }),
       // External renames healed by id follow through to sessions and routes,
       // exactly as for an in-app rename (Plan 17).


### PR DESCRIPTION
A note edited on another device while the app was backgrounded now refreshes in the open editor when the resume reconcile picks it up, instead of staying stale until the app is relaunched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Open documents now reload automatically after synchronization completes.
  - Clean documents adopt updated disk content without manual intervention.
  - Unsaved changes are preserved when disk updates create a conflict.

- **Bug Fixes**
  - Prevented unnecessary reloads when files have not changed.
  - Ensured all open documents receive reload notifications.
  - Reconciliation callbacks now run only after successful, current synchronization passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->