### PR TITLE
fix: show active pinned notes in dark mode

### DIFF
--- a/apps/desktop/src/components/sidebar/sidebar-pinned-row-preview.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar-pinned-row-preview.tsx
@@ -19,7 +19,7 @@ export function SidebarPinnedRowPreview({
     : overlay
       ? 'bg-white text-text-secondary'
       : active
-        ? 'bg-surface-hover text-text-secondary dark:bg-transparent'
+        ? 'bg-surface-hover text-text-secondary dark:bg-transparent dark:text-accent'
         : 'text-text-secondary hover:bg-surface-hover hover:text-text'
 
   return (

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -279,6 +279,7 @@ describe('Sidebar', () => {
     expect(roadmapPreview?.getAttribute('class')).toContain('hover:text-text')
     await roadmap.click()
     await expect.element(roadmap).toHaveAttribute('aria-current', 'page')
+    expect(roadmapPreview?.getAttribute('class')).toContain('dark:text-accent')
   })
 
   it('modifier-click opens a pinned note in a new window without changing routes', async () => {


### PR DESCRIPTION
## Problem

Pinned notes had no visible selected state in dark mode. The active row deliberately drops the light-theme background wash, but it did not adopt the accent text used by other active sidebar rows, leaving it visually identical to inactive notes.

## Changes

- Apply the dark-theme accent color to the active pinned-note label while preserving the existing light-theme selection wash and drag states.
- Extend the sidebar browser test to cover the dark-mode active-state class after navigation.

## Verification

- `pnpm test --run apps/desktop/src/components/sidebar/sidebar.test.tsx` (20 tests passed)
- `pnpm check`

## Risk / Rollout

Low-risk, CSS-only presentation change with no data, routing, or migration impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility of active pinned-note previews in dark mode by applying the accent text color.

* **Tests**
  * Added coverage to verify the correct dark-mode styling is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->