### PR TITLE
refactor: treat an aborted index sync pass as superseded

### DIFF
--- a/apps/desktop/src/providers/graph-index.test.ts
+++ b/apps/desktop/src/providers/graph-index.test.ts
@@ -172,6 +172,37 @@ describe('createGraphIndex', () => {
     expect(unlisten).toHaveBeenCalledTimes(1) // pending subscription cleaned up
   })
 
+  it('an abort during the subscribe drops the pending subscription', async () => {
+    const unlisten = vi.fn()
+    const index = createGraphIndex()
+    // The abort lands while `subscribeIndexChanges` is still in flight, so the
+    // pass clears its own signal check only after the listener exists.
+    mockSubscribe.mockImplementation(async () => {
+      void index.stop()
+      return unlisten
+    })
+    index.sync(5, () => false)
+    await index.settled()
+    expect(mockWatchStart).not.toHaveBeenCalled()
+    expect(unlisten).toHaveBeenCalledTimes(1) // pending subscription cleaned up
+  })
+
+  it('an abort during the watcher start leaves the subscription unadopted', async () => {
+    const unlisten = vi.fn()
+    const onProgress = vi.fn<(progress: GraphIndexProgress) => void>()
+    mockSubscribe.mockResolvedValue(unlisten)
+    const index = createGraphIndex({ onProgress })
+    mockWatchStart.mockImplementation(async () => {
+      void index.stop()
+    })
+    index.sync(5, () => false)
+    await index.settled()
+    // Dropped rather than adopted, and the pass never claims to be live. The
+    // watcher stays up for the replacement pass; only `close` stops it.
+    expect(unlisten).toHaveBeenCalledTimes(1)
+    expect(onProgress.mock.calls.map(([stage]) => stage)).toEqual(['reconciling'])
+  })
+
   it('reports a sync failure but stop() still settles', async () => {
     const onError = vi.fn()
     mockSync.mockRejectedValue(new Error('reconcile boom'))

--- a/apps/desktop/src/providers/graph-index.test.ts
+++ b/apps/desktop/src/providers/graph-index.test.ts
@@ -54,7 +54,7 @@ describe('createGraphIndex', () => {
     const onMoved = vi.fn()
     const index = createGraphIndex({ onApplied, onMoved })
     index.sync(5, () => false)
-    await index.stop()
+    await index.settled() // settle without aborting: `stop()` skips the tail
 
     // Both healing paths get the move hook: the reconcile pass and the live
     // subscription — external renames must follow through to sessions/routes.
@@ -101,35 +101,36 @@ describe('createGraphIndex', () => {
     const onReconciled = vi.fn()
     const index = createGraphIndex({ onReconciled })
     index.sync(5, () => true) // stale right after the reconcile
-    await index.stop()
+    await index.settled()
     expect(onReconciled).not.toHaveBeenCalled()
 
     mockSync.mockRejectedValue(new Error('boom'))
     index.sync(5, () => false)
-    await index.stop()
+    await index.settled()
     expect(onReconciled).not.toHaveBeenCalled()
   })
 
-  it('an aborted pass never fires onReconciled', async () => {
-    // `stop()` aborts without making `isStale()` true, so the pass a refresh
-    // interrupted would otherwise reload every open note off disk moments
-    // before the replacement pass does it again.
+  it('an aborted pass runs no tail: no callbacks, no subscribe, no watcher', async () => {
+    // `stop()` aborts without making `isStale()` true, so an interrupted pass
+    // bails on its own signal. Whoever stopped it either starts a replacement
+    // pass (`refresh`, a graph switch) or tears the lifecycle down (`close`),
+    // so a tail here is only undone and redone moments later.
     const onApplied = vi.fn()
     const onReconciled = vi.fn()
     const index = createGraphIndex({ onApplied, onReconciled })
     index.sync(5, () => false)
     await index.stop()
+    expect(onApplied).not.toHaveBeenCalled()
     expect(onReconciled).not.toHaveBeenCalled()
-    // The cheap idempotent callback keeps its existing behavior; only the one
-    // that touches the filesystem is withheld.
-    expect(onApplied).toHaveBeenCalledTimes(1)
+    expect(mockSubscribe).not.toHaveBeenCalled()
+    expect(mockWatchStart).not.toHaveBeenCalled()
   })
 
   it('reports progress: reconciling → live; idle when closed', async () => {
     const onProgress = vi.fn<(progress: GraphIndexProgress) => void>()
     const index = createGraphIndex({ onProgress })
     index.sync(5, () => false)
-    await index.stop()
+    await index.settled()
     expect(onProgress.mock.calls.map(([stage]) => stage)).toEqual(['reconciling', 'live'])
 
     onProgress.mockClear()
@@ -149,7 +150,7 @@ describe('createGraphIndex', () => {
   it('bails after reconcile when superseded — no subscribe, no watcher', async () => {
     const index = createGraphIndex()
     index.sync(5, () => true) // stale immediately after reconcile
-    await index.stop()
+    await index.settled()
     expect(mockSync).toHaveBeenCalledTimes(1)
     expect(mockSubscribe).not.toHaveBeenCalled()
     expect(mockWatchStart).not.toHaveBeenCalled()
@@ -157,13 +158,15 @@ describe('createGraphIndex', () => {
 
   it('tears down a subscription created after supersession (no listener leak)', async () => {
     const unlisten = vi.fn()
-    mockSubscribe.mockResolvedValue(unlisten)
-    // Fresh after reconcile (1st check), stale after subscribe (2nd check).
-    let checks = 0
-    const isStale = () => ++checks >= 2
+    let stale = false
+    // Fresh through the reconcile, stale by the time the subscription resolves.
+    mockSubscribe.mockImplementation(async () => {
+      stale = true
+      return unlisten
+    })
     const index = createGraphIndex()
-    index.sync(5, isStale)
-    await index.stop()
+    index.sync(5, () => stale)
+    await index.settled()
     expect(mockSubscribe).toHaveBeenCalledTimes(1)
     expect(mockWatchStart).not.toHaveBeenCalled()
     expect(unlisten).toHaveBeenCalledTimes(1) // pending subscription cleaned up
@@ -208,7 +211,7 @@ describe('createGraphIndex', () => {
     mockSubscribe.mockResolvedValue(unlisten)
     const index = createGraphIndex()
     index.sync(5, () => false)
-    await index.stop()
+    await index.settled()
 
     await index.close()
 

--- a/apps/desktop/src/providers/graph-index.ts
+++ b/apps/desktop/src/providers/graph-index.ts
@@ -262,12 +262,13 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
             `index: pass finished in ${Math.round(performance.now() - passStarted)}ms — read ${passWorked} of ${passTotal} files`,
           )
         }
-        // Aborted counts as superseded here: `stop()` aborts without making
-        // `isStale()` true, and every caller that stops a pass (`refresh`,
-        // `close`, a graph switch) either starts a replacement pass or tears
-        // the lifecycle down. Letting a stopped pass subscribe, start the
-        // watcher, and reload every open note is churn the replacement pass
-        // immediately undoes and redoes.
+        // Aborted counts as superseded at every step below: `stop()` aborts
+        // without making `isStale()` true, and every caller that stops a pass
+        // (`refresh`, `close`, a graph switch) either starts a replacement pass
+        // or tears the lifecycle down. Letting a stopped pass subscribe, start
+        // the watcher, and reload every open note is churn the replacement pass
+        // immediately undoes and redoes. The watcher itself is left running:
+        // only `close` wants it stopped, and it calls `watchStop` itself.
         if (controller.signal.aborted || isStale() || isSuspended()) {
           return
         }
@@ -279,11 +280,11 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
           onMoved,
           () => !controller.signal.aborted && !isStale() && !isSuspended(),
         )
-        if (isStale() || isSuspended()) {
+        if (controller.signal.aborted || isStale() || isSuspended()) {
           return
         }
         await watchStart()
-        if (isStale() || isSuspended()) {
+        if (controller.signal.aborted || isStale() || isSuspended()) {
           return
         }
         live.unlisten?.()

--- a/apps/desktop/src/providers/graph-index.ts
+++ b/apps/desktop/src/providers/graph-index.ts
@@ -262,18 +262,17 @@ export function createGraphIndex(options: GraphIndexOptions = {}): GraphIndex {
             `index: pass finished in ${Math.round(performance.now() - passStarted)}ms — read ${passWorked} of ${passTotal} files`,
           )
         }
-        if (isStale() || isSuspended()) {
+        // Aborted counts as superseded here: `stop()` aborts without making
+        // `isStale()` true, and every caller that stops a pass (`refresh`,
+        // `close`, a graph switch) either starts a replacement pass or tears
+        // the lifecycle down. Letting a stopped pass subscribe, start the
+        // watcher, and reload every open note is churn the replacement pass
+        // immediately undoes and redoes.
+        if (controller.signal.aborted || isStale() || isSuspended()) {
           return
         }
         onApplied?.()
-        // Aborted passes are excluded (`stop()` aborts without making
-        // `isStale()` true, so the checks above let one through): this reads
-        // every open note off disk, and the refresh that stopped this pass
-        // runs its own to completion. Same reasoning as the `aborted` leg of
-        // the `onStalePlaceholders` guard above.
-        if (!controller.signal.aborted) {
-          onReconciled?.()
-        }
+        onReconciled?.()
         pending = await subscribeIndexChanges(
           generation,
           onApplied,


### PR DESCRIPTION
A sync pass stopped by `refresh()`/`close()` now bails at every step of its tail, like a stale or suspended one, instead of subscribing, starting the watcher, and firing `onApplied`/`onReconciled` for the replacement pass to immediately undo.