### PR TITLE
refactor: replace native action state with mutations

### DIFF
--- a/apps/desktop/src/components/settings/agents-section.test.tsx
+++ b/apps/desktop/src/components/settings/agents-section.test.tsx
@@ -58,7 +58,7 @@ function installFakeBridge(): void {
         case 'skill_install': {
           const generation = args?.['generation']
           if (typeof generation !== 'number') {
-            throw new Error('missing generation')
+            throw new TypeError('missing generation')
           }
           installGenerations.push(generation)
           return await installResult()
@@ -66,7 +66,7 @@ function installFakeBridge(): void {
         case 'skill_uninstall': {
           const generation = args?.['generation']
           if (typeof generation !== 'number') {
-            throw new Error('missing generation')
+            throw new TypeError('missing generation')
           }
           uninstallGenerations.push(generation)
           return await uninstallResult()
@@ -82,7 +82,7 @@ function installFakeBridge(): void {
 type SectionView = Awaited<ReturnType<typeof render>>
 
 async function renderSection(): Promise<SectionView> {
-  return render(
+  return await render(
     <QueryClientProvider client={queryClient}>
       <AgentsSection />
     </QueryClientProvider>,

--- a/apps/desktop/src/components/settings/agents-section.test.tsx
+++ b/apps/desktop/src/components/settings/agents-section.test.tsx
@@ -169,6 +169,23 @@ describe('AgentsSection', () => {
     expect(page.getByText('Installing failed').query()).toBeNull()
   })
 
+  it('does not carry a mutation error to another graph', async () => {
+    installResult = () => Promise.reject(new Error('Installing failed'))
+    const view = await renderSection()
+    await page.getByRole('button', { name: 'Install skill' }).click()
+    await expect.element(page.getByText('Installing failed')).toBeInTheDocument()
+
+    graphState.graph = { root: '/graphs/Work', name: 'Work', generation: 11 }
+    await view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <AgentsSection />
+      </QueryClientProvider>,
+    )
+
+    await expect.element(page.getByRole('button', { name: 'Install skill' })).toBeEnabled()
+    expect(page.getByText('Installing failed').query()).toBeNull()
+  })
+
   it('writes a completed mutation to its original graph cache', async () => {
     const pendingInstall = deferred<AgentSkillStatus>()
     installResult = () => pendingInstall.promise
@@ -182,6 +199,12 @@ describe('AgentsSection', () => {
         <AgentsSection />
       </QueryClientProvider>,
     )
+    await vi.waitFor(() =>
+      expect(queryClient.getQueryState(queryKeys.agentSkill.status(nextGraph.root))?.status).toBe(
+        'success',
+      ),
+    )
+    await expect.element(page.getByRole('button', { name: 'Install skill' })).toBeEnabled()
     const nextStatus = { ...statusPayload(), skillPath: '/work/SKILL.md' }
     queryClient.setQueryData(queryKeys.agentSkill.status(nextGraph.root), nextStatus)
 

--- a/apps/desktop/src/components/settings/agents-section.test.tsx
+++ b/apps/desktop/src/components/settings/agents-section.test.tsx
@@ -2,7 +2,8 @@ import { render } from 'vitest-browser-react'
 import { page } from 'vitest/browser'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { setBridge } from '@reflect/core'
+import { setBridge, type AgentSkillStatus } from '@reflect/core'
+import { queryKeys } from '@/lib/query-client'
 import { AgentsSection } from './agents-section'
 
 // A browser-mode module mock materializes value exports once, so this file
@@ -11,17 +12,33 @@ import { AgentsSection } from './agents-section'
 vi.mock('@/lib/platform', () => ({ isMacosDesktop: true, isNativeShell: () => true }))
 
 const GRAPH = { root: '/graphs/Personal', name: 'Personal', generation: 7 }
+const graphState = vi.hoisted(() => ({
+  graph: { root: '/graphs/Personal', name: 'Personal', generation: 7 },
+}))
 vi.mock('@/providers/graph-provider', () => ({
-  useGraph: () => ({ graph: GRAPH }),
+  useGraph: () => graphState,
 }))
 
 type InstallState = 'missing' | 'current' | 'stale' | 'conflict'
 
 let installState: InstallState
-let installCalls: Array<Record<string, unknown>>
-let uninstallCalls: Array<Record<string, unknown>>
+let installGenerations: number[]
+let uninstallGenerations: number[]
+let installResult: () => Promise<AgentSkillStatus>
+let uninstallResult: () => Promise<AgentSkillStatus>
+let queryClient: QueryClient
 
-function statusPayload(): Record<string, unknown> {
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolvePromise = (_value: T): void => {
+    throw new Error('promise not initialized')
+  }
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve
+  })
+  return { promise, resolve: (value) => resolvePromise(value) }
+}
+
+function statusPayload(): AgentSkillStatus {
   return {
     skillName: 'reflect-personal',
     skillPath: '/Users/me/.agents/skills/reflect-personal/SKILL.md',
@@ -31,22 +48,28 @@ function statusPayload(): Record<string, unknown> {
 }
 
 function installFakeBridge(): void {
-  installCalls = []
-  uninstallCalls = []
+  installGenerations = []
+  uninstallGenerations = []
   setBridge({
     invoke: async (command, args) => {
       switch (command) {
         case 'skill_status':
           return statusPayload()
         case 'skill_install': {
-          installCalls.push(args ?? {})
-          installState = 'current'
-          return statusPayload()
+          const generation = args?.['generation']
+          if (typeof generation !== 'number') {
+            throw new Error('missing generation')
+          }
+          installGenerations.push(generation)
+          return await installResult()
         }
         case 'skill_uninstall': {
-          uninstallCalls.push(args ?? {})
-          installState = 'missing'
-          return statusPayload()
+          const generation = args?.['generation']
+          if (typeof generation !== 'number') {
+            throw new Error('missing generation')
+          }
+          uninstallGenerations.push(generation)
+          return await uninstallResult()
         }
         default:
           throw new Error(`unexpected command ${command}`)
@@ -56,9 +79,10 @@ function installFakeBridge(): void {
   })
 }
 
-async function renderSection(): Promise<void> {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  await render(
+type SectionView = Awaited<ReturnType<typeof render>>
+
+async function renderSection(): Promise<SectionView> {
+  return render(
     <QueryClientProvider client={queryClient}>
       <AgentsSection />
     </QueryClientProvider>,
@@ -66,12 +90,23 @@ async function renderSection(): Promise<void> {
 }
 
 beforeEach(() => {
+  graphState.graph = GRAPH
   installState = 'missing'
+  installResult = async () => {
+    installState = 'current'
+    return statusPayload()
+  }
+  uninstallResult = async () => {
+    installState = 'missing'
+    return statusPayload()
+  }
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   installFakeBridge()
 })
 
 afterEach(() => {
   setBridge(null)
+  queryClient.clear()
 })
 
 describe('AgentsSection', () => {
@@ -80,19 +115,86 @@ describe('AgentsSection', () => {
     await page.getByRole('button', { name: 'Install skill' }).click()
 
     await expect.element(page.getByText('Installed')).toBeInTheDocument()
-    expect(installCalls).toEqual([{ generation: GRAPH.generation }])
+    expect(installGenerations).toEqual([GRAPH.generation])
     await expect
       .element(page.getByText('/Users/me/.agents/skills/reflect-personal/SKILL.md'))
       .toBeInTheDocument()
   })
 
-  it('offers an update for a stale install and removal for any managed one', async () => {
+  it('updates a stale install with the graph generation pinned', async () => {
+    installState = 'stale'
+    await renderSection()
+
+    await page.getByRole('button', { name: 'Update skill' }).click()
+    await expect.element(page.getByText('Installed')).toBeInTheDocument()
+    expect(installGenerations).toEqual([GRAPH.generation])
+  })
+
+  it('removes any managed install with the graph generation pinned', async () => {
     installState = 'stale'
     await renderSection()
 
     await page.getByRole('button', { name: 'Remove' }).click()
     await expect.element(page.getByRole('button', { name: 'Install skill' })).toBeInTheDocument()
-    expect(uninstallCalls).toEqual([{ generation: GRAPH.generation }])
+    expect(uninstallGenerations).toEqual([GRAPH.generation])
+  })
+
+  it('disables all actions while one mutation is pending', async () => {
+    installState = 'stale'
+    installResult = () => new Promise<AgentSkillStatus>(() => {})
+    await renderSection()
+
+    await page.getByRole('button', { name: 'Update skill' }).click()
+    await expect.element(page.getByRole('button', { name: 'Update skill' })).toBeDisabled()
+    await expect.element(page.getByRole('button', { name: 'Remove' })).toBeDisabled()
+  })
+
+  it('shows mutation errors and clears them when retrying', async () => {
+    let shouldFail = true
+    installResult = async () => {
+      if (shouldFail) {
+        throw new Error('Installing failed')
+      }
+      installState = 'current'
+      return statusPayload()
+    }
+    await renderSection()
+
+    await page.getByRole('button', { name: 'Install skill' }).click()
+    await expect.element(page.getByText('Installing failed')).toBeInTheDocument()
+
+    shouldFail = false
+    await page.getByRole('button', { name: 'Install skill' }).click()
+    await expect.element(page.getByText('Installed')).toBeInTheDocument()
+    expect(page.getByText('Installing failed').query()).toBeNull()
+  })
+
+  it('writes a completed mutation to its original graph cache', async () => {
+    const pendingInstall = deferred<AgentSkillStatus>()
+    installResult = () => pendingInstall.promise
+    const view = await renderSection()
+    await page.getByRole('button', { name: 'Install skill' }).click()
+
+    const nextGraph = { root: '/graphs/Work', name: 'Work', generation: 11 }
+    graphState.graph = nextGraph
+    await view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <AgentsSection />
+      </QueryClientProvider>,
+    )
+    const nextStatus = { ...statusPayload(), skillPath: '/work/SKILL.md' }
+    queryClient.setQueryData(queryKeys.agentSkill.status(nextGraph.root), nextStatus)
+
+    installState = 'current'
+    pendingInstall.resolve(statusPayload())
+    await vi.waitFor(() =>
+      expect(queryClient.getQueryData(queryKeys.agentSkill.status(GRAPH.root))).toEqual(
+        statusPayload(),
+      ),
+    )
+    expect(queryClient.getQueryData(queryKeys.agentSkill.status(nextGraph.root))).toEqual(
+      nextStatus,
+    )
   })
 
   it('refuses to touch an unmanaged file', async () => {

--- a/apps/desktop/src/components/settings/agents-section.test.tsx
+++ b/apps/desktop/src/components/settings/agents-section.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setBridge, type AgentSkillStatus } from '@reflect/core'
 import { queryKeys } from '@/lib/query-client'
+import { deferred } from '@/test-utils/deferred'
 import { AgentsSection } from './agents-section'
 
 // A browser-mode module mock materializes value exports once, so this file
@@ -27,16 +28,6 @@ let uninstallGenerations: number[]
 let installResult: () => Promise<AgentSkillStatus>
 let uninstallResult: () => Promise<AgentSkillStatus>
 let queryClient: QueryClient
-
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
-  let resolvePromise = (_value: T): void => {
-    throw new Error('promise not initialized')
-  }
-  const promise = new Promise<T>((resolve) => {
-    resolvePromise = resolve
-  })
-  return { promise, resolve: (value) => resolvePromise(value) }
-}
 
 function statusPayload(): AgentSkillStatus {
   return {

--- a/apps/desktop/src/components/settings/agents-section.tsx
+++ b/apps/desktop/src/components/settings/agents-section.tsx
@@ -60,6 +60,8 @@ export function AgentsSection(): ReactElement | null {
 
   const installed = status?.installState === 'current'
   const actionError = mutation.error === null ? null : errorMessage(mutation.error)
+  const mutate = (action: AgentSkillAction['action']): void =>
+    mutation.mutate({ action, generation: graph.generation, root: graph.root })
   return (
     <SettingsSection id="agents">
       <SettingsField
@@ -83,17 +85,7 @@ export function AgentsSection(): ReactElement | null {
                     Installed
                   </span>
                 ) : (
-                  <Button
-                    size="xs"
-                    disabled={mutation.isPending}
-                    onClick={() =>
-                      mutation.mutate({
-                        action: 'install',
-                        generation: graph.generation,
-                        root: graph.root,
-                      })
-                    }
-                  >
+                  <Button size="xs" disabled={mutation.isPending} onClick={() => mutate('install')}>
                     {status.installState === 'stale' ? 'Update skill' : 'Install skill'}
                   </Button>
                 )}
@@ -102,13 +94,7 @@ export function AgentsSection(): ReactElement | null {
                     size="xs"
                     variant="outline"
                     disabled={mutation.isPending}
-                    onClick={() =>
-                      mutation.mutate({
-                        action: 'uninstall',
-                        generation: graph.generation,
-                        root: graph.root,
-                      })
-                    }
+                    onClick={() => mutate('uninstall')}
                   >
                     Remove
                   </Button>

--- a/apps/desktop/src/components/settings/agents-section.tsx
+++ b/apps/desktop/src/components/settings/agents-section.tsx
@@ -1,5 +1,5 @@
-import { useState, type ReactElement } from 'react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import type { ReactElement } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Check } from 'lucide-react'
 import {
   agentSkillInstall,
@@ -13,8 +13,19 @@ import { SettingsSection } from '@/components/settings/section'
 import { Button } from '@/components/ui/button'
 import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { isMacosDesktop } from '@/lib/platform'
-import { queryKeys } from '@/lib/query-client'
+import { mutationKeys, mutationScopeIds, queryKeys } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
+
+type AgentSkillAction =
+  | { action: 'install'; generation: number; root: string }
+  | { action: 'update'; generation: number; root: string }
+  | { action: 'remove'; generation: number; root: string }
+
+function writeAgentSkill(variables: AgentSkillAction): Promise<AgentSkillStatus> {
+  return variables.action === 'remove'
+    ? agentSkillUninstall(variables.generation)
+    : agentSkillInstall(variables.generation)
+}
 
 /**
  * Settings → Agents: one-click install of a per-graph agent skill under
@@ -26,8 +37,6 @@ import { useGraph } from '@/providers/graph-provider'
 export function AgentsSection(): ReactElement | null {
   const { graph } = useGraph()
   const queryClient = useQueryClient()
-  const [busy, setBusy] = useState(false)
-  const [error, setError] = useState<string | null>(null)
   const queryKey = queryKeys.agentSkill.status(graph?.root)
   const bridgeReady = useBridgeReady()
   const { data: status } = useQuery({
@@ -35,27 +44,21 @@ export function AgentsSection(): ReactElement | null {
     queryFn: agentSkillStatus,
     enabled: bridgeReady && isMacosDesktop && graph !== null,
   })
+  const mutation = useMutation({
+    mutationKey: mutationKeys.agentSkill.write(graph?.root),
+    scope: { id: mutationScopeIds.agentSkillWrite(graph?.root) },
+    mutationFn: writeAgentSkill,
+    onSuccess: (nextStatus, variables) => {
+      queryClient.setQueryData(queryKeys.agentSkill.status(variables.root), nextStatus)
+    },
+  })
 
   if (!isMacosDesktop || graph === null) {
     return null
   }
 
-  async function run(action: (generation: number) => Promise<AgentSkillStatus>): Promise<void> {
-    if (graph === null) {
-      return
-    }
-    setBusy(true)
-    setError(null)
-    try {
-      queryClient.setQueryData(queryKey, await action(graph.generation))
-    } catch (caught) {
-      setError(errorMessage(caught))
-    } finally {
-      setBusy(false)
-    }
-  }
-
   const installed = status?.installState === 'current'
+  const actionError = mutation.error === null ? null : errorMessage(mutation.error)
   return (
     <SettingsSection id="agents">
       <SettingsField
@@ -79,7 +82,17 @@ export function AgentsSection(): ReactElement | null {
                     Installed
                   </span>
                 ) : (
-                  <Button size="xs" disabled={busy} onClick={() => void run(agentSkillInstall)}>
+                  <Button
+                    size="xs"
+                    disabled={mutation.isPending}
+                    onClick={() =>
+                      mutation.mutate({
+                        action: status.installState === 'stale' ? 'update' : 'install',
+                        generation: graph.generation,
+                        root: graph.root,
+                      })
+                    }
+                  >
                     {status.installState === 'stale' ? 'Update skill' : 'Install skill'}
                   </Button>
                 )}
@@ -87,15 +100,23 @@ export function AgentsSection(): ReactElement | null {
                   <Button
                     size="xs"
                     variant="outline"
-                    disabled={busy}
-                    onClick={() => void run(agentSkillUninstall)}
+                    disabled={mutation.isPending}
+                    onClick={() =>
+                      mutation.mutate({
+                        action: 'remove',
+                        generation: graph.generation,
+                        root: graph.root,
+                      })
+                    }
                   >
                     Remove
                   </Button>
                 ) : null}
               </div>
             )}
-            {error !== null ? <p className="text-xs text-destructive">{error}</p> : null}
+            {actionError !== null ? (
+              <p className="text-xs text-destructive">{actionError}</p>
+            ) : null}
           </div>
         ) : null}
       </SettingsField>

--- a/apps/desktop/src/components/settings/agents-section.tsx
+++ b/apps/desktop/src/components/settings/agents-section.tsx
@@ -59,7 +59,10 @@ export function AgentsSection(): ReactElement | null {
   }
 
   const installed = status?.installState === 'current'
-  const actionError = mutation.error === null ? null : errorMessage(mutation.error)
+  const isCurrentMutation = mutation.variables?.root === graph.root
+  const actionPending = isCurrentMutation && mutation.isPending
+  const actionError =
+    isCurrentMutation && mutation.error !== null ? errorMessage(mutation.error) : null
   const mutate = (action: AgentSkillAction['action']): void =>
     mutation.mutate({ action, generation: graph.generation, root: graph.root })
   return (
@@ -85,7 +88,7 @@ export function AgentsSection(): ReactElement | null {
                     Installed
                   </span>
                 ) : (
-                  <Button size="xs" disabled={mutation.isPending} onClick={() => mutate('install')}>
+                  <Button size="xs" disabled={actionPending} onClick={() => mutate('install')}>
                     {status.installState === 'stale' ? 'Update skill' : 'Install skill'}
                   </Button>
                 )}
@@ -93,7 +96,7 @@ export function AgentsSection(): ReactElement | null {
                   <Button
                     size="xs"
                     variant="outline"
-                    disabled={mutation.isPending}
+                    disabled={actionPending}
                     onClick={() => mutate('uninstall')}
                   >
                     Remove

--- a/apps/desktop/src/components/settings/agents-section.tsx
+++ b/apps/desktop/src/components/settings/agents-section.tsx
@@ -16,13 +16,14 @@ import { isMacosDesktop } from '@/lib/platform'
 import { mutationKeys, mutationScopeIds, queryKeys } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 
-type AgentSkillAction =
-  | { action: 'install'; generation: number; root: string }
-  | { action: 'update'; generation: number; root: string }
-  | { action: 'remove'; generation: number; root: string }
+interface AgentSkillAction {
+  action: 'install' | 'uninstall'
+  generation: number
+  root: string
+}
 
 function writeAgentSkill(variables: AgentSkillAction): Promise<AgentSkillStatus> {
-  return variables.action === 'remove'
+  return variables.action === 'uninstall'
     ? agentSkillUninstall(variables.generation)
     : agentSkillInstall(variables.generation)
 }
@@ -87,7 +88,7 @@ export function AgentsSection(): ReactElement | null {
                     disabled={mutation.isPending}
                     onClick={() =>
                       mutation.mutate({
-                        action: status.installState === 'stale' ? 'update' : 'install',
+                        action: 'install',
                         generation: graph.generation,
                         root: graph.root,
                       })
@@ -103,7 +104,7 @@ export function AgentsSection(): ReactElement | null {
                     disabled={mutation.isPending}
                     onClick={() =>
                       mutation.mutate({
-                        action: 'remove',
+                        action: 'uninstall',
                         generation: graph.generation,
                         root: graph.root,
                       })

--- a/apps/desktop/src/hooks/use-reorder-pinned-notes.test.tsx
+++ b/apps/desktop/src/hooks/use-reorder-pinned-notes.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, renderHook } from 'vitest-browser-react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PinnedNote } from '@reflect/core'
 import { queryKeys } from '@/lib/query-client'
+import { deferred } from '@/test-utils/deferred'
 import { useReorderPinnedNotes } from './use-reorder-pinned-notes'
 
 const reorderPinnedNotes = vi.hoisted(() =>
@@ -16,29 +17,13 @@ const graphState: {
 } = vi.hoisted(() => ({ graph: { generation: 7, root: '/graphs/personal' } }))
 vi.mock('@/providers/graph-provider', () => ({ useGraph: () => graphState }))
 
-const A = { dailyDate: null, path: 'a.md', title: 'A' } satisfies PinnedNote
-const B = { dailyDate: null, path: 'b.md', title: 'B' } satisfies PinnedNote
-const C = { dailyDate: null, path: 'c.md', title: 'C' } satisfies PinnedNote
-const NOTES = [A, B, C] as const
-const FIRST_ORDER = [B, A, C]
-const SECOND_ORDER = [B, C, A]
-const THIRD_ORDER = [C, A, B]
-
-interface Deferred<T> {
-  promise: Promise<T>
-  reject: (error: Error) => void
-  resolve: (value: T) => void
-}
-
-function deferred<T>(): Deferred<T> {
-  let rejectPromise = (_error: Error): void => {}
-  let resolvePromise = (_value: T): void => {}
-  const promise = new Promise<T>((resolve, reject) => {
-    rejectPromise = reject
-    resolvePromise = resolve
-  })
-  return { promise, reject: rejectPromise, resolve: resolvePromise }
-}
+const NOTE_A = { dailyDate: null, path: 'a.md', title: 'A' } satisfies PinnedNote
+const NOTE_B = { dailyDate: null, path: 'b.md', title: 'B' } satisfies PinnedNote
+const NOTE_C = { dailyDate: null, path: 'c.md', title: 'C' } satisfies PinnedNote
+const NOTES = [NOTE_A, NOTE_B, NOTE_C] as const
+const FIRST_ORDER = [NOTE_B, NOTE_A, NOTE_C]
+const SECOND_ORDER = [NOTE_B, NOTE_C, NOTE_A]
+const THIRD_ORDER = [NOTE_C, NOTE_A, NOTE_B]
 
 let queryClient: QueryClient
 
@@ -134,7 +119,7 @@ describe('useReorderPinnedNotes', () => {
   })
 
   it('refetches disk truth when the last outstanding reorder fails', async () => {
-    const diskTruth = [A, C, B]
+    const diskTruth = [NOTE_A, NOTE_C, NOTE_B]
     const readPinnedNotes = vi.fn<() => Promise<PinnedNote[]>>().mockResolvedValue(diskTruth)
     reorderPinnedNotes.mockRejectedValue(new Error('write failed'))
     const hook = await renderHook(

--- a/apps/desktop/src/hooks/use-reorder-pinned-notes.test.tsx
+++ b/apps/desktop/src/hooks/use-reorder-pinned-notes.test.tsx
@@ -1,0 +1,159 @@
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
+import { cleanup, renderHook } from 'vitest-browser-react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PinnedNote } from '@reflect/core'
+import { queryKeys } from '@/lib/query-client'
+import { useReorderPinnedNotes } from './use-reorder-pinned-notes'
+
+const reorderPinnedNotes = vi.hoisted(() =>
+  vi.fn<(notes: readonly PinnedNote[], generation: number) => Promise<void>>(),
+)
+vi.mock('@/lib/note-pin', () => ({ reorderPinnedNotes }))
+
+const graphState: {
+  graph: { generation: number; root: string } | null
+} = vi.hoisted(() => ({ graph: { generation: 7, root: '/graphs/personal' } }))
+vi.mock('@/providers/graph-provider', () => ({ useGraph: () => graphState }))
+
+const A = { dailyDate: null, path: 'a.md', title: 'A' } satisfies PinnedNote
+const B = { dailyDate: null, path: 'b.md', title: 'B' } satisfies PinnedNote
+const C = { dailyDate: null, path: 'c.md', title: 'C' } satisfies PinnedNote
+const NOTES = [A, B, C] as const
+const FIRST_ORDER = [B, A, C]
+const SECOND_ORDER = [B, C, A]
+const THIRD_ORDER = [C, A, B]
+
+interface Deferred<T> {
+  promise: Promise<T>
+  reject: (error: Error) => void
+  resolve: (value: T) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let rejectPromise = (_error: Error): void => {}
+  let resolvePromise = (_value: T): void => {}
+  const promise = new Promise<T>((resolve, reject) => {
+    rejectPromise = reject
+    resolvePromise = resolve
+  })
+  return { promise, reject: rejectPromise, resolve: resolvePromise }
+}
+
+let queryClient: QueryClient
+
+function wrapper({ children }: { children: ReactNode }): ReactNode {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+function renderReorder(pinned: readonly PinnedNote[] = NOTES) {
+  return renderHook(
+    (
+      { pinned }: { pinned: readonly PinnedNote[] } = {
+        pinned: NOTES,
+      },
+    ) => useReorderPinnedNotes(pinned),
+    { initialProps: { pinned }, wrapper },
+  )
+}
+
+beforeEach(() => {
+  graphState.graph = { generation: 7, root: '/graphs/personal' }
+  queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false, staleTime: Infinity },
+    },
+  })
+  queryClient.setQueryData(queryKeys.index.pinnedNotes('/graphs/personal'), NOTES)
+  reorderPinnedNotes.mockReset()
+})
+
+afterEach(async () => {
+  queryClient.clear()
+  await cleanup()
+})
+
+describe('useReorderPinnedNotes', () => {
+  it('does nothing for a missing graph, missing note, or unchanged position', async () => {
+    const hook = await renderReorder()
+
+    await hook.act(() => hook.result.current('missing.md', 'b.md'))
+    await hook.act(() => hook.result.current('a.md', 'a.md'))
+    graphState.graph = null
+    await hook.rerender({ pinned: NOTES })
+    await hook.act(() => hook.result.current('a.md', 'b.md'))
+
+    expect(reorderPinnedNotes).not.toHaveBeenCalled()
+    expect(queryClient.getQueryData(queryKeys.index.pinnedNotes('/graphs/personal'))).toEqual(NOTES)
+  })
+
+  it('updates optimistically and serializes disk writes after an earlier failure', async () => {
+    const first = deferred<void>()
+    const second = deferred<void>()
+    const third = deferred<void>()
+    reorderPinnedNotes
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise)
+      .mockImplementationOnce(() => third.promise)
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+    const hook = await renderReorder()
+
+    await hook.act(() => hook.result.current('a.md', 'b.md'))
+    expect(queryClient.getQueryData(queryKeys.index.pinnedNotes('/graphs/personal'))).toEqual(
+      FIRST_ORDER,
+    )
+    await hook.rerender({ pinned: FIRST_ORDER })
+    await hook.act(() => hook.result.current('a.md', 'c.md'))
+    expect(queryClient.getQueryData(queryKeys.index.pinnedNotes('/graphs/personal'))).toEqual(
+      SECOND_ORDER,
+    )
+    await hook.rerender({ pinned: SECOND_ORDER })
+    await hook.act(() => hook.result.current('b.md', 'a.md'))
+    expect(queryClient.getQueryData(queryKeys.index.pinnedNotes('/graphs/personal'))).toEqual(
+      THIRD_ORDER,
+    )
+    expect(reorderPinnedNotes).toHaveBeenCalledTimes(1)
+
+    first.resolve()
+    await vi.waitFor(() => expect(reorderPinnedNotes).toHaveBeenCalledTimes(2))
+    second.reject(new Error('second write failed'))
+    await vi.waitFor(() => expect(reorderPinnedNotes).toHaveBeenCalledTimes(3))
+    third.resolve()
+    await vi.waitFor(() => expect(queryClient.isMutating()).toBe(0))
+
+    expect(reorderPinnedNotes.mock.calls).toEqual([
+      [FIRST_ORDER, 7],
+      [SECOND_ORDER, 7],
+      [THIRD_ORDER, 7],
+    ])
+    expect(invalidateQueries).not.toHaveBeenCalled()
+    expect(queryClient.getQueryData(queryKeys.index.pinnedNotes('/graphs/personal'))).toEqual(
+      THIRD_ORDER,
+    )
+  })
+
+  it('refetches disk truth when the last outstanding reorder fails', async () => {
+    const diskTruth = [A, C, B]
+    const readPinnedNotes = vi.fn<() => Promise<PinnedNote[]>>().mockResolvedValue(diskTruth)
+    reorderPinnedNotes.mockRejectedValue(new Error('write failed'))
+    const hook = await renderHook(
+      () => {
+        useQuery({
+          queryFn: readPinnedNotes,
+          queryKey: queryKeys.index.pinnedNotes('/graphs/personal'),
+        })
+        return useReorderPinnedNotes(NOTES)
+      },
+      { wrapper },
+    )
+
+    await hook.act(() => hook.result.current('a.md', 'b.md'))
+    await vi.waitFor(() => expect(readPinnedNotes).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() =>
+      expect(queryClient.getQueryData(queryKeys.index.pinnedNotes('/graphs/personal'))).toEqual(
+        diskTruth,
+      ),
+    )
+  })
+})

--- a/apps/desktop/src/hooks/use-reorder-pinned-notes.ts
+++ b/apps/desktop/src/hooks/use-reorder-pinned-notes.ts
@@ -1,18 +1,41 @@
-import { useCallback, useRef } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useCallback } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { arrayMove } from '@dnd-kit/sortable'
 import type { PinnedNote } from '@reflect/core'
 import { reorderPinnedNotes } from '@/lib/note-pin'
+import { mutationKeys, mutationScopeIds } from '@/lib/query-client'
 import { useGraph } from '@/providers/graph-provider'
 import { invalidatePinnedNotesCache, updatePinnedNotesCache } from '@/lib/notes/pinned-notes-cache'
+
+interface ReorderPinnedNotesVariables {
+  generation: number
+  notes: readonly PinnedNote[]
+  root: string
+}
+
+function writePinnedNotesOrder(variables: ReorderPinnedNotesVariables): Promise<void> {
+  return reorderPinnedNotes(variables.notes, variables.generation)
+}
 
 export function useReorderPinnedNotes(
   pinned: readonly PinnedNote[],
 ): (activePath: string, overPath: string) => void {
   const { graph } = useGraph()
   const queryClient = useQueryClient()
-  const saveChain = useRef<Promise<void>>(Promise.resolve())
-  const mutationId = useRef(0)
+  const mutation = useMutation({
+    mutationKey: mutationKeys.pinnedNotes.reorder(graph?.root),
+    scope: { id: mutationScopeIds.pinnedNotesReorder(graph?.root) },
+    mutationFn: writePinnedNotesOrder,
+    onError: (_error, variables) => {
+      const pendingCount = queryClient.isMutating({
+        exact: true,
+        mutationKey: mutationKeys.pinnedNotes.reorder(variables.root),
+      })
+      if (pendingCount === 1) {
+        invalidatePinnedNotesCache(queryClient, variables.root)
+      }
+    },
+  })
 
   return useCallback(
     (activePath: string, overPath: string): void => {
@@ -26,21 +49,13 @@ export function useReorderPinnedNotes(
         return
       }
       const reordered = arrayMove([...pinned], activeIndex, overIndex)
-
-      const currentMutation = mutationId.current + 1
-      mutationId.current = currentMutation
-
       updatePinnedNotesCache(queryClient, graph.root, () => reordered)
-
-      saveChain.current = saveChain.current
-        .catch(() => undefined)
-        .then(() => reorderPinnedNotes(reordered, graph.generation))
-        .catch(() => {
-          if (mutationId.current === currentMutation) {
-            invalidatePinnedNotesCache(queryClient, graph.root)
-          }
-        })
+      mutation.mutate({
+        generation: graph.generation,
+        notes: reordered,
+        root: graph.root,
+      })
     },
-    [graph, pinned, queryClient],
+    [graph, mutation, pinned, queryClient],
   )
 }

--- a/apps/desktop/src/hooks/use-reorder-pinned-notes.ts
+++ b/apps/desktop/src/hooks/use-reorder-pinned-notes.ts
@@ -13,10 +13,6 @@ interface ReorderPinnedNotesVariables {
   root: string
 }
 
-function writePinnedNotesOrder(variables: ReorderPinnedNotesVariables): Promise<void> {
-  return reorderPinnedNotes(variables.notes, variables.generation)
-}
-
 export function useReorderPinnedNotes(
   pinned: readonly PinnedNote[],
 ): (activePath: string, overPath: string) => void {
@@ -25,13 +21,15 @@ export function useReorderPinnedNotes(
   const mutation = useMutation({
     mutationKey: mutationKeys.pinnedNotes.reorder(graph?.root),
     scope: { id: mutationScopeIds.pinnedNotesReorder(graph?.root) },
-    mutationFn: writePinnedNotesOrder,
+    mutationFn: (variables: ReorderPinnedNotesVariables) =>
+      reorderPinnedNotes(variables.notes, variables.generation),
     onError: (_error, variables) => {
-      const pendingCount = queryClient.isMutating({
-        exact: true,
-        mutationKey: mutationKeys.pinnedNotes.reorder(variables.root),
-      })
-      if (pendingCount === 1) {
+      if (
+        queryClient.isMutating({
+          exact: true,
+          mutationKey: mutationKeys.pinnedNotes.reorder(variables.root),
+        }) === 1
+      ) {
         invalidatePinnedNotesCache(queryClient, variables.root)
       }
     },
@@ -50,11 +48,7 @@ export function useReorderPinnedNotes(
       }
       const reordered = arrayMove([...pinned], activeIndex, overIndex)
       updatePinnedNotesCache(queryClient, graph.root, () => reordered)
-      mutation.mutate({
-        generation: graph.generation,
-        notes: reordered,
-        root: graph.root,
-      })
+      mutation.mutate({ generation: graph.generation, notes: reordered, root: graph.root })
     },
     [graph, mutation, pinned, queryClient],
   )

--- a/apps/desktop/src/hooks/use-reorder-pinned-notes.ts
+++ b/apps/desktop/src/hooks/use-reorder-pinned-notes.ts
@@ -18,7 +18,7 @@ export function useReorderPinnedNotes(
 ): (activePath: string, overPath: string) => void {
   const { graph } = useGraph()
   const queryClient = useQueryClient()
-  const mutation = useMutation({
+  const { mutate } = useMutation({
     mutationKey: mutationKeys.pinnedNotes.reorder(graph?.root),
     scope: { id: mutationScopeIds.pinnedNotesReorder(graph?.root) },
     mutationFn: (variables: ReorderPinnedNotesVariables) =>
@@ -48,8 +48,8 @@ export function useReorderPinnedNotes(
       }
       const reordered = arrayMove([...pinned], activeIndex, overIndex)
       updatePinnedNotesCache(queryClient, graph.root, () => reordered)
-      mutation.mutate({ generation: graph.generation, notes: reordered, root: graph.root })
+      mutate({ generation: graph.generation, notes: reordered, root: graph.root })
     },
-    [graph, mutation, pinned, queryClient],
+    [graph, mutate, pinned, queryClient],
   )
 }

--- a/apps/desktop/src/lib/query-client.ts
+++ b/apps/desktop/src/lib/query-client.ts
@@ -245,7 +245,7 @@ export const mutationKeys = {
 
 export const mutationScopeIds = {
   pinnedNotesReorder: (root: string) => `pinned-notes:reorder:${root}`,
-  agentSkillWrite: (root: string) => `agent-skill:write:${root}`,
+  agentSkillWrite: (root: GraphRoot) => `agent-skill:write:${root ?? 'none'}`,
   iapAction: 'iap:action',
   settingsSave: 'settings:save',
 } as const

--- a/apps/desktop/src/lib/query-client.ts
+++ b/apps/desktop/src/lib/query-client.ts
@@ -244,7 +244,7 @@ export const mutationKeys = {
 } as const
 
 export const mutationScopeIds = {
-  pinnedNotesReorder: (root: string) => `pinned-notes:reorder:${root}`,
+  pinnedNotesReorder: (root: GraphRoot) => `pinned-notes:reorder:${root ?? 'none'}`,
   agentSkillWrite: (root: GraphRoot) => `agent-skill:write:${root ?? 'none'}`,
   iapAction: 'iap:action',
   settingsSave: 'settings:save',

--- a/apps/desktop/src/mobile/paywall-screen.test.tsx
+++ b/apps/desktop/src/mobile/paywall-screen.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, render } from 'vitest-browser-react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { IAP_PRODUCT_IDS, setBridge, type IapProduct, type IpcBridge } from '@reflect/core'
 import { mutationKeys, mutationScopeIds } from '@/lib/query-client'
+import { deferred } from '@/test-utils/deferred'
 import { PaywallScreen } from './paywall-screen'
 
 const mocks = vi.hoisted(() => ({
@@ -24,26 +25,15 @@ vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({ updateSettings: mocks.updateSettings }),
 }))
 
-const PRODUCTS: IapProduct[] = [
-  { formattedPrice: '$39.99', productId: IAP_PRODUCT_IDS.yearly },
-  { formattedPrice: '$4.99', productId: IAP_PRODUCT_IDS.monthly },
-]
-
-interface Deferred<T> {
-  promise: Promise<T>
-  reject: (error: Error) => void
-  resolve: (value: T) => void
-}
-
-function deferred<T>(): Deferred<T> {
-  let rejectPromise = (_error: Error): void => {}
-  let resolvePromise = (_value: T): void => {}
-  const promise = new Promise<T>((resolve, reject) => {
-    rejectPromise = reject
-    resolvePromise = resolve
-  })
-  return { promise, reject: rejectPromise, resolve: resolvePromise }
-}
+const YEARLY_PRODUCT = {
+  formattedPrice: '$39.99',
+  productId: IAP_PRODUCT_IDS.yearly,
+} satisfies IapProduct
+const MONTHLY_PRODUCT = {
+  formattedPrice: '$4.99',
+  productId: IAP_PRODUCT_IDS.monthly,
+} satisfies IapProduct
+const PRODUCTS: IapProduct[] = [YEARLY_PRODUCT, MONTHLY_PRODUCT]
 
 let getProducts: () => Promise<{ products: IapProduct[] }>
 let purchase: () => Promise<null>
@@ -87,7 +77,7 @@ afterEach(async () => {
 
 describe('PaywallScreen products', () => {
   it('shows the existing failure UI when a required product is missing', async () => {
-    getProducts = async () => ({ products: [PRODUCTS[0]!] })
+    getProducts = async () => ({ products: [YEARLY_PRODUCT] })
     const view = await render(<PaywallScreen />, { wrapper })
 
     await expect.element(view.getByText(/Could not load subscription options/)).toBeVisible()

--- a/apps/desktop/src/mobile/paywall-screen.test.tsx
+++ b/apps/desktop/src/mobile/paywall-screen.test.tsx
@@ -1,8 +1,9 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render } from 'vitest-browser-react'
 import type { ReactNode } from 'react'
-import { setBridge } from '@reflect/core'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render } from 'vitest-browser-react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { IAP_PRODUCT_IDS, setBridge, type IapProduct, type IpcBridge } from '@reflect/core'
+import { mutationKeys, mutationScopeIds } from '@/lib/query-client'
 import { PaywallScreen } from './paywall-screen'
 
 const mocks = vi.hoisted(() => ({
@@ -23,43 +24,73 @@ vi.mock('@/providers/settings-provider', () => ({
   useSettings: () => ({ updateSettings: mocks.updateSettings }),
 }))
 
-let getProducts: () => Promise<unknown>
+const PRODUCTS: IapProduct[] = [
+  { formattedPrice: '$39.99', productId: IAP_PRODUCT_IDS.yearly },
+  { formattedPrice: '$4.99', productId: IAP_PRODUCT_IDS.monthly },
+]
+
+interface Deferred<T> {
+  promise: Promise<T>
+  reject: (error: Error) => void
+  resolve: (value: T) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let rejectPromise = (_error: Error): void => {}
+  let resolvePromise = (_value: T): void => {}
+  const promise = new Promise<T>((resolve, reject) => {
+    rejectPromise = reject
+    resolvePromise = resolve
+  })
+  return { promise, reject: rejectPromise, resolve: resolvePromise }
+}
+
+let getProducts: () => Promise<{ products: IapProduct[] }>
+let purchase: () => Promise<null>
+let restore: () => Promise<{ purchases: object[] }>
+let invoke = vi.fn<IpcBridge['invoke']>()
 let queryClient: QueryClient
 
-function wrapper({ children }: { children: ReactNode }) {
+function wrapper({ children }: { children: ReactNode }): ReactNode {
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 }
 
 beforeEach(() => {
-  getProducts = () => Promise.resolve({ products: [] })
-  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  setBridge({
-    invoke: async (command) => {
-      if (command === 'plugin:iap|get_products') {
-        return await getProducts()
-      }
-      return null
-    },
-    listen: async () => () => {},
+  getProducts = async () => ({ products: PRODUCTS })
+  purchase = async () => null
+  restore = async () => ({ purchases: [] })
+  queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
   })
+  invoke = vi.fn<IpcBridge['invoke']>(async (command) => {
+    switch (command) {
+      case 'plugin:iap|get_products':
+        return await getProducts()
+      case 'plugin:iap|purchase':
+        return await purchase()
+      case 'plugin:iap|restore_purchases':
+        return await restore()
+      default:
+        return null
+    }
+  })
+  setBridge({ invoke, listen: async () => () => {} })
+  mocks.invalidate.mockReset()
+  mocks.updateSettings.mockReset()
 })
 
-afterEach(() => {
+afterEach(async () => {
   setBridge(null)
   queryClient.clear()
-  vi.restoreAllMocks()
+  await cleanup()
 })
 
 describe('PaywallScreen products', () => {
   it('shows the existing failure UI when a required product is missing', async () => {
-    getProducts = () =>
-      Promise.resolve({
-        products: [{ productId: 'app.reflect.ios.pro.yearly', formattedPrice: '$39.99' }],
-      })
+    getProducts = async () => ({ products: [PRODUCTS[0]!] })
     const view = await render(<PaywallScreen />, { wrapper })
 
     await expect.element(view.getByText(/Could not load subscription options/)).toBeVisible()
-    await view.unmount()
   })
 
   it('shows the existing failure UI when the products query rejects', async () => {
@@ -67,6 +98,137 @@ describe('PaywallScreen products', () => {
     const view = await render(<PaywallScreen />, { wrapper })
 
     await expect.element(view.getByText(/Could not load subscription options/)).toBeVisible()
-    await view.unmount()
+  })
+})
+
+describe('PaywallScreen purchase mutation', () => {
+  it('purchases the yearly plan, disables every action, and invalidates on success', async () => {
+    const pendingPurchase = deferred<null>()
+    purchase = () => pendingPurchase.promise
+    const view = await render(<PaywallScreen />, { wrapper })
+    const trial = view.getByRole('button', { name: 'Start 7-day free trial' })
+
+    await expect.element(trial).toBeVisible()
+    await trial.click()
+
+    await expect.element(trial).toBeDisabled()
+    await expect.element(view.getByRole('radio', { name: /Yearly/ })).toBeDisabled()
+    await expect.element(view.getByRole('radio', { name: /Monthly/ })).toBeDisabled()
+    await expect
+      .element(view.getByRole('button', { name: /Already a Reflect member/ }))
+      .toBeDisabled()
+    await expect.element(view.getByRole('button', { name: 'Remind me later' })).toBeDisabled()
+    await expect.element(view.getByRole('button', { name: 'Restore Purchases' })).toBeDisabled()
+    expect(view.container.querySelector('button svg.animate-spin')).not.toBeNull()
+    expect(invoke).toHaveBeenCalledWith('plugin:iap|purchase', {
+      payload: { productId: IAP_PRODUCT_IDS.yearly, productType: 'subs' },
+    })
+    const activePurchase = queryClient
+      .getMutationCache()
+      .find({ exact: true, mutationKey: mutationKeys.iap.purchase })
+    expect(activePurchase?.options.scope?.id).toBe(mutationScopeIds.iapAction)
+    expect(activePurchase?.state.variables).toEqual({
+      plan: 'yearly',
+      productId: IAP_PRODUCT_IDS.yearly,
+    })
+
+    pendingPurchase.resolve(null)
+    await vi.waitFor(() => expect(mocks.invalidate).toHaveBeenCalledTimes(1))
+    await expect.element(trial).not.toBeDisabled()
+  })
+
+  it('uses the monthly initiator and treats a rejected purchase as fail soft', async () => {
+    purchase = () => Promise.reject(new Error('cancelled'))
+    const view = await render(<PaywallScreen />, { wrapper })
+    await expect.element(view.getByRole('button', { name: 'Start 7-day free trial' })).toBeVisible()
+
+    await view.getByRole('radio', { name: /Monthly/ }).click()
+    const trial = view.getByRole('button', { name: 'Start 7-day free trial' })
+    await trial.click()
+
+    await vi.waitFor(() => expect(queryClient.isMutating()).toBe(0))
+    expect(invoke).toHaveBeenCalledWith('plugin:iap|purchase', {
+      payload: { productId: IAP_PRODUCT_IDS.monthly, productType: 'subs' },
+    })
+    expect(mocks.invalidate).not.toHaveBeenCalled()
+    await expect.element(trial).not.toBeDisabled()
+    expect(view.getByText(/cancelled/).query()).toBeNull()
+  })
+})
+
+describe('PaywallScreen restore mutation', () => {
+  it('shows the no-purchase message for a zero result', async () => {
+    const view = await render(<PaywallScreen />, { wrapper })
+    await expect.element(view.getByRole('button', { name: 'Restore Purchases' })).toBeVisible()
+
+    await view.getByRole('button', { name: 'Restore Purchases' }).click()
+
+    await expect
+      .element(view.getByText('No previous purchase found for this Apple account.'))
+      .toBeVisible()
+    expect(mocks.invalidate).not.toHaveBeenCalled()
+  })
+
+  it('invalidates entitlements after restoring a purchase', async () => {
+    restore = async () => ({ purchases: [{}] })
+    const view = await render(<PaywallScreen />, { wrapper })
+    await expect.element(view.getByRole('button', { name: 'Restore Purchases' })).toBeVisible()
+
+    await view.getByRole('button', { name: 'Restore Purchases' }).click()
+
+    await vi.waitFor(() => expect(mocks.invalidate).toHaveBeenCalledTimes(1))
+    expect(view.getByText(/No previous purchase/).query()).toBeNull()
+  })
+
+  it('shows the existing retry message when restore rejects', async () => {
+    restore = () => Promise.reject(new Error('offline'))
+    const view = await render(<PaywallScreen />, { wrapper })
+    await expect.element(view.getByRole('button', { name: 'Restore Purchases' })).toBeVisible()
+
+    await view.getByRole('button', { name: 'Restore Purchases' }).click()
+
+    await expect
+      .element(view.getByText('Restore failed. Check your connection and try again.'))
+      .toBeVisible()
+    expect(mocks.invalidate).not.toHaveBeenCalled()
+  })
+
+  it('clears an old restore message when a purchase starts', async () => {
+    const pendingPurchase = deferred<null>()
+    purchase = () => pendingPurchase.promise
+    const view = await render(<PaywallScreen />, { wrapper })
+    await expect.element(view.getByRole('button', { name: 'Restore Purchases' })).toBeVisible()
+    await view.getByRole('button', { name: 'Restore Purchases' }).click()
+    await expect
+      .element(view.getByText('No previous purchase found for this Apple account.'))
+      .toBeVisible()
+
+    await view.getByRole('button', { name: 'Start 7-day free trial' }).click()
+
+    expect(view.getByText(/No previous purchase/).query()).toBeNull()
+    pendingPurchase.resolve(null)
+    await vi.waitFor(() => expect(queryClient.isMutating()).toBe(0))
+  })
+
+  it('uses the shared IAP scope and only restore shows progress while restoring', async () => {
+    const pendingRestore = deferred<{ purchases: object[] }>()
+    restore = () => pendingRestore.promise
+    const view = await render(<PaywallScreen />, { wrapper })
+    await expect.element(view.getByRole('button', { name: 'Restore Purchases' })).toBeVisible()
+
+    await view.getByRole('button', { name: 'Restore Purchases' }).click()
+
+    await expect.element(view.getByRole('button', { name: 'Restoring…' })).toBeDisabled()
+    await expect
+      .element(view.getByRole('button', { name: 'Start 7-day free trial' }))
+      .toBeDisabled()
+    expect(view.container.querySelector('button svg.animate-spin')).toBeNull()
+    const activeRestore = queryClient
+      .getMutationCache()
+      .find({ exact: true, mutationKey: mutationKeys.iap.restore })
+    expect(activeRestore?.options.scope?.id).toBe(mutationScopeIds.iapAction)
+
+    pendingRestore.resolve({ purchases: [] })
+    await vi.waitFor(() => expect(queryClient.isMutating()).toBe(0))
   })
 })

--- a/apps/desktop/src/mobile/paywall-screen.tsx
+++ b/apps/desktop/src/mobile/paywall-screen.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactElement } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { Check } from 'lucide-react'
 import { toast } from '@/components/ui/toast'
 import { IAP_PRODUCT_IDS, iapGetProducts, iapPurchase, iapRestorePurchases } from '@reflect/core'
@@ -7,15 +7,22 @@ import appIcon from '@/assets/app-icon.png'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
 import { openUrlSync } from '@/lib/open-url'
-import { queryKeys } from '@/lib/query-client'
+import { mutationKeys, mutationScopeIds, queryKeys } from '@/lib/query-client'
 import { cn } from '@/lib/utils'
 import { PRIVACY_POLICY_URL, TERMS_OF_USE_URL } from '@/mobile/legal-urls'
 import { useActiveSubscription } from '@/mobile/use-active-subscription'
 import { useSettings } from '@/providers/settings-provider'
 
-/** Which control kicked off the in-flight action (onboarding's PendingChoice
- * pattern): every button disables, only the initiator shows progress. */
-type PendingAction = 'monthly' | 'yearly' | 'restore' | null
+type PurchasePlan = 'monthly' | 'yearly'
+
+interface PurchaseVariables {
+  plan: PurchasePlan
+  productId: string
+}
+
+function purchaseProduct(variables: PurchaseVariables): Promise<void> {
+  return iapPurchase(variables.productId)
+}
 
 /** How long "Remind me later" keeps the paywall dismissed. */
 const SNOOZE_MS = 24 * 60 * 60 * 1000
@@ -34,9 +41,7 @@ const MEMBER_STOPGAP_UNTIL = Date.parse('2026-09-11')
 export function PaywallScreen(): ReactElement {
   const subscription = useActiveSubscription()
   const { updateSettings } = useSettings()
-  const [pending, setPending] = useState<PendingAction>(null)
-  const [restoreMessage, setRestoreMessage] = useState<string | null>(null)
-  const [plan, setPlan] = useState<'monthly' | 'yearly'>('yearly')
+  const [plan, setPlan] = useState<PurchasePlan>('yearly')
 
   const products = useQuery({
     queryKey: queryKeys.iap.products,
@@ -54,19 +59,37 @@ export function PaywallScreen(): ReactElement {
       ? `${yearly?.formattedPrice ?? ''}/year`
       : `${monthly?.formattedPrice ?? ''}/month`
 
-  const subscribe = async () => {
+  const purchaseMutation = useMutation({
+    mutationKey: mutationKeys.iap.purchase,
+    scope: { id: mutationScopeIds.iapAction },
+    mutationFn: purchaseProduct,
+    onSuccess: subscription.invalidate,
+  })
+  const restoreMutation = useMutation({
+    mutationKey: mutationKeys.iap.restore,
+    scope: { id: mutationScopeIds.iapAction },
+    mutationFn: iapRestorePurchases,
+    onSuccess: (count) => {
+      if (count > 0) {
+        subscription.invalidate()
+      }
+    },
+  })
+  const actionPending = purchaseMutation.isPending || restoreMutation.isPending
+  const purchasingPlan = purchaseMutation.isPending
+    ? (purchaseMutation.variables?.plan ?? null)
+    : null
+  const restoreMessage = restoreMutation.isError
+    ? 'Restore failed. Check your connection and try again.'
+    : restoreMutation.data === 0
+      ? 'No previous purchase found for this Apple account.'
+      : null
+
+  const subscribe = () => {
     const product = plan === 'yearly' ? yearly : monthly
     if (product === null) return
-    setPending(plan)
-    try {
-      await iapPurchase(product.productId)
-      // The plugin resolves `purchase` without emitting `purchaseUpdated`.
-      subscription.invalidate()
-    } catch {
-      // Cancelled or failed; the StoreKit sheet already told the user.
-    } finally {
-      setPending(null)
-    }
+    restoreMutation.reset()
+    purchaseMutation.mutate({ plan, productId: product.productId })
   }
 
   // Stopgap while reflect.app/claim-reflect-open is not live: members get a
@@ -88,21 +111,9 @@ export function PaywallScreen(): ReactElement {
     updateSettings({ paywallSnoozeUntil: Date.now() + MEMBER_SNOOZE_MS })
   }
 
-  const restore = async () => {
-    setPending('restore')
-    setRestoreMessage(null)
-    try {
-      const count = await iapRestorePurchases()
-      if (count === 0) {
-        setRestoreMessage('No previous purchase found for this Apple account.')
-      } else {
-        subscription.invalidate()
-      }
-    } catch {
-      setRestoreMessage('Restore failed. Check your connection and try again.')
-    } finally {
-      setPending(null)
-    }
+  const restore = () => {
+    purchaseMutation.reset()
+    restoreMutation.mutate()
   }
 
   return (
@@ -150,26 +161,24 @@ export function PaywallScreen(): ReactElement {
                 price={`${yearly.formattedPrice ?? ''} / year`}
                 badge="Best value"
                 selected={plan === 'yearly'}
-                disabled={pending !== null}
+                disabled={actionPending}
                 onSelect={() => setPlan('yearly')}
               />
               <PlanCard
                 title="Monthly"
                 price={`${monthly.formattedPrice ?? ''} / month`}
                 selected={plan === 'monthly'}
-                disabled={pending !== null}
+                disabled={actionPending}
                 onSelect={() => setPlan('monthly')}
               />
             </div>
             <div className="flex flex-col gap-2">
               <Button
                 className="h-12 rounded-xl text-base"
-                disabled={pending !== null}
-                onClick={() => void subscribe()}
+                disabled={actionPending}
+                onClick={subscribe}
               >
-                {pending === 'monthly' || pending === 'yearly' ? (
-                  <Spinner className="size-4" />
-                ) : null}
+                {purchasingPlan !== null ? <Spinner className="size-4" /> : null}
                 Start 7-day free trial
               </Button>
               <p className="text-center text-xs leading-5 text-text-muted">
@@ -185,7 +194,7 @@ export function PaywallScreen(): ReactElement {
           <button
             type="button"
             className="text-sm text-text-secondary underline disabled:opacity-50"
-            disabled={pending !== null}
+            disabled={actionPending}
             onClick={memberContinue}
           >
             Already a Reflect member? Get your first year free
@@ -196,7 +205,7 @@ export function PaywallScreen(): ReactElement {
           <button
             type="button"
             className="text-sm text-text-muted underline disabled:opacity-50"
-            disabled={pending !== null}
+            disabled={actionPending}
             onClick={() => updateSettings({ paywallSnoozeUntil: Date.now() + SNOOZE_MS })}
           >
             Remind me later
@@ -204,10 +213,10 @@ export function PaywallScreen(): ReactElement {
           <button
             type="button"
             className="text-sm text-text-muted underline disabled:opacity-50"
-            disabled={pending !== null}
-            onClick={() => void restore()}
+            disabled={actionPending}
+            onClick={restore}
           >
-            {pending === 'restore' ? 'Restoring…' : 'Restore Purchases'}
+            {restoreMutation.isPending ? 'Restoring…' : 'Restore Purchases'}
           </button>
           {restoreMessage !== null ? (
             <p className="text-center text-sm text-text-muted">{restoreMessage}</p>

--- a/apps/desktop/src/mobile/paywall-screen.tsx
+++ b/apps/desktop/src/mobile/paywall-screen.tsx
@@ -20,10 +20,6 @@ interface PurchaseVariables {
   productId: string
 }
 
-function purchaseProduct(variables: PurchaseVariables): Promise<void> {
-  return iapPurchase(variables.productId)
-}
-
 /** How long "Remind me later" keeps the paywall dismissed. */
 const SNOOZE_MS = 24 * 60 * 60 * 1000
 
@@ -62,7 +58,7 @@ export function PaywallScreen(): ReactElement {
   const purchaseMutation = useMutation({
     mutationKey: mutationKeys.iap.purchase,
     scope: { id: mutationScopeIds.iapAction },
-    mutationFn: purchaseProduct,
+    mutationFn: (variables: PurchaseVariables) => iapPurchase(variables.productId),
     onSuccess: subscription.invalidate,
   })
   const restoreMutation = useMutation({

--- a/apps/desktop/src/mobile/paywall-screen.tsx
+++ b/apps/desktop/src/mobile/paywall-screen.tsx
@@ -41,7 +41,7 @@ const MEMBER_STOPGAP_UNTIL = Date.parse('2026-09-11')
 export function PaywallScreen(): ReactElement {
   const subscription = useActiveSubscription()
   const { updateSettings } = useSettings()
-  const [plan, setPlan] = useState<PurchasePlan>('yearly')
+  const [selectedPlan, setSelectedPlan] = useState<PurchasePlan>('yearly')
 
   const products = useQuery({
     queryKey: queryKeys.iap.products,
@@ -55,7 +55,7 @@ export function PaywallScreen(): ReactElement {
     products.status === 'error' ||
     (products.status === 'success' && (yearly === null || monthly === null))
   const selectedPrice =
-    plan === 'yearly'
+    selectedPlan === 'yearly'
       ? `${yearly?.formattedPrice ?? ''}/year`
       : `${monthly?.formattedPrice ?? ''}/month`
 
@@ -79,17 +79,17 @@ export function PaywallScreen(): ReactElement {
   const purchasingPlan = purchaseMutation.isPending
     ? (purchaseMutation.variables?.plan ?? null)
     : null
-  const restoreMessage = restoreMutation.isError
+  const restoreFeedback = restoreMutation.isError
     ? 'Restore failed. Check your connection and try again.'
     : restoreMutation.data === 0
       ? 'No previous purchase found for this Apple account.'
       : null
 
   const subscribe = () => {
-    const product = plan === 'yearly' ? yearly : monthly
+    const product = selectedPlan === 'yearly' ? yearly : monthly
     if (product === null) return
     restoreMutation.reset()
-    purchaseMutation.mutate({ plan, productId: product.productId })
+    purchaseMutation.mutate({ plan: selectedPlan, productId: product.productId })
   }
 
   // Stopgap while reflect.app/claim-reflect-open is not live: members get a
@@ -160,16 +160,16 @@ export function PaywallScreen(): ReactElement {
                 title="Yearly"
                 price={`${yearly.formattedPrice ?? ''} / year`}
                 badge="Best value"
-                selected={plan === 'yearly'}
+                selected={selectedPlan === 'yearly'}
                 disabled={actionPending}
-                onSelect={() => setPlan('yearly')}
+                onSelect={() => setSelectedPlan('yearly')}
               />
               <PlanCard
                 title="Monthly"
                 price={`${monthly.formattedPrice ?? ''} / month`}
-                selected={plan === 'monthly'}
+                selected={selectedPlan === 'monthly'}
                 disabled={actionPending}
-                onSelect={() => setPlan('monthly')}
+                onSelect={() => setSelectedPlan('monthly')}
               />
             </div>
             <div className="flex flex-col gap-2">
@@ -218,8 +218,8 @@ export function PaywallScreen(): ReactElement {
           >
             {restoreMutation.isPending ? 'Restoring…' : 'Restore Purchases'}
           </button>
-          {restoreMessage !== null ? (
-            <p className="text-center text-sm text-text-muted">{restoreMessage}</p>
+          {restoreFeedback !== null ? (
+            <p className="text-center text-sm text-text-muted">{restoreFeedback}</p>
           ) : null}
         </div>
 

--- a/apps/desktop/src/test-utils/deferred.ts
+++ b/apps/desktop/src/test-utils/deferred.ts
@@ -1,0 +1,15 @@
+export interface Deferred<T> {
+  promise: Promise<T>
+  reject: (error: Error) => void
+  resolve: (value: T) => void
+}
+
+export function deferred<T>(): Deferred<T> {
+  let rejectPromise = (_error: Error): void => {}
+  let resolvePromise = (_value: T): void => {}
+  const promise = new Promise<T>((resolve, reject) => {
+    rejectPromise = reject
+    resolvePromise = resolve
+  })
+  return { promise, reject: rejectPromise, resolve: resolvePromise }
+}


### PR DESCRIPTION
## Summary

- replace agent skill install and uninstall busy/error state with a scoped TanStack mutation
- isolate agent mutation pending/error state by graph and keep graph-switch cache writes race-free
- replace the pinned-note promise chain and mutation counter with serial mutation scope and exact-key failure reconciliation
- model StoreKit purchase and restore as separate mutations sharing one IAP action scope
- add regression coverage for graph switches, queued reorder failures, purchase/restore UI state, and entitlement invalidation

## Testing

- desktop TypeScript typecheck
- full lint
- 5 targeted browser test files, 44 tests
- formatter and changed-file static checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved reliability when installing, updating, or removing agent skills, with clearer pending and error states.
  * Improved pinned-note reordering, including more consistent updates and recovery after interrupted or failed saves.
  * Improved paywall purchase and restore flows with clearer progress, success, and error feedback.
  * Paywall actions are disabled while an operation is in progress to help prevent duplicate actions.
  * Improved subscription and entitlement updates after purchases or restorations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->