### PR TITLE
fix(desktop): add a minimum size to the main window

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -15,6 +15,8 @@
         "title": "Reflect",
         "width": 1300,
         "height": 650,
+        "minWidth": 200,
+        "minHeight": 200,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "dragDropEnabled": false,


### PR DESCRIPTION
Prevent the desktop window from being resized below 200x200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Set minimum desktop window dimensions to 200 × 200 pixels to prevent the app window from becoming unusably small.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->