### PR TITLE
refactor: store hydrated settings in the query cache

### DIFF
--- a/apps/desktop/src/lib/query-client.test.ts
+++ b/apps/desktop/src/lib/query-client.test.ts
@@ -80,7 +80,6 @@ describe('query defaults', () => {
   it.each([
     [queryKeys.index.note('/graph', 'notes/example.md')],
     [queryKeys.chat.conversations('/graph')],
-    [queryKeys.settings.all],
   ])('keeps explicitly invalidated data fresh for %j', (queryKey) => {
     expect(queryClient.defaultQueryOptions({ queryKey }).staleTime).toBe(Infinity)
   })

--- a/apps/desktop/src/lib/query-client.ts
+++ b/apps/desktop/src/lib/query-client.ts
@@ -272,10 +272,9 @@ export const queryClient = new QueryClient({
 })
 
 // SQLite projections and chat history are refreshed by explicit invalidation.
-// Settings is hydrated once, then updated by its provider.
+// Settings load freshness lives with its shared query options.
 queryClient.setQueryDefaults(queryKeys.index.all, { staleTime: Infinity })
 queryClient.setQueryDefaults(queryKeys.chat.all, { staleTime: Infinity })
-queryClient.setQueryDefaults(queryKeys.settings.all, { staleTime: Infinity })
 
 /** Refetch all index-backed queries; called after index rows change. */
 export function invalidateIndexQueries(): void {

--- a/apps/desktop/src/lib/query-options.ts
+++ b/apps/desktop/src/lib/query-options.ts
@@ -5,6 +5,7 @@ import {
   getDuplicateNoteIds,
   listChatConversations,
   listTemplates,
+  loadSettings,
 } from '@reflect/core'
 import { queryKeys } from '@/lib/query-client'
 
@@ -45,5 +46,13 @@ export function createChatConversationsQueryOptions(root: string | undefined) {
   return queryOptions({
     queryKey: queryKeys.chat.conversations(root),
     queryFn: () => listChatConversations(),
+  })
+}
+
+export function createSettingsQueryOptions() {
+  return queryOptions({
+    queryKey: queryKeys.settings.all,
+    queryFn: loadSettings,
+    staleTime: Infinity,
   })
 }

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -1,11 +1,12 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderHook } from 'vitest-browser-react'
-import type { ReactNode } from 'react'
+import { StrictMode, type ReactNode } from 'react'
 import { setBridge, type AiProviderConfig } from '@reflect/core'
 import { resetOperations, useOperations } from '@/lib/operations'
 import { flushSettings } from '@/lib/settings-flush'
 import { queryKeys } from '@/lib/query-client'
+import { createSettingsQueryOptions } from '@/lib/query-options'
 import { SettingsProvider, useSettings } from './settings-provider'
 
 /**
@@ -22,6 +23,7 @@ let failLoad: boolean
 /** When set, `settings_load` blocks until {@link releaseLoad} is called. */
 let pendingLoad: (() => void) | null
 let gateLoad: boolean
+let loadCalls: number
 
 function releaseLoad(): void {
   pendingLoad?.()
@@ -38,6 +40,7 @@ function installFakeBridge(): void {
     invoke: async (command, args) => {
       switch (command) {
         case 'settings_load':
+          loadCalls += 1
           if (failLoad) {
             throw { kind: 'io', message: 'corrupt store' }
           }
@@ -78,6 +81,7 @@ async function loadSettled(): Promise<void> {
 
 beforeEach(() => {
   stored = {}
+  loadCalls = 0
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Infinity } },
   })
@@ -99,8 +103,25 @@ describe('SettingsProvider', () => {
     expect(result.current.settings.editorMarkdownSyntax).toBe('hide')
     releaseLoad()
     await vi.waitFor(() => expect(result.current.settings.editorMarkdownSyntax).toBe('show'))
+    expect(queryClient.getQueryData(queryKeys.settings.all)).toBe(result.current.settings)
     // Hydration alone must not write the store back.
     expect(saved).toEqual([])
+  })
+
+  it('keeps imperative loading pending until the disk read settles', async () => {
+    stored = { editorMarkdownSyntax: 'show' }
+    gateLoad = true
+    await renderHook(() => useSettings(), { wrapper })
+
+    const settled = vi.fn()
+    const loading = queryClient.ensureQueryData(createSettingsQueryOptions())
+    void loading.then(settled)
+    await vi.waitFor(() => expect(pendingLoad).not.toBeNull())
+    expect(settled).not.toHaveBeenCalled()
+
+    releaseLoad()
+    await expect(loading).resolves.toMatchObject({ editorMarkdownSyntax: 'show' })
+    expect(settled).toHaveBeenCalledOnce()
   })
 
   it('normalizes an invalid persisted value to its default', async () => {
@@ -114,6 +135,7 @@ describe('SettingsProvider', () => {
     stored = { allNotesFilterTags: ['book', 'person'] }
     const { result, act } = await renderHook(() => useSettings(), { wrapper })
     await loadSettled()
+    const before = queryClient.getQueryData(queryKeys.settings.all)
 
     // Same value, new instance — a consumer writing back what it read must
     // not count as a change (reference equality would).
@@ -124,6 +146,7 @@ describe('SettingsProvider', () => {
       await flushSettings()
     })
     expect(saved).toEqual([])
+    expect(queryClient.getQueryData(queryKeys.settings.all)).toBe(before)
 
     // A genuinely changed array still persists.
     await act(() => {
@@ -171,6 +194,7 @@ describe('SettingsProvider', () => {
     stored = { graphColors: { '/graphs/work': 'teal' } }
     const { result, act } = await renderHook(() => useSettings(), { wrapper })
     await loadSettled()
+    const before = queryClient.getQueryData(queryKeys.settings.all)
 
     // Same entries, new instance — re-choosing the current color rebuilds the
     // record without changing it; that must not count as a change.
@@ -181,6 +205,7 @@ describe('SettingsProvider', () => {
       await flushSettings()
     })
     expect(saved).toEqual([])
+    expect(queryClient.getQueryData(queryKeys.settings.all)).toBe(before)
 
     // A genuinely changed record still persists.
     await act(() => {
@@ -201,6 +226,7 @@ describe('SettingsProvider', () => {
     })
     // Applied synchronously — plain React state, no IO in the way.
     expect(result.current.settings.editorMarkdownSyntax).toBe('show')
+    expect(queryClient.getQueryData(queryKeys.settings.all)).toBe(result.current.settings)
     // The persisted document keeps unknown keys (newer-version settings survive).
     await vi.waitFor(() =>
       expect(saved).toEqual([
@@ -300,6 +326,28 @@ describe('SettingsProvider', () => {
     expect(result.current.settings.editorMarkdownSyntax).toBe('show')
   })
 
+  it('keeps a simple patch dispatched as the disk query settles', async () => {
+    stored = { editorMarkdownSyntax: 'hide', futureKey: true }
+    gateLoad = true
+    const { result, act } = await renderHook(() => useSettings(), { wrapper })
+    const loading = queryClient.ensureQueryData(createSettingsQueryOptions())
+    void loading.then(() => {
+      result.current.updateSettings({ editorMarkdownSyntax: 'show' })
+    })
+
+    await act(async () => {
+      releaseLoad()
+      await loading
+    })
+    await vi.waitFor(() => expect(result.current.settings.editorMarkdownSyntax).toBe('show'))
+    expect(queryClient.getQueryData(queryKeys.settings.all)).toBe(result.current.settings)
+    await vi.waitFor(() =>
+      expect(saved).toEqual([
+        expect.objectContaining({ editorMarkdownSyntax: 'show', futureKey: true }),
+      ]),
+    )
+  })
+
   it('compounding updates racing the initial load flush as one document', async () => {
     stored = { editorMarkdownSyntax: 'show' }
     gateLoad = true
@@ -373,6 +421,50 @@ describe('SettingsProvider', () => {
       }))
     })
     expect(result.current.settings.aiProviders).toEqual([])
+    expect(queryClient.getQueryData(queryKeys.settings.all)).toBe(result.current.settings)
+  })
+
+  it('merges disk, preload patches, and queued updaters in order', async () => {
+    const persisted: AiProviderConfig = {
+      id: 'a',
+      provider: 'openai',
+      model: 'gpt-5.1',
+      keyHint: '11111',
+    }
+    const added: AiProviderConfig = {
+      id: 'b',
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      keyHint: '22222',
+    }
+    stored = { aiProviders: [persisted], futureKey: true }
+    gateLoad = true
+    const { result, act } = await renderHook(() => useSettings(), { wrapper })
+
+    await act(() => {
+      result.current.updateSettings({ editorMarkdownSyntax: 'show' })
+      result.current.updateSettingsWith((current) => ({
+        aiProviders: [...current.aiProviders, added],
+      }))
+      result.current.updateSettingsWith((current) => ({
+        aiProviders: current.aiProviders.filter((provider) => provider.id !== persisted.id),
+      }))
+    })
+    expect(result.current.settings.editorMarkdownSyntax).toBe('show')
+    expect(result.current.settings.aiProviders).toEqual([])
+
+    await act(() => releaseLoad())
+    await vi.waitFor(() => expect(result.current.settings.aiProviders).toEqual([added]))
+    expect(queryClient.getQueryData(queryKeys.settings.all)).toBe(result.current.settings)
+    await vi.waitFor(() =>
+      expect(saved).toEqual([
+        expect.objectContaining({
+          editorMarkdownSyntax: 'show',
+          aiProviders: [added],
+          futureKey: true,
+        }),
+      ]),
+    )
   })
 
   it('a read-modify-write racing the initial load replays over the loaded document', async () => {
@@ -420,6 +512,10 @@ describe('SettingsProvider', () => {
     }
     failLoad = true
     const { result, act } = await renderHook(() => useSettings(), { wrapper })
+    await vi.waitFor(() =>
+      expect(queryClient.getQueryState(queryKeys.settings.all)?.status).toBe('error'),
+    )
+    const loadError = queryClient.getQueryState(queryKeys.settings.all)?.error
 
     await act(() => {
       result.current.updateSettingsWith((current) => ({
@@ -433,6 +529,9 @@ describe('SettingsProvider', () => {
       await flushSettings()
     })
     expect(saved).toEqual([])
+    expect(queryClient.getQueryState(queryKeys.settings.all)?.status).toBe('error')
+    expect(queryClient.getQueryState(queryKeys.settings.all)?.error).toBe(loadError)
+    expect(queryClient.getQueryData(queryKeys.settings.all)).toBeUndefined()
   })
 
   it('with no bridge (browser dev) the load settles as failed instead of hanging', async () => {
@@ -604,5 +703,34 @@ describe('SettingsProvider', () => {
       await flushSettings()
     })
     expect(saved).toEqual([])
+  })
+
+  it('does not repeat load, updater drain, or save in StrictMode', async () => {
+    const added: AiProviderConfig = {
+      id: 'b',
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      keyHint: '22222',
+    }
+    gateLoad = true
+    const strictWrapper = ({ children }: { children: ReactNode }) => (
+      <StrictMode>
+        <QueryClientProvider client={queryClient}>
+          <SettingsProvider>{children}</SettingsProvider>
+        </QueryClientProvider>
+      </StrictMode>
+    )
+    const { result, act } = await renderHook(() => useSettings(), { wrapper: strictWrapper })
+
+    await act(() => {
+      result.current.updateSettingsWith((current) => ({
+        aiProviders: [...current.aiProviders, added],
+      }))
+      releaseLoad()
+    })
+    await vi.waitFor(() => expect(result.current.settings.aiProviders).toEqual([added]))
+    await vi.waitFor(() => expect(saved).toHaveLength(1))
+    expect(loadCalls).toBe(1)
+    expect(saved[0]).toMatchObject({ aiProviders: [added] })
   })
 })

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -9,22 +9,12 @@ import {
   type ReactElement,
   type ReactNode,
 } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { DEFAULT_SETTINGS, saveSettings, errorMessage, type Settings } from '@reflect/core'
 import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { startOperation } from '@/lib/operations'
 import { createSettingsQueryOptions } from '@/lib/query-options'
 import { setSettingsFlusher } from '@/lib/settings-flush'
-
-/**
- * App-wide user settings (config-dir JSON, not graph state), applied instantly.
- *
- * The design is hydration + overrides: the query reads the disk document once
- * and is never written afterwards; session updates accumulate in local state
- * and win over whatever the load returns **by construction**. There is no
- * optimistic cache write to defend, so an update racing the initial load needs
- * no cancellation or re-apply — the merge order is the whole story.
- */
 
 interface SettingsContextValue {
   settings: Settings
@@ -55,6 +45,7 @@ interface SettingsContextValue {
 export type SettingsLoadOutcome = 'loaded' | 'failed'
 
 type SettingsLoadState = SettingsLoadOutcome | 'pending'
+type SettingsUpdater = (current: Settings) => Partial<Settings>
 
 const SettingsContext = createContext<SettingsContextValue | null>(null)
 
@@ -71,184 +62,45 @@ function createLoadSettle(): LoadSettle {
   return { promise, resolve }
 }
 
-/**
- * One settings value equals another: identity, element-wise for arrays
- * (`allNotesFilterTags`; `aiProviders` holds plain config objects, compared as
- * JSON below), or key-wise for plain-object records (`graphColors`, whose
- * values are scalars). Reference equality alone would make an equal-but-
- * rebuilt value (a re-parse — the schema transforms rebuild arrays and
- * records on every parse — or a no-op update) read as a change and trigger
- * spurious saves.
- */
-function sameValue(a: unknown, b: unknown): boolean {
-  if (Object.is(a, b)) {
-    return true
-  }
-  if (Array.isArray(a) || Array.isArray(b)) {
-    return (
-      Array.isArray(a) &&
-      Array.isArray(b) &&
-      a.length === b.length &&
-      a.every((item, index) => sameItem(item, b[index]))
-    )
-  }
-  if (isRecord(a) && isRecord(b)) {
-    const aKeys = Object.keys(a)
-    const bKeys = Object.keys(b)
-    return aKeys.length === bKeys.length && aKeys.every((key) => sameItem(a[key], b[key]))
-  }
-  return false
-}
-
-/** A plain-object record (not an array, not null). */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-/** One array element equals another: identity for scalars, JSON for objects. */
-function sameItem(a: unknown, b: unknown): boolean {
-  if (Object.is(a, b)) {
-    return true
-  }
-  if (typeof a === 'object' && a !== null && typeof b === 'object' && b !== null) {
-    return JSON.stringify(a) === JSON.stringify(b)
-  }
-  return false
-}
-
-/** Own-key equality over the flat settings document. */
-function sameDocument(a: Settings, b: Settings): boolean {
-  const aKeys = Object.keys(a)
-  const bKeys = Object.keys(b)
-  return aKeys.length === bKeys.length && aKeys.every((key) => sameValue(a[key], b[key]))
-}
-
 interface SettingsProviderProps {
   children: ReactNode
 }
 
 export function SettingsProvider({ children }: SettingsProviderProps): ReactElement {
   const bridgeReady = useBridgeReady()
-  const { data: loaded, error: loadError } = useQuery({
-    ...createSettingsQueryOptions(),
+  const queryClient = useQueryClient()
+  const queryOptions = createSettingsQueryOptions()
+  const settingsQuery = useQuery({
+    ...queryOptions,
     enabled: bridgeReady,
   })
-  const [overrides, setOverrides] = useState<Partial<Settings>>({})
-  const loadedRef = useRef(loaded)
-  useEffect(() => {
-    loadedRef.current = loaded
-  })
+  const [preloadPatch, setPreloadPatch] = useState<Partial<Settings>>({})
+  const preloadPatchRef = useRef<Partial<Settings>>({})
+  const pendingUpdaters = useRef<SettingsUpdater[] | null>([])
+  const [loadState, setLoadState] = useState<SettingsLoadState>('pending')
+  const loadStateRef = useRef<SettingsLoadState>('pending')
+  const [sessionSettings, setSessionSettings] = useState<Settings | null>(null)
+  const diskSettings = useRef<Settings | null>(null)
+  const settingsRef = useRef<Settings>(DEFAULT_SETTINGS)
 
-  // One derived load-state drives everything that waits on hydration (the
-  // updater queue drain, the settle promise). With no bridge installed
-  // (plain-browser dev) the query never runs, so there is nothing to wait
-  // for: that settles immediately as 'failed' — i.e. session-only — instead
-  // of leaving waiters hanging on a load that will never happen.
-  const loadState: SettingsLoadState =
-    !bridgeReady || loadError !== null ? 'failed' : loaded !== undefined ? 'loaded' : 'pending'
-
-  // Defaults are usable before the IPC load settles — no loading gate.
-  const settings = useMemo<Settings>(
-    () => ({ ...DEFAULT_SETTINGS, ...loaded, ...overrides }),
-    [loaded, overrides],
-  )
-
-  const updateSettings = useCallback((patch: Partial<Settings>) => {
-    setOverrides((current) => ({ ...current, ...patch }))
-  }, [])
-
-  const applyUpdater = useCallback((updater: (current: Settings) => Partial<Settings>) => {
-    setOverrides((current) => {
-      // Rebuild the merged document from the *queued* overrides, not the
-      // render-time `settings` value — React applies these updaters in
-      // order, so each one sees the result of the previous edit even when
-      // both were dispatched from stale closures.
-      const merged: Settings = { ...DEFAULT_SETTINGS, ...loadedRef.current, ...current }
-      return { ...current, ...updater(merged) }
-    })
-  }, [])
-
-  // Read-modify-write trails hydration, like persistence does: an updater
-  // applied over defaults would compute its patch from a list the disk
-  // document is about to supply (an early "add" would then override — and on
-  // the next save erase — every persisted entry). `null` marks the queue as
-  // drained; from then on updaters apply directly.
-  const pendingUpdaters = useRef<((current: Settings) => Partial<Settings>)[] | null>([])
-
-  const updateSettingsWith = useCallback(
-    (updater: (current: Settings) => Partial<Settings>) => {
-      if (pendingUpdaters.current !== null) {
-        pendingUpdaters.current.push(updater)
-        return
-      }
-      applyUpdater(updater)
-    },
-    [applyUpdater],
-  )
-
-  useEffect(() => {
-    // Drain once the load settles either way — after 'failed' the updaters
-    // apply over defaults and changes stay session-only, matching the
-    // scalar-update semantics below.
-    if (loadState === 'pending' || pendingUpdaters.current === null) {
-      return
-    }
-    const queued = pendingUpdaters.current
-    pendingUpdaters.current = null
-    for (const updater of queued) {
-      applyUpdater(updater)
-    }
-  }, [loadState, applyUpdater])
-
-  // Settling the load outcome as a promise lets callers *await* it; resolving
-  // an already-resolved promise is a no-op, so the effect can stay simple.
   const loadSettle = useRef<LoadSettle | null>(null)
   if (loadSettle.current === null) {
     loadSettle.current = createLoadSettle()
   }
-  useEffect(() => {
-    if (loadState !== 'pending') {
-      loadSettle.current?.resolve(loadState)
-    }
-  }, [loadState])
   const whenSettingsLoaded = useCallback(
     (): Promise<SettingsLoadOutcome> => loadSettle.current?.promise ?? Promise.resolve('failed'),
     [],
   )
 
-  // A corrupt store fails the load *by design* (Rust errors rather than
-  // reading empty, so a later save can't wipe the real document). Changes
-  // then apply for the session only — surface that state, don't hide it.
-  const loadErrorSurfaced = useRef(false)
-  useEffect(() => {
-    if (loadError && !loadErrorSurfaced.current) {
-      loadErrorSurfaced.current = true
-      startOperation('Loading settings').fail(errorMessage(loadError))
-    }
-  }, [loadError])
-
-  // Persistence trails hydration. Nothing is written before the disk document
-  // has been read — a save built from defaults would drop passthrough keys a
-  // newer app version wrote — and the full merged document is saved so those
-  // keys survive. `lastPersisted` is the last document *confirmed* on disk
-  // (hydration, or a successful save): a failed write leaves it untouched, so
-  // the next change or the quit flush retries the difference. Writes are
-  // chained so they reach disk in apply order.
   const persistQueue = useRef<Promise<void>>(Promise.resolve())
   const lastPersisted = useRef<Settings | null>(null)
-  const settingsRef = useRef(settings)
-  useEffect(() => {
-    settingsRef.current = settings
-  })
-
-  const persistIfChanged = useCallback((): Promise<void> => {
-    const disk = loadedRef.current
-    if (disk === undefined) {
-      return persistQueue.current // never write over an unread store
+  const persistIfChanged = useCallback((target = settingsRef.current): Promise<void> => {
+    const disk = diskSettings.current
+    if (disk === null) {
+      return persistQueue.current
     }
-    const target = settingsRef.current
     const confirmed = lastPersisted.current ?? disk
-    if (sameDocument(target, confirmed)) {
+    if (target === confirmed) {
       lastPersisted.current = confirmed
       return persistQueue.current
     }
@@ -257,21 +109,131 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
       .then(() => {
         lastPersisted.current = target
       })
-      .catch((error: unknown) => {
-        // The in-memory value stays applied and `lastPersisted` still points
-        // at the confirmed disk document, so the difference is retried later.
-        // The failure is product status, not console noise.
+      .catch((error) => {
         startOperation('Saving settings').fail(errorMessage(error))
       })
     return persistQueue.current
   }, [])
 
-  useEffect(() => {
-    void persistIfChanged()
-  }, [loaded, settings, persistIfChanged])
+  const setLoadedSettings = useCallback(
+    (updater: (current: Settings) => Settings): void => {
+      const next = queryClient.setQueryData(queryOptions.queryKey, (current) =>
+        current === undefined ? current : updater(current),
+      )
+      if (next !== undefined) {
+        settingsRef.current = next
+        void persistIfChanged(next)
+      }
+    },
+    [persistIfChanged, queryClient, queryOptions.queryKey],
+  )
 
-  // Quit-time persistence (window close, ⌘Q, reload): installQuitFlush drains
-  // this provider's queue — and retries anything unconfirmed — before exit.
+  const updateSettings = useCallback(
+    (patch: Partial<Settings>): void => {
+      if (loadStateRef.current === 'pending') {
+        preloadPatchRef.current = { ...preloadPatchRef.current, ...patch }
+        setPreloadPatch(preloadPatchRef.current)
+        return
+      }
+      if (loadStateRef.current === 'loaded') {
+        setLoadedSettings((current) => ({ ...current, ...patch }))
+        return
+      }
+      setSessionSettings((current) => {
+        const next = { ...(current ?? DEFAULT_SETTINGS), ...patch }
+        settingsRef.current = next
+        return next
+      })
+    },
+    [setLoadedSettings],
+  )
+
+  const updateSettingsWith = useCallback(
+    (updater: SettingsUpdater): void => {
+      if (loadStateRef.current === 'pending') {
+        pendingUpdaters.current?.push(updater)
+        return
+      }
+      if (loadStateRef.current === 'loaded') {
+        setLoadedSettings((current) => ({ ...current, ...updater(current) }))
+        return
+      }
+      setSessionSettings((current) => {
+        const base = current ?? DEFAULT_SETTINGS
+        const next = { ...base, ...updater(base) }
+        settingsRef.current = next
+        return next
+      })
+    },
+    [setLoadedSettings],
+  )
+
+  useEffect(() => {
+    if (loadStateRef.current !== 'pending') {
+      return
+    }
+
+    let outcome: SettingsLoadOutcome
+    let current: Settings
+    if (settingsQuery.isSuccess) {
+      outcome = 'loaded'
+      diskSettings.current = settingsQuery.data
+      current = { ...settingsQuery.data, ...preloadPatchRef.current }
+    } else if (!bridgeReady || settingsQuery.isError) {
+      outcome = 'failed'
+      current = { ...DEFAULT_SETTINGS, ...preloadPatchRef.current }
+    } else {
+      return
+    }
+
+    const queued = pendingUpdaters.current ?? []
+    pendingUpdaters.current = null
+    for (const updater of queued) {
+      current = { ...current, ...updater(current) }
+    }
+
+    if (outcome === 'loaded') {
+      current = queryClient.setQueryData(queryOptions.queryKey, current) ?? current
+    } else {
+      setSessionSettings(current)
+    }
+    settingsRef.current = current
+    loadStateRef.current = outcome
+    setLoadState(outcome)
+    preloadPatchRef.current = {}
+    setPreloadPatch({})
+    loadSettle.current?.resolve(outcome)
+    if (outcome === 'loaded') {
+      void persistIfChanged(current)
+    }
+  }, [
+    bridgeReady,
+    persistIfChanged,
+    queryClient,
+    queryOptions.queryKey,
+    settingsQuery.data,
+    settingsQuery.isError,
+    settingsQuery.isSuccess,
+  ])
+
+  const settings = useMemo<Settings>(() => {
+    if (loadState === 'loaded') {
+      return settingsQuery.data ?? settingsRef.current
+    }
+    if (loadState === 'failed') {
+      return sessionSettings ?? settingsRef.current
+    }
+    return { ...DEFAULT_SETTINGS, ...preloadPatch }
+  }, [loadState, preloadPatch, sessionSettings, settingsQuery.data])
+
+  const loadErrorSurfaced = useRef(false)
+  useEffect(() => {
+    if (settingsQuery.error && !loadErrorSurfaced.current) {
+      loadErrorSurfaced.current = true
+      startOperation('Loading settings').fail(errorMessage(settingsQuery.error))
+    }
+  }, [settingsQuery.error])
+
   useEffect(() => {
     setSettingsFlusher(persistIfChanged)
     return () => setSettingsFlusher(null)

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -91,6 +91,11 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
     (): Promise<SettingsLoadOutcome> => loadSettle.current?.promise ?? Promise.resolve('failed'),
     [],
   )
+  useEffect(() => {
+    if (loadState !== 'pending') {
+      loadSettle.current?.resolve(loadState)
+    }
+  }, [loadState])
 
   const persistQueue = useRef<Promise<void>>(Promise.resolve())
   const lastPersisted = useRef<Settings | null>(null)
@@ -202,7 +207,6 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
     setLoadState(outcome)
     preloadPatchRef.current = {}
     setPreloadPatch({})
-    loadSettle.current?.resolve(outcome)
     if (outcome === 'loaded') {
       void persistIfChanged(current)
     }

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -10,16 +10,10 @@ import {
   type ReactNode,
 } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import {
-  DEFAULT_SETTINGS,
-  loadSettings,
-  saveSettings,
-  errorMessage,
-  type Settings,
-} from '@reflect/core'
+import { DEFAULT_SETTINGS, saveSettings, errorMessage, type Settings } from '@reflect/core'
 import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { startOperation } from '@/lib/operations'
-import { queryKeys } from '@/lib/query-client'
+import { createSettingsQueryOptions } from '@/lib/query-options'
 import { setSettingsFlusher } from '@/lib/settings-flush'
 
 /**
@@ -136,8 +130,7 @@ interface SettingsProviderProps {
 export function SettingsProvider({ children }: SettingsProviderProps): ReactElement {
   const bridgeReady = useBridgeReady()
   const { data: loaded, error: loadError } = useQuery({
-    queryKey: queryKeys.settings.all,
-    queryFn: loadSettings,
+    ...createSettingsQueryOptions(),
     enabled: bridgeReady,
   })
   const [overrides, setOverrides] = useState<Partial<Settings>>({})

--- a/apps/desktop/src/providers/use-mobile-graph-boot.ts
+++ b/apps/desktop/src/providers/use-mobile-graph-boot.ts
@@ -4,7 +4,6 @@ import {
   createGraph,
   errorMessage,
   isMobilePlatform,
-  loadSettings,
   mobileStorage,
   mobileStorageLocal,
   type AppPlatform,
@@ -12,7 +11,7 @@ import {
   type MobileStorageKind,
 } from '@reflect/core'
 import { takeWarmMobileStorage } from '@/lib/mobile-boot-warm'
-import { queryKeys } from '@/lib/query-client'
+import { createSettingsQueryOptions } from '@/lib/query-options'
 import { useSettings } from '@/providers/settings-provider'
 
 /** The graph directory created in the container for a fresh start — reads as
@@ -179,10 +178,7 @@ export function useMobileGraphBoot(options: MobileGraphBootOptions): MobileGraph
         // before the mobile chunk was even fetched — so this reads the
         // in-flight (usually settled) load instead of issuing a second
         // settings_load round trip.
-        const settings = await queryClient.ensureQueryData({
-          queryKey: queryKeys.settings.all,
-          queryFn: loadSettings,
-        })
+        const settings = await queryClient.ensureQueryData(createSettingsQueryOptions())
         if (!active) {
           return
         }

--- a/docs/contributing/adding-a-setting.md
+++ b/docs/contributing/adding-a-setting.md
@@ -61,9 +61,9 @@ const { settings, updateSettings, updateSettingsWith } = useSettings()
 
 Semantics you get for free from the provider (and must not re-implement):
 
-- **Instant apply.** `updateSettings` merges into local state immediately;
-  defaults are usable before the disk load settles, so there is no loading
-  gate to handle.
+- **Instant simple patches.** `updateSettings` applies over defaults while the
+  disk load is pending. After hydration, it updates the current document in the
+  TanStack Query cache.
 - **Async, ordered persistence.** Writes are chained in apply order, trail
   hydration (nothing is written before the disk document has been read), and
   save the full merged document. Failures surface through the operations
@@ -73,10 +73,17 @@ Semantics you get for free from the provider (and must not re-implement):
   dispatched before hydration are queued and replayed over the loaded
   document, so an early edit cannot accidentally compute from defaults and
   wipe the stored value.
+- **One runtime document.** After a successful load, `useSettings()` and
+  imperative readers of `queryKeys.settings.all` observe the same Query cache
+  document. The settings JSON remains the durable source, and the provider's
+  ordered persistence queue writes cache updates back to it.
 - **Load-sensitive side effects must await hydration.** If a settings entry is
   paired with state elsewhere (for example an OS-keychain secret), call
   `whenSettingsLoaded()` before writing the other half. If the initial load
   failed, settings are session-only and the paired write would be stranded.
+- **Load failure is session-only.** Simple and functional updates still apply
+  over defaults for the current session, but the provider never writes over an
+  unreadable or corrupt settings document.
 - **No save button.** Settings apply live — design your control accordingly.
 
 ## 3. Add the control


### PR DESCRIPTION
## Summary

- centralize settings load query options for hook and imperative consumers
- store the hydrated runtime settings document in the TanStack Query cache
- preserve pre-hydration updates and the existing ordered persistence queue
- remove custom settings deep-equality helpers in favor of structural sharing
- document the pre-hydration and session-only contracts

## Testing

- `pnpm check`
- `pnpm --filter @reflect/desktop test --run src/providers/settings-provider.test.tsx src/providers/theme-provider.test.tsx src/providers/graph-provider.test.tsx src/components/settings-screen.test.tsx src/lib/query-client.test.ts` (102 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved settings loading and updates during startup, including queued changes and failed-load scenarios.
  - Prevented duplicate settings loads, updates, and saves in development mode.
  - Kept settings synchronized across the app and reduced unnecessary persistence.

- **Documentation**
  - Clarified settings hydration, caching, immediate updates, and session-only behavior when loading fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->