### PR TITLE
refactor: persist settings with scoped mutations

### DIFF
--- a/apps/desktop/src/lib/query-options.ts
+++ b/apps/desktop/src/lib/query-options.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from '@tanstack/react-query'
+import { mutationOptions, queryOptions } from '@tanstack/react-query'
 import {
   dailyDatesInRange,
   getConflictedNotes,
@@ -6,8 +6,9 @@ import {
   listChatConversations,
   listTemplates,
   loadSettings,
+  saveSettings,
 } from '@reflect/core'
-import { queryKeys } from '@/lib/query-client'
+import { mutationKeys, mutationScopeIds, queryKeys } from '@/lib/query-client'
 
 /** Conflicted-note rows shared by every sync status and settings surface. */
 export function createConflictedNotesQueryOptions(root: string | undefined) {
@@ -54,5 +55,14 @@ export function createSettingsQueryOptions() {
     queryKey: queryKeys.settings.all,
     queryFn: loadSettings,
     staleTime: Infinity,
+  })
+}
+
+export function createSettingsSaveMutationOptions() {
+  return mutationOptions({
+    mutationKey: mutationKeys.settings.save,
+    mutationFn: saveSettings,
+    scope: { id: mutationScopeIds.settingsSave },
+    retry: 0,
   })
 }

--- a/apps/desktop/src/lib/query-options.ts
+++ b/apps/desktop/src/lib/query-options.ts
@@ -57,7 +57,6 @@ export function createSettingsQueryOptions() {
     staleTime: Infinity,
   })
 }
