### PR TITLE
chore: macOS 26 window-state probe build (do not merge)

### DIFF
--- a/.github/workflows/window-probe.yml
+++ b/.github/workflows/window-probe.yml
@@ -1,0 +1,80 @@
+name: Window probe (macOS arm64)
+
+# TEMPORARY: builds the unsigned "Reflect Probe" macOS arm64 app from the
+# probe-window-state-macos26 branch and keeps it as a workflow artifact, so
+# the macOS 26 window-collapse bug can be investigated on a machine that
+# reproduces it. Never merged; see apps/desktop/scripts/window-probe/README.md.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [probe-window-state-macos26]
+
+permissions:
+  contents: read
+
+jobs:
+  macos-probe:
+    name: Build macOS arm64 probe app (unsigned)
+    runs-on: macos-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Install Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          cache-on-failure: true
+
+      # ort-sys extracts prebuilt ONNX Runtime binaries outside target/; see
+      # the same step in ci.yml. dirs::cache_dir on macOS is ~/Library/Caches.
+      - name: Cache ONNX Runtime binaries
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/Library/Caches/ort.pyke.io
+          key: ort-bin-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ort-bin-${{ runner.os }}-
+
+      - name: Ensure ort cache dir exists
+        run: mkdir -p ~/Library/Caches/ort.pyke.io
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # No signing secrets on purpose: the .app is unsigned (the linker's
+      # ad-hoc signature only); run.sh clears quarantine and re-signs ad-hoc
+      # on the test machine. The Tauri CLI JS entry point is invoked directly
+      # because pnpm mangles the --config argument (see release-windows.mjs).
+      - name: Build probe app
+        working-directory: apps/desktop
+        run: node node_modules/@tauri-apps/cli/tauri.js build --bundles app --config src-tauri/tauri.probe.conf.json
+
+      - name: Package artifact
+        run: |
+          mkdir -p "$RUNNER_TEMP/probe-artifact"
+          ditto -c -k --keepParent "target/release/bundle/macos/Reflect Probe.app" "$RUNNER_TEMP/probe-artifact/Reflect-Probe.app.zip"
+          cp apps/desktop/scripts/window-probe/run.sh "$RUNNER_TEMP/probe-artifact/"
+          cp apps/desktop/scripts/window-probe/README.md "$RUNNER_TEMP/probe-artifact/"
+
+      - name: Upload probe artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: reflect-window-probe-macos-arm64
+          path: ${{ runner.temp }}/probe-artifact/*
+          if-no-files-found: error
+          retention-days: 90

--- a/apps/desktop/scripts/window-probe/README.md
+++ b/apps/desktop/scripts/window-probe/README.md
@@ -1,0 +1,38 @@
+# Window probe (macOS 26 window-collapse investigation)
+
+A user on macOS 26 ended up with `~/Library/Application Support/app.reflect.desktop.beta/.window-state.json` containing a 2x2-pixel main window, which makes Reflect restore an invisible window on every launch. The collapse itself has not been reproduced yet; this probe build collects, in one automated run on a macOS 26 machine, the data needed to reproduce it end to end and to decide whether the frame collapse comes from AppKit (Apple bug) or from the tao/tauri layer.
+
+This branch is never merged. The probe app is a normal Reflect build plus:
+
+- full window-geometry logging (`src-tauri/src/window_probe.rs`): every resize/move event and every geometry change is recorded twice, once as tao/tauri sees it and once as raw AppKit reports it (NSWindow frame, contentView frame, contentRect, styleMask, isZoomed, occlusion, screen frames), plus a dump at the exact exit moment where the window-state plugin reads what it persists;
+- a scenario runner that replays updater-style relaunch cycles (zoom, un-zoom races, hide, minimize, fullscreen, tiling) driven by a plan file;
+- its own identity (`Reflect Probe`, `app.reflect.desktop.probe`), so it never touches a real Reflect install, and no `minWidth`/`minHeight` on the window, so nothing masks the bug;
+- a neutered updater endpoint, so the probe can never update itself away.
+
+## Running the probe (on the macOS 26 test machine)
+
+1. Download the `reflect-window-probe-macos-arm64` artifact from the "Window probe (macOS arm64)" GitHub Actions run and unzip it. It contains `Reflect-Probe.app.zip`, `run.sh`, and this README.
+2. In Terminal, from the unzipped folder:
+
+   ```bash
+   chmod +x run.sh && ./run.sh Reflect-Probe.app.zip
+   ```
+
+3. When macOS asks for permission for Terminal to control **System Events**, click Allow. This lets the script drive real window tiling through the app's Window menu, which is the one suspect that cannot be triggered programmatically.
+4. Leave the machine alone for about five minutes. The window opens, moves, tiles, and relaunches repeatedly; that is the test.
+5. When the script prints `DONE`, send back the `reflect-window-probe-<timestamp>.zip` it created on the Desktop.
+
+The zip contains the full event log (`probe.log`, one JSON object per line), every distinct version of `.window-state.json` the run produced (`state-history/`), the driver's own log, and machine info (`sw_vers`, display configuration, WindowManager tiling defaults).
+
+Extra useful passes, if there is time:
+
+- Run `./run.sh Reflect-Probe.app.zip` again with a different display setup (external monitor attached or detached, different scaling).
+- Open `Reflect Probe.app` by hand and use it like the real app for a while (tile it, zoom it, quit from tiled/zoomed states, let it sit); all logging is always on. Then run `./run.sh --collect-only` to zip whatever was recorded.
+
+## Reading the results
+
+Search `probe.log` for `"tag":"anomaly:` lines: they mark any moment either layer reported a dimension under 300 physical pixels. Each carries the paired `tao` and `appkit` snapshots:
+
+- `appkit.frame` / `appkit.contentViewFrame` collapsed too: AppKit itself set a degenerate frame (Apple bug; the record shows exactly which window-arrangement state, `styleMask`, `isZoomed`, and screen it happened under).
+- `appkit` sane but `tao.innerSize` tiny: the collapse is in the tao/tauri layer.
+- `state-file:changed` records show precisely which exit persisted a degenerate size.

--- a/apps/desktop/scripts/window-probe/run.sh
+++ b/apps/desktop/scripts/window-probe/run.sh
@@ -108,10 +108,32 @@ done
 PLAN
 echo 0 >"$PROBE_DIR/progress.txt"
 
+# Record the actual Window menu structure once: the injected tiling item
+# names vary across macOS 26 point releases, and the exact names on the
+# machine that reproduces the bug are themselves useful data.
+dump_window_menu() {
+  osascript >>"$DRIVER_LOG" 2>&1 <<EOF
+tell application "System Events"
+  tell process "$PROCESS_NAME"
+    set frontmost to true
+    delay 0.4
+    get name of every menu item of menu "Window" of menu bar 1
+  end tell
+end tell
+EOF
+  osascript >>"$DRIVER_LOG" 2>&1 <<EOF
+tell application "System Events"
+  tell process "$PROCESS_NAME"
+    try
+      get name of every menu item of menu 1 of menu item "Move & Resize" of menu "Window" of menu bar 1
+    end try
+  end tell
+end tell
+EOF
+}
+
 # One tiling attempt: try each candidate menu item under the app's Window
-# menu until one clicks. macOS injects the tiling items into every app's
-# Window menu, but their names vary across macOS 26 point releases, so we
-# probe a list. Requires the Automation permission (System Events).
+# menu until one clicks. Requires the Automation permission (System Events).
 tile_action() {
   local label="$1"; shift
   for item in "$@"; do
@@ -136,7 +158,7 @@ EOF
     log "tile[$label] $result"
     case "$result" in ok*) return 0 ;; esac
   done
-  log "tile[$label] all candidates failed (Automation permission missing, or menu names differ; dump the Window menu with probe-menu.sh if present)"
+  log "tile[$label] all candidates failed (Automation permission missing, or menu names differ; see the menu dump above)"
   return 1
 }
 
@@ -163,6 +185,7 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
   if [ -f "$PROBE_DIR/phase" ]; then
     PHASE_COUNT=$((PHASE_COUNT + 1))
     log "wait-user phase $PHASE_COUNT: driving window tiling"
+    [ "$PHASE_COUNT" = 1 ] && dump_window_menu
     run_tile_phase "$PHASE_COUNT"
     touch "$PROBE_DIR/continue"
     # Wait for the app to consume the signal before polling again.

--- a/apps/desktop/scripts/window-probe/run.sh
+++ b/apps/desktop/scripts/window-probe/run.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Automated data-collection run for the macOS 26 window-collapse bug.
+#
+# Usage:
+#   ./run.sh "Reflect-Probe.app.zip"   # or the unzipped "Reflect Probe.app"
+#   ./run.sh --collect-only            # just zip logs from an earlier run
+#
+# What it does: unpacks/prepares the probe app, seeds a scenario plan, then
+# launches the app, which relaunches itself through every scenario exactly
+# like the auto-updater does. During the three "wait-user" phases this
+# script drives REAL macOS window tiling through the app's Window menu via
+# System Events (grant the Automation permission when macOS asks). At the
+# end everything is zipped to the Desktop; send that zip back.
+#
+# The run takes about five minutes and flashes windows the whole time; do
+# not use the machine for anything else while it runs.
+
+set -u
+
+CONFIG_DIR="$HOME/Library/Application Support/app.reflect.desktop.probe"
+PROBE_DIR="$CONFIG_DIR/window-probe"
+STATE_FILE="$CONFIG_DIR/.window-state.json"
+OUT_ZIP="$HOME/Desktop/reflect-window-probe-$(date +%Y%m%d-%H%M%S).zip"
+PROCESS_NAME="Reflect Probe"
+DRIVER_LOG="$PROBE_DIR/driver.log"
+
+log() {
+  echo "[probe] $*"
+  echo "$(date '+%H:%M:%S') $*" >>"$DRIVER_LOG" 2>/dev/null
+}
+
+collect() {
+  log "collecting results into $OUT_ZIP"
+  local staging
+  staging=$(mktemp -d)
+  mkdir -p "$staging/collected"
+  cp -R "$PROBE_DIR" "$staging/collected/window-probe" 2>/dev/null
+  cp "$STATE_FILE" "$staging/collected/window-state.final.json" 2>/dev/null
+  sw_vers >"$staging/collected/sw_vers.txt" 2>&1
+  system_profiler SPDisplaysDataType >"$staging/collected/displays.txt" 2>&1
+  defaults read com.apple.WindowManager >"$staging/collected/windowmanager-defaults.txt" 2>&1
+  uname -a >"$staging/collected/uname.txt" 2>&1
+  if [ -n "${APP_PATH:-}" ]; then
+    codesign -dvv "$APP_PATH" >"$staging/collected/codesign.txt" 2>&1
+  fi
+  (cd "$staging" && zip -qr "$OUT_ZIP" collected)
+  rm -rf "$staging"
+  log "DONE. Please send back: $OUT_ZIP"
+}
+
+if [ "${1:-}" = "--collect-only" ]; then
+  APP_PATH=""
+  collect
+  exit 0
+fi
+
+APP_INPUT="${1:-Reflect-Probe.app.zip}"
+if [[ "$APP_INPUT" == *.zip ]]; then
+  UNPACK_DIR=$(mktemp -d)
+  ditto -x -k "$APP_INPUT" "$UNPACK_DIR" || { echo "cannot unzip $APP_INPUT"; exit 1; }
+  APP_PATH="$UNPACK_DIR/Reflect Probe.app"
+else
+  APP_PATH="$APP_INPUT"
+fi
+[ -d "$APP_PATH" ] || { echo "app not found at $APP_PATH"; exit 1; }
+
+mkdir -p "$PROBE_DIR"
+log "using app: $APP_PATH"
+
+# Fresh probe state: keep nothing from earlier runs so every log line in the
+# zip belongs to this run.
+osascript -e "tell application \"$PROCESS_NAME\" to quit" >/dev/null 2>&1
+sleep 1
+rm -rf "$PROBE_DIR"
+rm -f "$STATE_FILE"
+mkdir -p "$PROBE_DIR"
+
+# The artifact is unsigned: clear quarantine and re-seal ad-hoc so
+# Gatekeeper lets it launch.
+xattr -dr com.apple.quarantine "$APP_PATH" 2>/dev/null
+codesign --force --deep -s - "$APP_PATH" 2>/dev/null
+
+# The scenario chain. Every line is one app launch; the app relaunches
+# itself between lines through the same code path the auto-updater uses.
+# "wait-user" pauses for this script, which performs real tiling actions.
+cat >"$PROBE_DIR/plan.txt" <<'PLAN'
+plain
+plain
+zoom
+zoom            # relaunch restores maximized:true onto a hidden window
+unzoom
+zoom
+unzoom-race
+zoom-race
+hidden
+minimized
+fullscreen
+fullscreen-exit-race
+plain
+wait-user       # driver tiles the window LEFT, then the app exits tiled
+plain
+wait-user       # driver FILLS the window, then the app exits filled
+plain
+wait-user       # driver un-tiles (Return to Previous Size), racing the exit
+plain
+plain
+done
+PLAN
+echo 0 >"$PROBE_DIR/progress.txt"
+
+# One tiling attempt: try each candidate menu item under the app's Window
+# menu until one clicks. macOS injects the tiling items into every app's
+# Window menu, but their names vary across macOS 26 point releases, so we
+# probe a list. Requires the Automation permission (System Events).
+tile_action() {
+  local label="$1"; shift
+  for item in "$@"; do
+    result=$(osascript 2>>"$DRIVER_LOG" <<EOF
+tell application "System Events"
+  tell process "$PROCESS_NAME"
+    set frontmost to true
+    delay 0.4
+    try
+      click menu item "$item" of menu 1 of menu item "Move & Resize" of menu "Window" of menu bar 1
+      return "ok submenu: $item"
+    end try
+    try
+      click menu item "$item" of menu "Window" of menu bar 1
+      return "ok direct: $item"
+    end try
+    return "miss: $item"
+  end tell
+end tell
+EOF
+    )
+    log "tile[$label] $result"
+    case "$result" in ok*) return 0 ;; esac
+  done
+  log "tile[$label] all candidates failed (Automation permission missing, or menu names differ; dump the Window menu with probe-menu.sh if present)"
+  return 1
+}
+
+# Phase K of wait-user: perform the K-th tiling choreography.
+run_tile_phase() {
+  case "$1" in
+    1) tile_action "left" "Left" "Left Half" "﻿Left" ;;
+    2) tile_action "fill" "Fill" "Fill Screen" ;;
+    3) tile_action "revert" "Return to Previous Size" "Revert" "Restore" ;;
+  esac
+  sleep 2
+}
+
+log "launching probe app; the window will open and close repeatedly"
+open -n "$APP_PATH" || { echo "failed to launch"; exit 1; }
+
+PHASE_COUNT=0
+DEADLINE=$(( $(date +%s) + 900 ))
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  if [ -f "$PROBE_DIR/done" ]; then
+    log "plan complete"
+    break
+  fi
+  if [ -f "$PROBE_DIR/phase" ]; then
+    PHASE_COUNT=$((PHASE_COUNT + 1))
+    log "wait-user phase $PHASE_COUNT: driving window tiling"
+    run_tile_phase "$PHASE_COUNT"
+    touch "$PROBE_DIR/continue"
+    # Wait for the app to consume the signal before polling again.
+    for _ in $(seq 1 40); do
+      [ -f "$PROBE_DIR/phase" ] || break
+      sleep 0.5
+    done
+  fi
+  sleep 1
+done
+[ -f "$PROBE_DIR/done" ] || log "WARNING: timed out before the plan finished; collecting what exists"
+
+sleep 2
+osascript -e "tell application \"$PROCESS_NAME\" to quit" >/dev/null 2>&1
+sleep 1
+collect

--- a/apps/desktop/scripts/window-probe/run.sh
+++ b/apps/desktop/scripts/window-probe/run.sh
@@ -143,7 +143,7 @@ EOF
 # Phase K of wait-user: perform the K-th tiling choreography.
 run_tile_phase() {
   case "$1" in
-    1) tile_action "left" "Left" "Left Half" "﻿Left" ;;
+    1) tile_action "left" "Left" "Left Half" ;;
     2) tile_action "fill" "Fill" "Fill Screen" ;;
     3) tile_action "revert" "Return to Previous Size" "Revert" "Restore" ;;
   esac

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -88,6 +88,7 @@ objc2-foundation = { version = "0.3.2", default-features = false, features = [
   "NSDate",
   "NSEnumerator",
   "NSError",
+  "NSGeometry",
   "NSNotification",
   "NSObject",
   "NSOperation",
@@ -113,8 +114,13 @@ objc2-app-kit = { version = "0.3.2", default-features = false, features = [
   "NSColor",
   "NSColorSpace",
   "NSEvent",
+  "NSGraphics",
   "NSMenu",
   "NSMenuItem",
+  "NSResponder",
+  "NSScreen",
+  "NSView",
+  "NSWindow",
   "NSWorkspace",
 ] }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -51,6 +51,9 @@ mod watcher;
 #[cfg(mobile)]
 #[path = "watcher_mobile.rs"]
 mod watcher;
+// PROBE: temporary instrumentation for the macOS 26 window-collapse bug.
+#[cfg(desktop)]
+mod window_probe;
 
 use tauri::{Emitter, Manager};
 
@@ -179,6 +182,9 @@ pub fn run() {
     let builder = builder
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        // PROBE: must stay registered before window-state so the boot record
+        // captures the state file before the plugin's setup reads it.
+        .plugin(window_probe::init())
         .plugin(
             // Note windows are excluded from state tracking: they cascade
             // fresh from their opener, and their content-hashed labels would
@@ -187,7 +193,9 @@ pub fn run() {
                 .with_state_flags(windows::restorable_window_state_flags())
                 .with_filter(|label| !label.starts_with(windows::NOTE_WINDOW_PREFIX))
                 .build(),
-        );
+        )
+        // PROBE: log every window event with a paired tao + AppKit dump.
+        .on_window_event(window_probe::on_window_event);
 
     // Reveal the main window on `PageLoadEvent::Finished`, not on
     // `RunEvent::Ready`. Ready only guarantees plugin init + window-state
@@ -388,7 +396,11 @@ pub fn run() {
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(move |app, event| match &event {
+        .run(move |app, event| {
+            // PROBE: run-loop milestones, including the exit-moment dump.
+            #[cfg(desktop)]
+            window_probe::on_run_event(app, &event);
+            match &event {
             // Ready no longer reveals the main window — the page-load hook
             // above does, once the webview has painted. It is still the first
             // point where the window and an app handle both exist, so arm the
@@ -499,5 +511,6 @@ pub fn run() {
                 }
             }
             _ => {}
+            }
         });
 }

--- a/apps/desktop/src-tauri/src/window_probe.rs
+++ b/apps/desktop/src-tauri/src/window_probe.rs
@@ -1,0 +1,495 @@
+//! TEMPORARY window-geometry probe for the macOS 26 "2x2 main window" bug.
+//! This module ships only in the `probe-window-state-macos26` branch and is
+//! never merged: it exists to collect, on a macOS 26 machine, every piece of
+//! data needed to decide whether the frame collapse is produced by AppKit
+//! (window/view frame really goes to ~1pt) or by the tao/tauri layer (AppKit
+//! reports a sane frame while tao reports a tiny one).
+//!
+//! What it records, all into `<app-config-dir>/window-probe/`:
+//!
+//! - `probe.log`: one JSON object per line. Boot info (OS build, AppKit
+//!   version, monitors, raw state file), every window event (`Resized`,
+//!   `Moved`, close/destroy/focus/scale), a 250ms sampler that logs on any
+//!   geometry change, run-loop events (`Ready`, `ExitRequested`, `Exit`),
+//!   and a full dump at exit. Every geometry record carries both the
+//!   tao-level view (`inner_size`, `outer_position`, ...) and the raw
+//!   AppKit view (NSWindow frame, contentView frame, contentRect, styleMask,
+//!   isZoomed, occlusion, screen frames), captured on the main thread.
+//! - `state-history/<ms>.json`: a copy of `.window-state.json` every time
+//!   its content changes.
+//!
+//! A scenario runner replays the exit/restore cycles that surround the bug
+//! (updater-style relaunches via `request_restart`, zoom, un-zoom races,
+//! hide, minimize, fullscreen, and externally-driven tiling phases). It is
+//! driven by `window-probe/plan.txt` (one scenario per line, `#` comments);
+//! without a plan the app just logs while being used by hand. See
+//! `apps/desktop/scripts/window-probe/README.md`.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde_json::{json, Value};
+use tauri::plugin::{Builder as PluginBuilder, TauriPlugin};
+use tauri::{AppHandle, Manager, RunEvent, Runtime, WindowEvent};
+
+const MAIN_WINDOW: &str = "main";
+/// Hard cap on chained relaunches, so a bad plan can never leave the tester
+/// with an app that restarts itself forever.
+const MAX_LAUNCHES: u64 = 200;
+/// Physical pixels; any observed dimension below this triggers a full dump
+/// tagged "anomaly".
+const ANOMALY_PX: u32 = 300;
+
+fn now_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}
+
+fn probe_dir<R: Runtime>(app: &AppHandle<R>) -> Option<PathBuf> {
+    let dir = app.path().app_config_dir().ok()?.join("window-probe");
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir)
+}
+
+fn state_file<R: Runtime>(app: &AppHandle<R>) -> Option<PathBuf> {
+    Some(
+        app.path()
+            .app_config_dir()
+            .ok()?
+            .join(tauri_plugin_window_state::DEFAULT_FILENAME),
+    )
+}
+
+pub fn log_record<R: Runtime>(app: &AppHandle<R>, tag: &str, mut record: Value) {
+    let Some(dir) = probe_dir(app) else { return };
+    if let Some(map) = record.as_object_mut() {
+        map.insert("t".into(), json!(now_ms() as u64));
+        map.insert("pid".into(), json!(std::process::id()));
+        map.insert("tag".into(), json!(tag));
+    }
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join("probe.log"))
+    {
+        let _ = writeln!(f, "{record}");
+    }
+}
+
+/// The tao/tauri view of the main window's geometry. Callable from any
+/// thread (the getters proxy to the event loop).
+fn tao_snapshot<R: Runtime>(window: &tauri::WebviewWindow<R>) -> Value {
+    json!({
+        "innerSize": window.inner_size().map(|s| [s.width, s.height]).ok(),
+        "outerSize": window.outer_size().map(|s| [s.width, s.height]).ok(),
+        "outerPosition": window.outer_position().map(|p| [p.x, p.y]).ok(),
+        "scaleFactor": window.scale_factor().ok(),
+        "maximized": window.is_maximized().ok(),
+        "minimized": window.is_minimized().ok(),
+        "fullscreen": window.is_fullscreen().ok(),
+        "visible": window.is_visible().ok(),
+        "focused": window.is_focused().ok(),
+    })
+}
+
+#[cfg(target_os = "macos")]
+mod appkit {
+    use objc2_app_kit::NSWindow;
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+    use serde_json::{json, Value};
+    use tauri::Runtime;
+
+    fn rect(r: NSRect) -> Value {
+        json!([r.origin.x, r.origin.y, r.size.width, r.size.height])
+    }
+
+    fn size(s: NSSize) -> Value {
+        json!([s.width, s.height])
+    }
+
+    fn point(p: NSPoint) -> Value {
+        json!([p.x, p.y])
+    }
+
+    /// The raw AppKit view of the same window. MUST run on the main thread;
+    /// callers go through `run_on_main_thread` or an event-loop callback.
+    pub fn snapshot<R: Runtime>(window: &tauri::WebviewWindow<R>) -> Value {
+        let Ok(ptr) = window.ns_window() else {
+            return json!({ "error": "no ns_window" });
+        };
+        let ns: &NSWindow = unsafe { &*ptr.cast::<NSWindow>() };
+        let frame = ns.frame();
+        let content_rect = ns.contentRectForFrameRect(frame);
+        let content_view = ns.contentView().map(|view| rect(view.frame()));
+        let screen = ns.screen().map(|screen| {
+            json!({
+                "frame": rect(screen.frame()),
+                "visibleFrame": rect(screen.visibleFrame()),
+                "backingScaleFactor": screen.backingScaleFactor(),
+            })
+        });
+        json!({
+            "frame": rect(frame),
+            "frameOrigin": point(frame.origin),
+            "contentRect": rect(content_rect),
+            "contentViewFrame": content_view,
+            "styleMask": ns.styleMask().0,
+            "isZoomed": ns.isZoomed(),
+            "isMiniaturized": ns.isMiniaturized(),
+            "isVisible": ns.isVisible(),
+            "isOnActiveSpace": ns.isOnActiveSpace(),
+            "isKeyWindow": ns.isKeyWindow(),
+            "occlusionState": ns.occlusionState().0,
+            "backingScaleFactor": ns.backingScaleFactor(),
+            "contentMinSize": size(ns.contentMinSize()),
+            "contentMaxSize": size(ns.contentMaxSize()),
+            "screen": screen,
+        })
+    }
+}
+
+/// Full dump (tao + AppKit). Must run on the main thread on macOS.
+fn full_dump_on_main<R: Runtime>(app: &AppHandle<R>, tag: &str, extra: Value) {
+    let Some(window) = app.get_webview_window(MAIN_WINDOW) else {
+        log_record(app, tag, json!({ "window": null, "extra": extra }));
+        return;
+    };
+    #[cfg(target_os = "macos")]
+    let appkit = appkit::snapshot(&window);
+    #[cfg(not(target_os = "macos"))]
+    let appkit = Value::Null;
+    log_record(
+        app,
+        tag,
+        json!({ "tao": tao_snapshot(&window), "appkit": appkit, "extra": extra }),
+    );
+}
+
+fn schedule_full_dump<R: Runtime>(app: &AppHandle<R>, tag: &'static str, extra: Value) {
+    let handle = app.clone();
+    let _ = app.run_on_main_thread(move || full_dump_on_main(&handle, tag, extra));
+}
+
+/// Wire-up for `Builder::on_window_event`. Events arrive on the event loop
+/// thread, so the AppKit dump is taken inline for geometry events.
+pub fn on_window_event<R: Runtime>(window: &tauri::Window<R>, event: &WindowEvent) {
+    let app = window.app_handle();
+    let label = window.label().to_owned();
+    match event {
+        WindowEvent::Resized(size) => {
+            log_record(
+                app,
+                "event:resized",
+                json!({ "label": label, "size": [size.width, size.height] }),
+            );
+            if label == MAIN_WINDOW {
+                let anomaly = size.width < ANOMALY_PX || size.height < ANOMALY_PX;
+                full_dump_on_main(
+                    app,
+                    if anomaly {
+                        "anomaly:resized"
+                    } else {
+                        "dump:resized"
+                    },
+                    json!({ "size": [size.width, size.height] }),
+                );
+            }
+        }
+        WindowEvent::Moved(position) => {
+            log_record(
+                app,
+                "event:moved",
+                json!({ "label": label, "position": [position.x, position.y] }),
+            );
+            if label == MAIN_WINDOW {
+                full_dump_on_main(app, "dump:moved", json!(null));
+            }
+        }
+        WindowEvent::CloseRequested { .. } => {
+            log_record(app, "event:close-requested", json!({ "label": label }));
+        }
+        WindowEvent::Destroyed => {
+            log_record(app, "event:destroyed", json!({ "label": label }));
+        }
+        WindowEvent::Focused(focused) => {
+            log_record(
+                app,
+                "event:focused",
+                json!({ "label": label, "focused": focused }),
+            );
+        }
+        WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+            log_record(
+                app,
+                "event:scale-changed",
+                json!({ "label": label, "scaleFactor": scale_factor }),
+            );
+        }
+        _ => {}
+    }
+}
+
+/// Wire-up for the `Builder::run` callback: logs run-loop milestones and
+/// takes the exit-moment dump (the exact read the window-state plugin
+/// persists happens during `RunEvent::Exit`).
+pub fn on_run_event<R: Runtime>(app: &AppHandle<R>, event: &RunEvent) {
+    match event {
+        RunEvent::Ready => {
+            log_record(app, "run:ready", json!(null));
+            full_dump_on_main(app, "dump:ready", json!(null));
+        }
+        RunEvent::ExitRequested { code, .. } => {
+            log_record(app, "run:exit-requested", json!({ "code": code }));
+        }
+        RunEvent::Exit => {
+            // Same thread and moment as the plugin's own exit-time read.
+            full_dump_on_main(app, "dump:exit", json!(null));
+            if let Some(path) = state_file(app) {
+                let content = std::fs::read_to_string(path).ok();
+                log_record(
+                    app,
+                    "state-file:at-exit-before-save",
+                    json!({ "content": content }),
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
+fn os_version() -> Value {
+    let read = |args: &[&str]| -> Option<String> {
+        let out = std::process::Command::new("sw_vers")
+            .args(args)
+            .output()
+            .ok()?;
+        Some(String::from_utf8_lossy(&out.stdout).trim().to_owned())
+    };
+    json!({
+        "productVersion": read(&["-productVersion"]),
+        "buildVersion": read(&["-buildVersion"]),
+    })
+}
+
+fn monitors<R: Runtime>(app: &AppHandle<R>) -> Value {
+    match app.available_monitors() {
+        Ok(list) => json!(list
+            .iter()
+            .map(|monitor| {
+                json!({
+                    "name": monitor.name(),
+                    "size": [monitor.size().width, monitor.size().height],
+                    "position": [monitor.position().x, monitor.position().y],
+                    "scaleFactor": monitor.scale_factor(),
+                })
+            })
+            .collect::<Vec<_>>()),
+        Err(err) => json!({ "error": err.to_string() }),
+    }
+}
+
+/// Counts this launch and returns the number of launches so far.
+fn count_launch<R: Runtime>(app: &AppHandle<R>) -> u64 {
+    let Some(dir) = probe_dir(app) else { return 0 };
+    let path = dir.join("launches.txt");
+    let n: u64 = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0)
+        + 1;
+    let _ = std::fs::write(&path, n.to_string());
+    n
+}
+
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    PluginBuilder::new("window-probe")
+        .setup(|app, _api| {
+            let handle = app.clone();
+            let launches = count_launch(&handle);
+            #[cfg(target_os = "macos")]
+            let appkit_version = unsafe { objc2_app_kit::NSAppKitVersionNumber };
+            #[cfg(not(target_os = "macos"))]
+            let appkit_version = 0.0;
+            let state = state_file(&handle).and_then(|p| std::fs::read_to_string(p).ok());
+            log_record(
+                &handle,
+                "boot",
+                json!({
+                    "appVersion": handle.package_info().version.to_string(),
+                    "tauriVersion": tauri::VERSION,
+                    "pinnedCrates": "tao 0.35.3 / wry 0.55.1 / tauri-plugin-window-state 2.4.1 (Cargo.lock)",
+                    "os": os_version(),
+                    "appKitVersion": appkit_version,
+                    "monitors": monitors(&handle),
+                    "launches": launches,
+                    "args": std::env::args().collect::<Vec<_>>(),
+                    "stateFileBeforeRestore": state,
+                }),
+            );
+            if launches > MAX_LAUNCHES {
+                log_record(&handle, "abort", json!({ "reason": "launch cap reached" }));
+                handle.exit(0);
+                return Ok(());
+            }
+            spawn_sampler(handle.clone());
+            spawn_scenario_runner(handle);
+            Ok(())
+        })
+        .build()
+}
+
+/// Every 250ms: log a full dump when the tao-level geometry changed, and
+/// archive `.window-state.json` whenever its content changed.
+fn spawn_sampler<R: Runtime>(app: AppHandle<R>) {
+    std::thread::spawn(move || {
+        let mut last_geometry = String::new();
+        let mut last_state = String::new();
+        loop {
+            std::thread::sleep(Duration::from_millis(250));
+            if let Some(window) = app.get_webview_window(MAIN_WINDOW) {
+                let snapshot = tao_snapshot(&window);
+                let serialized = snapshot.to_string();
+                if serialized != last_geometry {
+                    last_geometry = serialized;
+                    let inner = window.inner_size().ok();
+                    let anomaly = inner
+                        .map(|s| s.width < ANOMALY_PX || s.height < ANOMALY_PX)
+                        .unwrap_or(false);
+                    schedule_full_dump(
+                        &app,
+                        if anomaly {
+                            "anomaly:sampler"
+                        } else {
+                            "dump:sampler"
+                        },
+                        json!(null),
+                    );
+                }
+            }
+            if let Some(path) = state_file(&app) {
+                if let Ok(content) = std::fs::read_to_string(&path) {
+                    if content != last_state {
+                        last_state = content.clone();
+                        log_record(&app, "state-file:changed", json!({ "content": content }));
+                        if let Some(dir) = probe_dir(&app) {
+                            let history = dir.join("state-history");
+                            let _ = std::fs::create_dir_all(&history);
+                            let _ =
+                                std::fs::write(history.join(format!("{}.json", now_ms())), content);
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+fn spawn_scenario_runner<R: Runtime>(app: AppHandle<R>) {
+    std::thread::spawn(move || run_scenario(app));
+}
+
+/// One scenario per launch: read `plan.txt`, execute the step at
+/// `progress.txt`, advance it, then relaunch (the same
+/// `AppHandle::request_restart` path the updater uses) or exit.
+fn run_scenario<R: Runtime>(app: AppHandle<R>) {
+    let Some(dir) = probe_dir(&app) else { return };
+    let Ok(plan) = std::fs::read_to_string(dir.join("plan.txt")) else {
+        log_record(&app, "plan", json!({ "mode": "manual (no plan.txt)" }));
+        return;
+    };
+    let steps: Vec<&str> = plan
+        .lines()
+        .map(|line| line.split('#').next().unwrap_or("").trim())
+        .filter(|line| !line.is_empty())
+        .collect();
+    let progress: usize = std::fs::read_to_string(dir.join("progress.txt"))
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0);
+    let Some(step) = steps.get(progress).copied() else {
+        log_record(&app, "plan", json!({ "done": true }));
+        let _ = std::fs::write(dir.join("done"), "done");
+        app.exit(0);
+        return;
+    };
+    let _ = std::fs::write(dir.join("progress.txt"), (progress + 1).to_string());
+    log_record(
+        &app,
+        "scenario:start",
+        json!({ "step": step, "index": progress }),
+    );
+
+    // Let the page-load reveal and the window-state restore settle first.
+    std::thread::sleep(Duration::from_millis(1500));
+    let window = app.get_webview_window(MAIN_WINDOW);
+    let act = |action: &str, result: tauri::Result<()>| {
+        log_record(
+            &app,
+            "scenario:action",
+            json!({ "action": action, "error": result.err().map(|e| e.to_string()) }),
+        );
+    };
+    let mut restart = true;
+    match (step, window) {
+        ("plain", _) => std::thread::sleep(Duration::from_millis(700)),
+        ("zoom", Some(w)) => {
+            act("maximize", w.maximize());
+            std::thread::sleep(Duration::from_millis(1200));
+        }
+        ("zoom-race", Some(w)) => act("maximize", w.maximize()),
+        ("unzoom", Some(w)) => {
+            act("unmaximize", w.unmaximize());
+            std::thread::sleep(Duration::from_millis(1200));
+        }
+        ("unzoom-race", Some(w)) => act("unmaximize", w.unmaximize()),
+        ("hidden", Some(w)) => {
+            act("hide", w.hide());
+            std::thread::sleep(Duration::from_millis(1000));
+        }
+        ("minimized", Some(w)) => {
+            act("minimize", w.minimize());
+            std::thread::sleep(Duration::from_millis(1000));
+        }
+        ("fullscreen", Some(w)) => {
+            act("fullscreen", w.set_fullscreen(true));
+            std::thread::sleep(Duration::from_millis(2000));
+        }
+        ("fullscreen-exit-race", Some(w)) => {
+            act("fullscreen", w.set_fullscreen(true));
+            std::thread::sleep(Duration::from_millis(2000));
+            act("unfullscreen", w.set_fullscreen(false));
+            std::thread::sleep(Duration::from_millis(250));
+        }
+        ("wait-user", _) => {
+            // An external driver (or a human) acts on the window now; the
+            // run.sh script performs real tiling here. Continue on signal.
+            let _ = std::fs::write(dir.join("phase"), "waiting-user");
+            let deadline = SystemTime::now() + Duration::from_secs(300);
+            while !dir.join("continue").exists() && SystemTime::now() < deadline {
+                std::thread::sleep(Duration::from_millis(300));
+            }
+            let _ = std::fs::remove_file(dir.join("continue"));
+            let _ = std::fs::remove_file(dir.join("phase"));
+        }
+        ("done", _) => {
+            let _ = std::fs::write(dir.join("done"), "done");
+            restart = false;
+        }
+        (other, _) => {
+            log_record(&app, "scenario:unknown", json!({ "step": other }));
+        }
+    }
+    log_record(
+        &app,
+        "scenario:end",
+        json!({ "step": step, "restart": restart }),
+    );
+    if restart {
+        app.request_restart();
+    } else {
+        app.exit(0);
+    }
+}

--- a/apps/desktop/src-tauri/tauri.probe.conf.json
+++ b/apps/desktop/src-tauri/tauri.probe.conf.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Reflect Probe",
+  "identifier": "app.reflect.desktop.probe",
+  "app": {
+    "windows": [
+      {
+        "title": "Reflect Probe",
+        "width": 1300,
+        "height": 650,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "dragDropEnabled": false,
+        "visible": false
+      }
+    ]
+  },
+  "bundle": {
+    "icon": [
+      "icons-dev/32x32.png",
+      "icons-dev/128x128.png",
+      "icons-dev/128x128@2x.png",
+      "icons-dev/icon.icns",
+      "icons-dev/icon.ico"
+    ],
+    "macOS": {
+      "entitlements": "Entitlements.dev.plist",
+      "files": {
+        "embedded.provisionprofile": null
+      }
+    }
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/team-reflect/reflect-open/releases/download/updater-probe-noop/latest.json"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Instrumented build for reproducing the macOS 26 window-collapse bug on a test machine: the "Window probe (macOS arm64)" workflow uploads an unsigned arm64 `Reflect Probe.app` plus a driver script, and `apps/desktop/scripts/window-probe/README.md` explains the automated data-collection run.