-
 export function createSettingsSaveMutationOptions() {
   return mutationOptions({
     mutationKey: mutationKeys.settings.save,

--- a/apps/desktop/src/providers/settings-provider.test.tsx
+++ b/apps/desktop/src/providers/settings-provider.test.tsx
@@ -2,11 +2,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderHook } from 'vitest-browser-react'
 import { StrictMode, type ReactNode } from 'react'
-import { setBridge, type AiProviderConfig } from '@reflect/core'
+import { setBridge, type AiProviderConfig, type Settings } from '@reflect/core'
 import { resetOperations, useOperations } from '@/lib/operations'
 import { flushSettings } from '@/lib/settings-flush'
-import { queryKeys } from '@/lib/query-client'
+import { mutationKeys, mutationScopeIds, queryKeys } from '@/lib/query-client'
 import { createSettingsQueryOptions } from '@/lib/query-options'
+import { deferred, type Deferred } from '@/test-utils/deferred'
 import { SettingsProvider, useSettings } from './settings-provider'
 
 /**
@@ -17,13 +18,16 @@ import { SettingsProvider, useSettings } from './settings-provider'
  */
 
 let stored: Record<string, unknown>
-let saved: unknown[]
+let saved: Settings[]
 let failSaves: boolean
 let failLoad: boolean
 /** When set, `settings_load` blocks until {@link releaseLoad} is called. */
 let pendingLoad: (() => void) | null
 let gateLoad: boolean
 let loadCalls: number
+let gateSaves: boolean
+let pendingSaves: Deferred<void>[]
+let saveAttempts: Settings[]
 
 function releaseLoad(): void {
   pendingLoad?.()
@@ -35,7 +39,10 @@ function installFakeBridge(): void {
   failSaves = false
   failLoad = false
   gateLoad = false
+  gateSaves = false
   pendingLoad = null
+  pendingSaves = []
+  saveAttempts = []
   setBridge({
     invoke: async (command, args) => {
       switch (command) {
@@ -51,10 +58,17 @@ function installFakeBridge(): void {
           }
           return stored
         case 'settings_save':
-          if (failSaves) {
+          saveAttempts.push(args['settings'] as Settings)
+          const shouldFail = failSaves
+          if (gateSaves) {
+            const pending = deferred<void>()
+            pendingSaves.push(pending)
+            await pending.promise
+          }
+          if (shouldFail) {
             throw { kind: 'io', message: 'disk full' }
           }
-          saved.push(args['settings'])
+          saved.push(args['settings'] as Settings)
           return null
         default:
           return null
@@ -83,7 +97,10 @@ beforeEach(() => {
   stored = {}
   loadCalls = 0
   queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    defaultOptions: {
+      mutations: { networkMode: 'always' },
+      queries: { retry: false, staleTime: Infinity },
+    },
   })
   installFakeBridge()
 })
@@ -265,6 +282,63 @@ describe('SettingsProvider', () => {
         },
       ]),
     )
+  })
+
+  it('uses the shared settings mutation key, scope, and retry policy', async () => {
+    const { result, act } = await renderHook(() => useSettings(), { wrapper })
+    await loadSettled()
+    await expect(result.current.whenSettingsLoaded()).resolves.toBe('loaded')
+
+    await act(() => {
+      result.current.updateSettings({ editorMarkdownSyntax: 'show' })
+    })
+    await vi.waitFor(() => expect(saved).toHaveLength(1))
+
+    const mutation = queryClient.getMutationCache().getAll().at(-1)
+    expect(mutation?.options).toMatchObject({
+      mutationKey: mutationKeys.settings.save,
+      networkMode: 'always',
+      retry: 0,
+      scope: { id: mutationScopeIds.settingsSave },
+    })
+  })
+
+  it('serializes rapid saves and leaves disk equal to the query cache', async () => {
+    const { result, act } = await renderHook(() => useSettings(), { wrapper })
+    await loadSettled()
+    await expect(result.current.whenSettingsLoaded()).resolves.toBe('loaded')
+    gateSaves = true
+
+    await act(() => {
+      result.current.updateSettings({ editorMarkdownSyntax: 'show' })
+    })
+    await vi.waitFor(() => expect(saveAttempts).toHaveLength(1))
+    expect(saveAttempts[0]).toMatchObject({
+      editorFullWidth: false,
+      editorMarkdownSyntax: 'show',
+    })
+
+    let flushed = false
+    await act(async () => {
+      const flushing = flushSettings().then(() => {
+        flushed = true
+      })
+      result.current.updateSettings({ editorFullWidth: true })
+      expect(saveAttempts).toHaveLength(1)
+      pendingSaves[0]?.resolve()
+      await vi.waitFor(() => expect(saveAttempts).toHaveLength(2))
+      expect(flushed).toBe(false)
+      pendingSaves[1]?.resolve()
+      await flushing
+    })
+    expect(saveAttempts[1]).toMatchObject({
+      editorFullWidth: true,
+      editorMarkdownSyntax: 'show',
+    })
+
+    expect(flushed).toBe(true)
+    expect(saved).toEqual(saveAttempts)
+    expect(saved.at(-1)).toBe(queryClient.getQueryData(queryKeys.settings.all))
   })
 
   it('an update racing the initial load wins and keeps passthrough keys', async () => {
@@ -532,6 +606,7 @@ describe('SettingsProvider', () => {
     expect(queryClient.getQueryState(queryKeys.settings.all)?.status).toBe('error')
     expect(queryClient.getQueryState(queryKeys.settings.all)?.error).toBe(loadError)
     expect(queryClient.getQueryData(queryKeys.settings.all)).toBeUndefined()
+    expect(queryClient.getMutationCache().getAll()).toHaveLength(0)
   })
 
   it('with no bridge (browser dev) the load settles as failed instead of hanging', async () => {
@@ -548,6 +623,7 @@ describe('SettingsProvider', () => {
     })
     expect(result.current.settings.editorMarkdownSyntax).toBe('show')
     expect(saved).toEqual([])
+    expect(queryClient.getMutationCache().getAll()).toHaveLength(0)
   })
 
   it('keeps the applied value and surfaces a failed save as an operation', async () => {
@@ -556,6 +632,7 @@ describe('SettingsProvider', () => {
       { wrapper },
     )
     await loadSettled()
+    await expect(result.current.whenSettingsLoaded()).resolves.toBe('loaded')
 
     failSaves = true
     await act(() => {
@@ -583,8 +660,7 @@ describe('SettingsProvider', () => {
     await vi.waitFor(() => expect(result.current.operations).toHaveLength(1))
     expect(saved).toEqual([])
 
-    // Disk recovered; re-applying the same value must re-attempt the write —
-    // `lastPersisted` only advances on a *confirmed* save.
+    // Disk recovered; dirty state makes the same value re-attempt the write.
     failSaves = false
     await act(() => {
       result.current.updateSettings({ editorMarkdownSyntax: 'show' })
@@ -625,6 +701,41 @@ describe('SettingsProvider', () => {
         },
       ]),
     )
+  })
+
+  it('continues a queued save after an earlier save fails', async () => {
+    const { result, act } = await renderHook(
+      () => ({ ...useSettings(), operations: useOperations() }),
+      { wrapper },
+    )
+    await loadSettled()
+    await expect(result.current.whenSettingsLoaded()).resolves.toBe('loaded')
+    failSaves = true
+    gateSaves = true
+
+    await act(() => {
+      result.current.updateSettings({ editorMarkdownSyntax: 'show' })
+    })
+    await vi.waitFor(() => expect(saveAttempts).toHaveLength(1))
+    await act(() => {
+      result.current.updateSettings({ editorFullWidth: true })
+    })
+    expect(saveAttempts).toHaveLength(1)
+
+    failSaves = false
+    pendingSaves[0]?.resolve()
+    await vi.waitFor(() => expect(saveAttempts).toHaveLength(2))
+    pendingSaves[1]?.resolve()
+    await act(async () => {
+      await flushSettings()
+    })
+
+    expect(result.current.operations).toMatchObject([
+      { label: 'Saving settings', status: 'failed', message: 'disk full' },
+    ])
+    expect(saved).toEqual([saveAttempts[1]])
+    expect(saved[0]).toBe(queryClient.getQueryData(queryKeys.settings.all))
+    expect(saveAttempts).toHaveLength(2)
   })
 
   it('the quit flush persists changes a failed save left unconfirmed', async () => {
@@ -679,6 +790,55 @@ describe('SettingsProvider', () => {
         aiPrompts: [],
       },
     ])
+  })
+
+  it('the quit flush drains a pending failure, retries, and awaits the retry', async () => {
+    const { result, act } = await renderHook(() => useSettings(), { wrapper })
+    await loadSettled()
+    await expect(result.current.whenSettingsLoaded()).resolves.toBe('loaded')
+    failSaves = true
+    gateSaves = true
+
+    await act(() => {
+      result.current.updateSettings({ editorMarkdownSyntax: 'show' })
+    })
+    await vi.waitFor(() => expect(saveAttempts).toHaveLength(1))
+
+    let flushed = false
+    await act(async () => {
+      const flushing = flushSettings().then(() => {
+        flushed = true
+      })
+      failSaves = false
+      pendingSaves[0]?.resolve()
+      await vi.waitFor(() => expect(saveAttempts).toHaveLength(2))
+      expect(flushed).toBe(false)
+      pendingSaves[1]?.resolve()
+      await flushing
+    })
+
+    expect(flushed).toBe(true)
+    expect(saved).toEqual([saveAttempts[1]])
+    expect(saved[0]).toBe(queryClient.getQueryData(queryKeys.settings.all))
+  })
+
+  it('handles an in-flight save rejection after the provider unmounts', async () => {
+    const view = await renderHook(() => useSettings(), { wrapper })
+    await loadSettled()
+    await expect(view.result.current.whenSettingsLoaded()).resolves.toBe('loaded')
+    failSaves = true
+    gateSaves = true
+
+    await view.act(() => {
+      view.result.current.updateSettings({ editorMarkdownSyntax: 'show' })
+    })
+    await vi.waitFor(() => expect(saveAttempts).toHaveLength(1))
+    await view.unmount()
+    pendingSaves[0]?.resolve()
+
+    await vi.waitFor(() =>
+      expect(queryClient.isMutating({ mutationKey: mutationKeys.settings.save })).toBe(0),
+    )
   })
 
   it('surfaces a failed load and keeps changes session-only', async () => {

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -1,9 +1,7 @@
 import {
   createContext,
-  useCallback,
   use,
   useEffect,
-  useMemo,
   useRef,
   useState,
   type ReactElement,
@@ -13,10 +11,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { DEFAULT_SETTINGS, errorMessage, type Settings } from '@reflect/core'
 import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { startOperation } from '@/lib/operations'
-import {
-  createSettingsQueryOptions,
-  createSettingsSaveMutationOptions,
-} from '@/lib/query-options'
+import { createSettingsQueryOptions, createSettingsSaveMutationOptions } from '@/lib/query-options'
 import { setSettingsFlusher } from '@/lib/settings-flush'
 
 interface SettingsContextValue {
@@ -36,11 +31,7 @@ type SettingsUpdater = (current: Settings) => Partial<Settings>
 
 const SettingsContext = createContext<SettingsContextValue | null>(null)
 
-interface SettingsProviderProps {
-  children: ReactNode
-}
-
-export function SettingsProvider({ children }: SettingsProviderProps): ReactElement {
+export function SettingsProvider({ children }: { children: ReactNode }): ReactElement {
   const bridgeReady = useBridgeReady()
   const queryClient = useQueryClient()
   const queryOptions = createSettingsQueryOptions()
@@ -60,13 +51,9 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
         resolveLoad.current = resolve
       }),
   )
-  const whenSettingsLoaded = useCallback(() => loadPromise, [loadPromise])
+  const whenSettingsLoaded = (): Promise<SettingsLoadOutcome> => loadPromise
   const loadState =
-    pendingUpdaters.current === null
-      ? settingsQuery.isSuccess
-        ? 'loaded'
-        : 'failed'
-      : 'pending'
+    pendingUpdaters.current !== null ? 'pending' : settingsQuery.isSuccess ? 'loaded' : 'failed'
   useEffect(() => {
     if (loadState !== 'pending') {
       resolveLoad.current(loadState)
@@ -85,56 +72,44 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
     onError: (error) => startOperation('Saving settings').fail(errorMessage(error)),
   })
 
-  const submitSettings = useCallback(
-    (target: Settings): void => {
-      dirty.current = true
-      lastSubmission.current = save(target).catch(() => {})
-    },
-    [save],
-  )
+  const submitSettings = (target: Settings): void => {
+    dirty.current = true
+    lastSubmission.current = save(target).catch(() => {})
+  }
 
-  const applySettingsUpdate = useCallback(
-    (updater: SettingsUpdater): void => {
-      if (settingsQuery.isSuccess) {
-        const previous = queryClient.getQueryData(queryOptions.queryKey)
-        const next = queryClient.setQueryData(queryOptions.queryKey, (current) =>
-          current === undefined ? current : { ...current, ...updater(current) },
-        )
-        if (next !== undefined && (dirty.current || next !== previous)) {
-          submitSettings(next)
-        }
-        return
+  const applySettingsUpdate = (updater: SettingsUpdater): void => {
+    if (settingsQuery.isSuccess) {
+      const previous = queryClient.getQueryData(queryOptions.queryKey)
+      const next = queryClient.setQueryData(queryOptions.queryKey, (current) =>
+        current === undefined ? current : { ...current, ...updater(current) },
+      )
+      if (next !== undefined && (dirty.current || next !== previous)) {
+        submitSettings(next)
       }
-      setSessionSettings((current) => {
-        const base = current ?? DEFAULT_SETTINGS
-        return { ...base, ...updater(base) }
-      })
-    },
-    [queryClient, queryOptions.queryKey, settingsQuery.isSuccess, submitSettings],
-  )
+      return
+    }
+    setSessionSettings((current) => {
+      const base = current ?? DEFAULT_SETTINGS
+      return { ...base, ...updater(base) }
+    })
+  }
 
-  const updateSettings = useCallback(
-    (patch: Partial<Settings>): void => {
-      if (pendingUpdaters.current !== null) {
-        preloadPatchRef.current = { ...preloadPatchRef.current, ...patch }
-        setPreloadPatch(preloadPatchRef.current)
-        return
-      }
-      applySettingsUpdate(() => patch)
-    },
-    [applySettingsUpdate],
-  )
+  const updateSettings = (patch: Partial<Settings>): void => {
+    if (pendingUpdaters.current !== null) {
+      preloadPatchRef.current = { ...preloadPatchRef.current, ...patch }
+      setPreloadPatch(preloadPatchRef.current)
+      return
+    }
+    applySettingsUpdate(() => patch)
+  }
 
-  const updateSettingsWith = useCallback(
-    (updater: SettingsUpdater): void => {
-      if (pendingUpdaters.current !== null) {
-        pendingUpdaters.current?.push(updater)
-        return
-      }
-      applySettingsUpdate(updater)
-    },
-    [applySettingsUpdate],
-  )
+  const updateSettingsWith = (updater: SettingsUpdater): void => {
+    if (pendingUpdaters.current !== null) {
+      pendingUpdaters.current.push(updater)
+      return
+    }
+    applySettingsUpdate(updater)
+  }
 
   useEffect(() => {
     if (pendingUpdaters.current === null) {
@@ -180,42 +155,41 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
     submitSettings,
   ])
 
-  const settings = useMemo<Settings>(() => {
-    if (loadState === 'loaded') {
-      return settingsQuery.data ?? DEFAULT_SETTINGS
-    }
-    if (loadState === 'failed') {
-      return sessionSettings ?? DEFAULT_SETTINGS
-    }
-    return { ...DEFAULT_SETTINGS, ...preloadPatch }
-  }, [loadState, preloadPatch, sessionSettings, settingsQuery.data])
+  const settings: Settings =
+    loadState === 'loaded'
+      ? (settingsQuery.data ?? DEFAULT_SETTINGS)
+      : loadState === 'failed'
+        ? (sessionSettings ?? DEFAULT_SETTINGS)
+        : { ...DEFAULT_SETTINGS, ...preloadPatch }
 
-  const drainSubmissions = useCallback(async (): Promise<void> => {
+  const drainSubmissions = async (): Promise<void> => {
     let submission = lastSubmission.current
     await submission
     while (submission !== lastSubmission.current) {
       submission = lastSubmission.current
       await submission
     }
-  }, [])
-  const flush = useCallback(async (): Promise<void> => {
+  }
+  const flush = async (): Promise<void> => {
     await drainSubmissions()
     const current = queryClient.getQueryData(queryOptions.queryKey)
     if (dirty.current && current !== undefined) {
       submitSettings(current)
       await drainSubmissions()
     }
-  }, [drainSubmissions, queryClient, queryOptions.queryKey, submitSettings])
+  }
 
   useEffect(() => {
     setSettingsFlusher(flush)
     return () => setSettingsFlusher(null)
   }, [flush])
 
-  const value = useMemo<SettingsContextValue>(
-    () => ({ settings, updateSettings, updateSettingsWith, whenSettingsLoaded }),
-    [settings, updateSettings, updateSettingsWith, whenSettingsLoaded],
-  )
+  const value: SettingsContextValue = {
+    settings,
+    updateSettings,
+    updateSettingsWith,
+    whenSettingsLoaded,
+  }
 
   return <SettingsContext value={value}>{children}</SettingsContext>
 }

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -9,58 +9,32 @@ import {
   type ReactElement,
   type ReactNode,
 } from 'react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { DEFAULT_SETTINGS, saveSettings, errorMessage, type Settings } from '@reflect/core'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { DEFAULT_SETTINGS, errorMessage, type Settings } from '@reflect/core'
 import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { startOperation } from '@/lib/operations'
-import { createSettingsQueryOptions } from '@/lib/query-options'
+import {
+  createSettingsQueryOptions,
+  createSettingsSaveMutationOptions,
+} from '@/lib/query-options'
 import { setSettingsFlusher } from '@/lib/settings-flush'
 
 interface SettingsContextValue {
   settings: Settings
   /** Merge `patch` into the settings: applied immediately, persisted async. */
   updateSettings: (patch: Partial<Settings>) => void
-  /**
-   * Like {@link updateSettings}, but the patch is computed from the latest
-   * merged settings at apply time. Use this for read-modify-write updates
-   * (e.g. list edits after an `await`): React applies functional updaters
-   * sequentially, so concurrent edits compose instead of clobbering each
-   * other through a stale render-time snapshot. Updaters dispatched before
-   * hydration are queued and replayed over the loaded document — an edit of
-   * a list the disk is about to supply must not be computed from defaults.
-   */
+  /** Compute a patch from the latest settings; pre-load calls replay after hydration. */
   updateSettingsWith: (updater: (current: Settings) => Partial<Settings>) => void
-  /**
-   * Resolves once the initial disk load has settled, and with which outcome.
-   * After `'failed'`, changes apply session-only and nothing persists —
-   * callers that pair a settings entry with state elsewhere (e.g. a keychain
-   * secret) must await this before writing the other half, or a restart
-   * loses the entry and strands its counterpart. A boolean can't close that
-   * window: a write racing the in-flight load needs the eventual outcome.
-   */
+  /** Resolve after the initial disk load; `'failed'` means session-only updates. */
   whenSettingsLoaded: () => Promise<SettingsLoadOutcome>
 }
 
 /** How the initial settings load ended (`'failed'` ⇒ session-only mode). */
 export type SettingsLoadOutcome = 'loaded' | 'failed'
 
-type SettingsLoadState = SettingsLoadOutcome | 'pending'
 type SettingsUpdater = (current: Settings) => Partial<Settings>
 
 const SettingsContext = createContext<SettingsContextValue | null>(null)
-
-interface LoadSettle {
-  promise: Promise<SettingsLoadOutcome>
-  resolve: (outcome: SettingsLoadOutcome) => void
-}
-
-function createLoadSettle(): LoadSettle {
-  let resolve: (outcome: SettingsLoadOutcome) => void = () => {}
-  const promise = new Promise<SettingsLoadOutcome>((promiseResolve) => {
-    resolve = promiseResolve
-  })
-  return { promise, resolve }
-}
 
 interface SettingsProviderProps {
   children: ReactNode
@@ -77,116 +51,105 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
   const [preloadPatch, setPreloadPatch] = useState<Partial<Settings>>({})
   const preloadPatchRef = useRef<Partial<Settings>>({})
   const pendingUpdaters = useRef<SettingsUpdater[] | null>([])
-  const [loadState, setLoadState] = useState<SettingsLoadState>('pending')
-  const loadStateRef = useRef<SettingsLoadState>('pending')
   const [sessionSettings, setSessionSettings] = useState<Settings | null>(null)
-  const diskSettings = useRef<Settings | null>(null)
-  const settingsRef = useRef<Settings>(DEFAULT_SETTINGS)
 
-  const loadSettle = useRef<LoadSettle | null>(null)
-  if (loadSettle.current === null) {
-    loadSettle.current = createLoadSettle()
-  }
-  const whenSettingsLoaded = useCallback(
-    (): Promise<SettingsLoadOutcome> => loadSettle.current?.promise ?? Promise.resolve('failed'),
-    [],
+  const resolveLoad = useRef<(outcome: SettingsLoadOutcome) => void>(() => {})
+  const [loadPromise] = useState(
+    () =>
+      new Promise<SettingsLoadOutcome>((resolve) => {
+        resolveLoad.current = resolve
+      }),
   )
+  const whenSettingsLoaded = useCallback(() => loadPromise, [loadPromise])
+  const loadState =
+    pendingUpdaters.current === null
+      ? settingsQuery.isSuccess
+        ? 'loaded'
+        : 'failed'
+      : 'pending'
   useEffect(() => {
     if (loadState !== 'pending') {
-      loadSettle.current?.resolve(loadState)
+      resolveLoad.current(loadState)
     }
   }, [loadState])
 
-  const persistQueue = useRef<Promise<void>>(Promise.resolve())
-  const lastPersisted = useRef<Settings | null>(null)
-  const persistIfChanged = useCallback((target = settingsRef.current): Promise<void> => {
-    const disk = diskSettings.current
-    if (disk === null) {
-      return persistQueue.current
-    }
-    const confirmed = lastPersisted.current ?? disk
-    if (target === confirmed) {
-      lastPersisted.current = confirmed
-      return persistQueue.current
-    }
-    persistQueue.current = persistQueue.current
-      .then(() => saveSettings(target))
-      .then(() => {
-        lastPersisted.current = target
-      })
-      .catch((error) => {
-        startOperation('Saving settings').fail(errorMessage(error))
-      })
-    return persistQueue.current
-  }, [])
-
-  const setLoadedSettings = useCallback(
-    (updater: (current: Settings) => Settings): void => {
-      const next = queryClient.setQueryData(queryOptions.queryKey, (current) =>
-        current === undefined ? current : updater(current),
-      )
-      if (next !== undefined) {
-        settingsRef.current = next
-        void persistIfChanged(next)
+  const dirty = useRef(false)
+  const lastSubmission = useRef<Promise<void>>(Promise.resolve())
+  const { mutateAsync: save } = useMutation({
+    ...createSettingsSaveMutationOptions(),
+    onSuccess: (_data, target) => {
+      if (queryClient.getQueryData(queryOptions.queryKey) === target) {
+        dirty.current = false
       }
     },
-    [persistIfChanged, queryClient, queryOptions.queryKey],
-  )
+    onError: (error) => startOperation('Saving settings').fail(errorMessage(error)),
+  })
 
-  const updateSettings = useCallback(
-    (patch: Partial<Settings>): void => {
-      if (loadStateRef.current === 'pending') {
-        preloadPatchRef.current = { ...preloadPatchRef.current, ...patch }
-        setPreloadPatch(preloadPatchRef.current)
-        return
-      }
-      if (loadStateRef.current === 'loaded') {
-        setLoadedSettings((current) => ({ ...current, ...patch }))
-        return
-      }
-      setSessionSettings((current) => {
-        const next = { ...(current ?? DEFAULT_SETTINGS), ...patch }
-        settingsRef.current = next
-        return next
-      })
+  const submitSettings = useCallback(
+    (target: Settings): void => {
+      dirty.current = true
+      lastSubmission.current = save(target).catch(() => {})
     },
-    [setLoadedSettings],
+    [save],
   )
 
-  const updateSettingsWith = useCallback(
+  const applySettingsUpdate = useCallback(
     (updater: SettingsUpdater): void => {
-      if (loadStateRef.current === 'pending') {
-        pendingUpdaters.current?.push(updater)
-        return
-      }
-      if (loadStateRef.current === 'loaded') {
-        setLoadedSettings((current) => ({ ...current, ...updater(current) }))
+      if (settingsQuery.isSuccess) {
+        const previous = queryClient.getQueryData(queryOptions.queryKey)
+        const next = queryClient.setQueryData(queryOptions.queryKey, (current) =>
+          current === undefined ? current : { ...current, ...updater(current) },
+        )
+        if (next !== undefined && (dirty.current || next !== previous)) {
+          submitSettings(next)
+        }
         return
       }
       setSessionSettings((current) => {
         const base = current ?? DEFAULT_SETTINGS
-        const next = { ...base, ...updater(base) }
-        settingsRef.current = next
-        return next
+        return { ...base, ...updater(base) }
       })
     },
-    [setLoadedSettings],
+    [queryClient, queryOptions.queryKey, settingsQuery.isSuccess, submitSettings],
+  )
+
+  const updateSettings = useCallback(
+    (patch: Partial<Settings>): void => {
+      if (pendingUpdaters.current !== null) {
+        preloadPatchRef.current = { ...preloadPatchRef.current, ...patch }
+        setPreloadPatch(preloadPatchRef.current)
+        return
+      }
+      applySettingsUpdate(() => patch)
+    },
+    [applySettingsUpdate],
+  )
+
+  const updateSettingsWith = useCallback(
+    (updater: SettingsUpdater): void => {
+      if (pendingUpdaters.current !== null) {
+        pendingUpdaters.current?.push(updater)
+        return
+      }
+      applySettingsUpdate(updater)
+    },
+    [applySettingsUpdate],
   )
 
   useEffect(() => {
-    if (loadStateRef.current !== 'pending') {
+    if (pendingUpdaters.current === null) {
       return
     }
 
-    let outcome: SettingsLoadOutcome
+    const loaded = settingsQuery.isSuccess
     let current: Settings
-    if (settingsQuery.isSuccess) {
-      outcome = 'loaded'
-      diskSettings.current = settingsQuery.data
+    if (loaded) {
       current = { ...settingsQuery.data, ...preloadPatchRef.current }
     } else if (!bridgeReady || settingsQuery.isError) {
-      outcome = 'failed'
       current = { ...DEFAULT_SETTINGS, ...preloadPatchRef.current }
+      if (settingsQuery.error) {
+        startOperation('Loading settings').fail(errorMessage(settingsQuery.error))
+      }
     } else {
       return
     }
@@ -197,51 +160,57 @@ export function SettingsProvider({ children }: SettingsProviderProps): ReactElem
       current = { ...current, ...updater(current) }
     }
 
-    if (outcome === 'loaded') {
+    if (loaded) {
       current = queryClient.setQueryData(queryOptions.queryKey, current) ?? current
     } else {
       setSessionSettings(current)
     }
-    settingsRef.current = current
-    loadStateRef.current = outcome
-    setLoadState(outcome)
     preloadPatchRef.current = {}
     setPreloadPatch({})
-    if (outcome === 'loaded') {
-      void persistIfChanged(current)
+    if (loaded && current !== settingsQuery.data) {
+      submitSettings(current)
     }
   }, [
     bridgeReady,
-    persistIfChanged,
     queryClient,
     queryOptions.queryKey,
     settingsQuery.data,
     settingsQuery.isError,
     settingsQuery.isSuccess,
+    submitSettings,
   ])
 
   const settings = useMemo<Settings>(() => {
     if (loadState === 'loaded') {
-      return settingsQuery.data ?? settingsRef.current
+      return settingsQuery.data ?? DEFAULT_SETTINGS
     }
     if (loadState === 'failed') {
-      return sessionSettings ?? settingsRef.current
+      return sessionSettings ?? DEFAULT_SETTINGS
     }
     return { ...DEFAULT_SETTINGS, ...preloadPatch }
   }, [loadState, preloadPatch, sessionSettings, settingsQuery.data])
 
-  const loadErrorSurfaced = useRef(false)
-  useEffect(() => {
-    if (settingsQuery.error && !loadErrorSurfaced.current) {
-      loadErrorSurfaced.current = true
-      startOperation('Loading settings').fail(errorMessage(settingsQuery.error))
+  const drainSubmissions = useCallback(async (): Promise<void> => {
+    let submission = lastSubmission.current
+    await submission
+    while (submission !== lastSubmission.current) {
+      submission = lastSubmission.current
+      await submission
     }
-  }, [settingsQuery.error])
+  }, [])
+  const flush = useCallback(async (): Promise<void> => {
+    await drainSubmissions()
+    const current = queryClient.getQueryData(queryOptions.queryKey)
+    if (dirty.current && current !== undefined) {
+      submitSettings(current)
+      await drainSubmissions()
+    }
+  }, [drainSubmissions, queryClient, queryOptions.queryKey, submitSettings])
 
   useEffect(() => {
-    setSettingsFlusher(persistIfChanged)
+    setSettingsFlusher(flush)
     return () => setSettingsFlusher(null)
-  }, [persistIfChanged])
+  }, [flush])
 
   const value = useMemo<SettingsContextValue>(
     () => ({ settings, updateSettings, updateSettingsWith, whenSettingsLoaded }),

--- a/apps/desktop/src/providers/settings-provider.tsx
+++ b/apps/desktop/src/providers/settings-provider.tsx
@@ -28,7 +28,6 @@ interface SettingsContextValue {
 export type SettingsLoadOutcome = 'loaded' | 'failed'
 
 type SettingsUpdater = (current: Settings) => Partial<Settings>
-
 const SettingsContext = createContext<SettingsContextValue | null>(null)
 
 export function SettingsProvider({ children }: { children: ReactNode }): ReactElement {

--- a/docs/contributing/adding-a-setting.md
+++ b/docs/contributing/adding-a-setting.md
@@ -64,10 +64,12 @@ Semantics you get for free from the provider (and must not re-implement):
 - **Instant simple patches.** `updateSettings` applies over defaults while the
   disk load is pending. After hydration, it updates the current document in the
   TanStack Query cache.
-- **Async, ordered persistence.** Writes are chained in apply order, trail
-  hydration (nothing is written before the disk document has been read), and
-  save the full merged document. Failures surface through the operations
-  status UI and retry on the next change or the quit flush.
+- **Async, ordered persistence.** Each hydrated cache update submits its full
+  immutable document to a scoped TanStack Query mutation. The scope serializes
+  writes in apply order, and nothing is submitted before the disk document has
+  been read. Failures keep the optimistic cache value, surface through the
+  operations status UI, and leave it dirty for the next change or quit flush
+  to retry.
 - **Functional updates for read-modify-write.** Use `updateSettingsWith` for
   list/object edits or anything derived from the current document. Updaters
   dispatched before hydration are queued and replayed over the loaded
@@ -75,8 +77,9 @@ Semantics you get for free from the provider (and must not re-implement):
   wipe the stored value.
 - **One runtime document.** After a successful load, `useSettings()` and
   imperative readers of `queryKeys.settings.all` observe the same Query cache
-  document. The settings JSON remains the durable source, and the provider's
-  ordered persistence queue writes cache updates back to it.
+  document. The settings JSON remains the durable source. Quit and background
+  flushes drain submitted mutations, then retry and await the current document
+  when its last save was not confirmed.
 - **Load-sensitive side effects must await hydration.** If a settings entry is
   paired with state elsewhere (for example an OS-keychain secret), call
   `whenSettingsLoaded()` before writing the other half. If the initial load


### PR DESCRIPTION
## Summary

- persist settings through a shared TanStack Query mutation with a serial scope
- keep the optimistic Query cache document dirty until the current submitted target is confirmed, then retry unconfirmed data on later updates or lifecycle flushes
- remove the manual promise queue and memoization boilerplate, and document the scoped persistence contract

## Testing

- `pnpm check`
- `settings-provider.test.tsx`: 24 tests
- settings provider, theme provider, and settings screen regression matrix: 74 tests