### PR TITLE
feat: add on-device page summaries to Chrome captures

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -22,8 +22,9 @@ raw note + daily `## [[Links]]` entry now (resolving or creating that category
 note), meta-scrape + BYOK AI title + description async. Optional summaries run
 inside Chrome with its built-in local model; the extension stores no keys and
 sends no page content to an AI provider. Chrome may download the model before its
-first use. The extension's only honest status is **queued** — it cannot observe
-the desktop drain.
+first use. After local handoff, the desktop app may separately perform BYOK AI
+enrichment under Reflect's desktop privacy rules. The extension's only honest
+status is **queued** — it cannot observe the desktop drain.
 
 ## Develop
 
@@ -131,16 +132,18 @@ in the [Developer Dashboard](https://chrome.google.com/webstore/devconsole).
 >
 > A capture includes the page's URL and title, your current text selection, and a
 > screenshot of the visible tab. Optionally, tick "Capture page text" to include the
-> page's readable text, or "Capture page summary" to summarize that text with Chrome's
-> built-in on-device AI. The link is queued first, then its summary is added shortly
+> page's readable text and/or "Capture page summary" to summarize that text with
+> Chrome's built-in on-device AI. The two options are independent and can be selected
+> together. The link is queued first, then its text and summary are added shortly
 > afterward.
 >
 > Captures are handed to the **installed Reflect desktop app** over a local connection
 > on your own machine — there is no Reflect account and no Reflect server in the path.
 > Capturing works even when the app is closed: the link is held and saved automatically
 > the next time Reflect runs. The extension stores no API keys and sends no captured
-> content to an AI provider. Chrome may download its local summarization model before
-> the first summary.
+> content to an AI provider; Chrome may download its local summarization model before
+> the first summary. After local capture, the desktop app may perform separately
+> configured BYOK AI enrichment under Reflect's privacy controls.
 >
 > Requires the Reflect desktop app: https://github.com/team-reflect/reflect-open
 
@@ -177,8 +180,10 @@ Each is reviewed individually; every permission below is exercised by the code:
   screenshot, and — only when opted in — page text and/or its on-device summary). Collected
   **only on an explicit user action**, never in the background.
 - **Where it goes:** to the user's own machine (the local Reflect desktop app). It is
-  **not** sent to Reflect or an AI provider; Chrome's built-in model processes summary
-  input locally.
+  **not** sent to Reflect, and the extension sends nothing to an AI provider; Chrome's
+  built-in model processes summary input locally. Once captured, the desktop app may
+  separately send eligible content to the user's configured BYOK provider for optional
+  enrichment, subject to Reflect's privacy controls.
 - The three required certifications are all true and can be affirmed:
   1. Data is **not** sold to third parties.
   2. Data is **not** used or transferred for purposes unrelated to the single purpose.

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -1,9 +1,9 @@
 # Reflect Capture (Chrome extension)
 
-Save the page you're reading into Reflect: ⌘⇧K saves immediately with default
-settings, including the stored page-text preference, while the toolbar button
-opens the capture popup for an optional note. Captures include the page URL,
-title, selection, screenshot, and optional page text when Chrome allows them,
+Save the page you're reading into Reflect: the toolbar button or ⌘⇧K opens the
+capture popup, and Enter saves. Captures include the page URL, title, selection,
+screenshot, and optional page text. On supported devices, Chrome's on-device
+Summarizer can also add a page summary shortly after the link is queued. Captures
 then hand off to the **installed desktop app** through a local native-messaging
 host. No Reflect-hosted services are involved, and capture works even while the
 app is closed: the host spools into the graph's capture inbox
@@ -19,9 +19,11 @@ popup → `chrome.storage` queue → background `sendNativeMessage` →
 `reflect-capture-host` (Tauri sidecar, registered by the desktop app on every
 launch) → capture inbox → desktop drain (`@reflect/core` `actions/capture`):
 raw note + daily `## [[Links]]` entry now (resolving or creating that category
-note), meta-scrape + BYOK AI title + description async. The extension stores no
-keys and makes no AI or network calls; its only honest status is **queued** — it
-cannot observe the desktop drain.
+note), meta-scrape + BYOK AI title + description async. Optional summaries run
+inside Chrome with its built-in local model; the extension stores no keys and
+sends no page content to an AI provider. Chrome may download the model before its
+first use. The extension's only honest status is **queued** — it cannot observe
+the desktop drain.
 
 ## Develop
 
@@ -124,18 +126,21 @@ in the [Developer Dashboard](https://chrome.google.com/webstore/devconsole).
 
 **Detailed description:**
 
-> Reflect Capture saves the page you're reading into Reflect with one click or a
-> keyboard shortcut (⌘⇧K / Ctrl+Shift+K).
+> Reflect Capture saves the page you're reading into Reflect from the toolbar or
+> keyboard shortcut (⌘⇧K / Ctrl+Shift+K). Press Enter in the popup to save.
 >
 > A capture includes the page's URL and title, your current text selection, and a
 > screenshot of the visible tab. Optionally, tick "Capture page text" to include the
-> page's readable text as well.
+> page's readable text, or "Capture page summary" to summarize that text with Chrome's
+> built-in on-device AI. The link is queued first, then its summary is added shortly
+> afterward.
 >
 > Captures are handed to the **installed Reflect desktop app** over a local connection
 > on your own machine — there is no Reflect account and no Reflect server in the path.
 > Capturing works even when the app is closed: the link is held and saved automatically
-> the next time Reflect runs. The extension stores no API keys and makes no AI or
-> network calls of its own.
+> the next time Reflect runs. The extension stores no API keys and sends no captured
+> content to an AI provider. Chrome may download its local summarization model before
+> the first summary.
 >
 > Requires the Reflect desktop app: https://github.com/team-reflect/reflect-open
 
@@ -160,7 +165,7 @@ Each is reviewed individually; every permission below is exercised by the code:
 | Permission | Why it's needed |
 | --- | --- |
 | `activeTab` | Read the URL/title and grab a screenshot + selection of the tab you capture — only at the moment you click the button or press the shortcut. Avoids any broad host permission. |
-| `scripting` | Run a one-line script in the active tab to read the current selection and, when opted in, extract the page's readable text. |
+| `scripting` | Run a script in the active tab to read the current selection and, when opted in, extract readable text for full-text capture or on-device summarization. |
 | `nativeMessaging` | The only output: hand each capture to the local `reflect-capture-host` the desktop app registers. No network is used. |
 | `storage` | Queue captures locally so a capture survives the app being closed and retries until it spools. |
 | `unlimitedStorage` | Queued captures embed a screenshot data URL, which can exceed the default storage quota while waiting for the app. |
@@ -169,10 +174,11 @@ Each is reviewed individually; every permission below is exercised by the code:
 ### Data-handling disclosures (Privacy practices tab)
 
 - **Data collected:** *Website content* (the captured page's URL, title, selection,
-  screenshot, and — only when opted in — page text). Collected **only on an explicit
-  user action**, never in the background.
+  screenshot, and — only when opted in — page text and/or its on-device summary). Collected
+  **only on an explicit user action**, never in the background.
 - **Where it goes:** to the user's own machine (the local Reflect desktop app). It is
-  **not** sent to Reflect or any third party.
+  **not** sent to Reflect or an AI provider; Chrome's built-in model processes summary
+  input locally.
 - The three required certifications are all true and can be affirmed:
   1. Data is **not** sold to third parties.
   2. Data is **not** used or transferred for purposes unrelated to the single purpose.

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -54,6 +54,7 @@ export default defineBackground(() => {
 
   browser.commands.onCommand.addListener((command, tab) => {
     if (command === SAVE_CURRENT_PAGE_COMMAND) {
+      void flushQueue()
       const openPopup =
         typeof browser.action.openPopup === 'function'
           ? () => browser.action.openPopup()

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -1,6 +1,6 @@
 import { browser } from 'wxt/browser'
 import { defineBackground } from '#imports'
-import { SAVE_CURRENT_PAGE_COMMAND } from '@/lib/commands'
+import { openCapturePopupOrFallback, SAVE_CURRENT_PAGE_COMMAND } from '@/lib/commands'
 import { flushQueue } from '@/lib/flush'
 import { isFlushRequest } from '@/lib/messages'
 import { readIncludePageTextPreference } from '@/lib/popup-preferences'
@@ -9,11 +9,10 @@ import { snapshotTab } from '@/lib/snapshot-active-tab'
 import { tryExtractPageText } from './popup/extract-page-text'
 
 /**
- * The MV3 service worker owns retries and the shortcut fast path. Every
- * capture is persisted before a flush starts, so nothing depends on this
- * worker's (or the popup's) lifetime. Retries ride four triggers: every flush
- * ping, the keyboard shortcut, browser startup, and a coarse alarm for the
- * "Reflect installed an hour later" case.
+ * The MV3 service worker owns retries and opens the popup for the shortcut.
+ * Every capture is persisted before a flush starts, so nothing depends on
+ * this worker's (or the popup's) lifetime. Retries ride flush pings, browser
+ * startup, and a coarse alarm for the "Reflect installed an hour later" case.
  */
 
 const RETRY_ALARM = 'capture-retry'
@@ -55,9 +54,15 @@ export default defineBackground(() => {
 
   browser.commands.onCommand.addListener((command, tab) => {
     if (command === SAVE_CURRENT_PAGE_COMMAND) {
-      void saveTabWithDefaults(tab).catch((cause: unknown) => {
-        console.error('shortcut capture failed:', cause)
-      })
+      const openPopup =
+        typeof browser.action.openPopup === 'function'
+          ? () => browser.action.openPopup()
+          : undefined
+      void openCapturePopupOrFallback(openPopup, () => saveTabWithDefaults(tab)).catch(
+        (cause: unknown) => {
+          console.error('shortcut capture failed:', cause)
+        },
+      )
     }
   })
 

--- a/apps/extension/entrypoints/popup/app.tsx
+++ b/apps/extension/entrypoints/popup/app.tsx
@@ -4,10 +4,19 @@ import { readQueue } from '@/lib/flush'
 import type { FlushResult } from '@/lib/messages'
 import { saveCapture } from '@/lib/save-capture'
 import {
+  readIncludePageSummaryPreference,
   readIncludePageTextPreference,
+  writeIncludePageSummaryPreference,
   writeIncludePageTextPreference,
 } from '@/lib/popup-preferences'
+import {
+  pageSummaryAvailability,
+  startPageSummary,
+  type PageSummaryAvailability,
+  type PageSummaryTask,
+} from '@/lib/page-summary'
 import { tryExtractPageText } from './extract-page-text'
+import { runCaptureFlow, type CaptureFlowPhase } from './capture-flow'
 import { useCapturedPage } from './use-captured-page'
 
 /**
@@ -19,11 +28,16 @@ import { useCapturedPage } from './use-captured-page'
 
 type SaveState =
   | { phase: 'idle' }
-  | { phase: 'saving' }
+  | { phase: 'working'; step: CaptureFlowPhase }
   | { phase: 'held'; result: FlushResult }
   | { phase: 'failed'; message: string }
+  | { phase: 'summary-failed'; message: string; result?: FlushResult | undefined }
 
 const RELEASES_URL = 'https://github.com/team-reflect/reflect-open/releases/latest'
+
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause)
+}
 
 function holdMessage(result: FlushResult): string {
   switch (result.holdReason) {
@@ -40,14 +54,50 @@ export function CapturePopup(): ReactElement {
   const captured = useCapturedPage()
   const [note, setNote] = useState('')
   const [includePageText, setIncludePageText] = useState(false)
+  const [includePageSummary, setIncludePageSummary] = useState(false)
   const includePageTextTouched = useRef(false)
+  const includePageSummaryTouched = useRef(false)
   const [includePageTextPreferenceLoaded, setIncludePageTextPreferenceLoaded] = useState(false)
+  const [includePageSummaryPreferenceLoaded, setIncludePageSummaryPreferenceLoaded] =
+    useState(false)
+  const [summaryAvailability, setSummaryAvailability] = useState<
+    PageSummaryAvailability | 'checking'
+  >('checking')
+  const [downloadProgress, setDownloadProgress] = useState<number | null>(null)
+  const activeSummaryTask = useRef<PageSummaryTask | null>(null)
   const [save, setSave] = useState<SaveState>({ phase: 'idle' })
   const [heldCount, setHeldCount] = useState(0)
 
   useEffect(() => {
     void readQueue().then((queue) => setHeldCount(queue.length))
   }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    void pageSummaryAvailability().then(
+      (availability) => {
+        if (!cancelled) {
+          setSummaryAvailability(availability)
+        }
+      },
+      (cause) => {
+        console.warn('Chrome page summary availability could not be read:', cause)
+        if (!cancelled) {
+          setSummaryAvailability('unavailable')
+        }
+      },
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(
+    () => () => {
+      activeSummaryTask.current?.cancel()
+    },
+    [],
+  )
 
   useEffect(() => {
     let cancelled = false
@@ -72,40 +122,101 @@ export function CapturePopup(): ReactElement {
     }
   }, [])
 
+  useEffect(() => {
+    let cancelled = false
+    void readIncludePageSummaryPreference().then(
+      (preference) => {
+        if (!cancelled && !includePageSummaryTouched.current) {
+          setIncludePageSummary(preference)
+        }
+        if (!cancelled) {
+          setIncludePageSummaryPreferenceLoaded(true)
+        }
+      },
+      (cause) => {
+        console.warn('capture page summary preference could not be read:', cause)
+        if (!cancelled) {
+          setIncludePageSummaryPreferenceLoaded(true)
+        }
+      },
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
   async function onSubmit(event: FormEvent): Promise<void> {
     event.preventDefault()
     if (
       captured.status !== 'ready' ||
       !includePageTextPreferenceLoaded ||
-      save.phase === 'saving'
+      !includePageSummaryPreferenceLoaded ||
+      save.phase === 'working' ||
+      save.phase === 'summary-failed'
     ) {
       return
     }
-    setSave({ phase: 'saving' })
+    const canSummarize =
+      summaryAvailability === 'available' ||
+      summaryAvailability === 'downloadable' ||
+      summaryAvailability === 'downloading'
+    const shouldSummarize = includePageSummary && canSummarize
+    setDownloadProgress(null)
+    setSave({ phase: 'working', step: shouldSummarize ? 'saving-link' : 'extracting-page' })
     try {
-      const contentText = includePageText
-        ? await tryExtractPageText(captured.tabId, captured.page.url)
-        : undefined
-      const outcome = await saveCapture(
+      const result = await runCaptureFlow(
         {
-          ...captured.page,
-          contentText,
+          page: captured.page,
+          tabId: captured.tabId,
           note,
-          id: crypto.randomUUID(),
-          capturedAt: new Date(),
+          includePageText,
+          includePageSummary: shouldSummarize,
         },
-        () => browser.runtime.sendMessage({ type: 'flush' }),
+        {
+          onPhase: (step) => setSave({ phase: 'working', step }),
+          onDownloadProgress: setDownloadProgress,
+        },
+        {
+          now: () => new Date(),
+          randomId: () => crypto.randomUUID(),
+          extractPageText: tryExtractPageText,
+          saveCapture: (page) =>
+            saveCapture(page, () => browser.runtime.sendMessage({ type: 'flush' })),
+          startPageSummary: (options) => {
+            const task = startPageSummary(options)
+            activeSummaryTask.current = task
+            return task
+          },
+        },
       )
-      if (outcome.fate === 'queued') {
+      activeSummaryTask.current = null
+      if (result.kind === 'link-rejected') {
+        setSave({ phase: 'failed', message: 'The capture was rejected — please report this.' })
+      } else if (result.kind === 'update-rejected') {
+        setSave({
+          phase: 'summary-failed',
+          message: 'Link captured, but the summary update was rejected — please report this.',
+          result: result.linkOutcome.fate === 'held' ? result.linkOutcome.result : undefined,
+        })
+      } else if (result.kind === 'summary-failed') {
+        const lastOutcome = result.pageTextOutcome ?? result.linkOutcome
+        setSave({
+          phase: 'summary-failed',
+          message: `Link captured, but the summary could not be generated: ${errorMessage(result.cause)}`,
+          result: lastOutcome.fate === 'held' ? lastOutcome.result : undefined,
+        })
+      } else if (result.outcome.fate === 'queued') {
         window.close()
-      } else if (outcome.fate === 'held') {
-        setSave({ phase: 'held', result: outcome.result })
-        setHeldCount(outcome.result.held)
+      } else if (result.outcome.fate === 'held') {
+        setSave({ phase: 'held', result: result.outcome.result })
+        setHeldCount(result.outcome.result.held)
       } else {
         setSave({ phase: 'failed', message: 'The capture was rejected — please report this.' })
       }
     } catch (cause) {
-      setSave({ phase: 'failed', message: cause instanceof Error ? cause.message : String(cause) })
+      activeSummaryTask.current?.cancel()
+      activeSummaryTask.current = null
+      setSave({ phase: 'failed', message: errorMessage(cause) })
     }
   }
 
@@ -118,7 +229,18 @@ export function CapturePopup(): ReactElement {
 
   const { page } = captured
   const host = new URL(page.url).host
-  const busy = save.phase === 'saving' || !includePageTextPreferenceLoaded
+  const summarySupported =
+    summaryAvailability === 'available' ||
+    summaryAvailability === 'downloadable' ||
+    summaryAvailability === 'downloading'
+  const waitingForSummaryAvailability = includePageSummary && summaryAvailability === 'checking'
+  const summaryRequested = includePageSummary && summarySupported
+  const busy =
+    save.phase === 'working' ||
+    !includePageTextPreferenceLoaded ||
+    !includePageSummaryPreferenceLoaded ||
+    waitingForSummaryAvailability
+  const lockedAfterSummaryFailure = save.phase === 'summary-failed'
 
   function onIncludePageTextChange(checked: boolean): void {
     includePageTextTouched.current = true
@@ -127,6 +249,39 @@ export function CapturePopup(): ReactElement {
     void writeIncludePageTextPreference(checked).catch((cause) => {
       console.warn('capture page text preference could not be saved:', cause)
     })
+  }
+
+  function onIncludePageSummaryChange(checked: boolean): void {
+    includePageSummaryTouched.current = true
+    setIncludePageSummaryPreferenceLoaded(true)
+    setIncludePageSummary(checked)
+    void writeIncludePageSummaryPreference(checked).catch((cause) => {
+      console.warn('capture page summary preference could not be saved:', cause)
+    })
+  }
+
+  function workingMessage(step: CaptureFlowPhase): string | null {
+    const downloadingModel = downloadProgress !== null && downloadProgress < 100
+    switch (step) {
+      case 'saving-link':
+        return downloadingModel
+          ? `Saving link. Downloading Chrome’s local model… ${downloadProgress}%`
+          : null
+      case 'extracting-page':
+        return summaryRequested
+          ? downloadingModel
+            ? `Link captured. Downloading Chrome’s local model… ${downloadProgress}%`
+            : 'Link captured. Reading page…'
+          : null
+      case 'generating-summary':
+        return downloadingModel
+          ? `Link captured. Downloading Chrome’s local model… ${downloadProgress}%`
+          : 'Link captured. Generating summary…'
+      case 'saving-update':
+        return 'Link captured. Adding summary…'
+      default:
+        return null
+    }
   }
 
   return (
@@ -153,7 +308,7 @@ export function CapturePopup(): ReactElement {
         onChange={(event) => setNote(event.target.value)}
         placeholder="Add a note (optional)"
         autoFocus
-        disabled={busy}
+        disabled={busy || lockedAfterSummaryFailure}
         className="rounded-md border border-border bg-input-bg px-2 py-1.5 text-sm text-text outline-none placeholder:text-text-muted focus:ring-2 focus:ring-focus-ring"
       />
       <label className="flex items-center gap-2 text-xs text-text-secondary">
@@ -161,18 +316,49 @@ export function CapturePopup(): ReactElement {
           type="checkbox"
           checked={includePageText}
           onChange={(event) => onIncludePageTextChange(event.target.checked)}
-          disabled={busy}
+          disabled={busy || lockedAfterSummaryFailure}
           className="size-3.5 rounded border-border text-accent focus:ring-focus-ring"
         />
         Capture page text
       </label>
+      <label
+        className="flex items-center gap-2 text-xs text-text-secondary"
+        title={
+          summarySupported
+            ? 'Runs locally with Chrome built-in AI'
+            : 'Chrome built-in page summaries are unavailable on this device'
+        }
+      >
+        <input
+          type="checkbox"
+          checked={summarySupported && includePageSummary}
+          onChange={(event) => onIncludePageSummaryChange(event.target.checked)}
+          disabled={busy || lockedAfterSummaryFailure || !summarySupported}
+          className="size-3.5 rounded border-border text-accent focus:ring-focus-ring"
+        />
+        Capture page summary
+        {summaryAvailability === 'unsupported'
+          ? ' (requires Chrome 138+)'
+          : summaryAvailability === 'unavailable'
+            ? ' (unavailable)'
+            : ''}
+      </label>
       <button
         type="submit"
-        disabled={busy}
+        disabled={busy || lockedAfterSummaryFailure}
         className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-text-on-brand hover:bg-accent-hover disabled:opacity-60"
       >
-        {save.phase === 'saving' ? 'Saving…' : 'Save to Reflect'}
+        {save.phase === 'working'
+          ? save.step === 'generating-summary'
+            ? 'Generating…'
+            : 'Saving…'
+          : save.phase === 'summary-failed'
+            ? 'Link captured'
+            : 'Save to Reflect'}
       </button>
+      {save.phase === 'working' && workingMessage(save.step) ? (
+        <p className="text-xs text-text-muted">{workingMessage(save.step)}</p>
+      ) : null}
       {save.phase === 'held' ? (
         <p className="text-xs text-text-muted">
           {holdMessage(save.result)}{' '}
@@ -189,6 +375,12 @@ export function CapturePopup(): ReactElement {
         </p>
       ) : null}
       {save.phase === 'failed' ? <p className="text-xs text-destructive">{save.message}</p> : null}
+      {save.phase === 'summary-failed' ? (
+        <p className="text-xs text-destructive">
+          {save.message}{' '}
+          {save.result ? <span className="text-text-muted">{holdMessage(save.result)}</span> : null}
+        </p>
+      ) : null}
       {save.phase === 'idle' && heldCount > 0 ? (
         <p className="text-xs text-text-muted">
           {heldCount} earlier {heldCount === 1 ? 'capture' : 'captures'} waiting for Reflect.

--- a/apps/extension/entrypoints/popup/app.tsx
+++ b/apps/extension/entrypoints/popup/app.tsx
@@ -50,6 +50,39 @@ function holdMessage(result: FlushResult): string {
   }
 }
 
+function CheckIcon(): ReactElement {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 16 16" className="size-3.5" fill="none">
+      <path
+        d="m3.25 8.25 3 3 6.5-6.5"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function Spinner(): ReactElement {
+  return <span aria-hidden="true" className="capture-spinner size-3.5 rounded-full border" />
+}
+
+function workingButtonLabel(step: CaptureFlowPhase, downloadingModel: boolean): string {
+  switch (step) {
+    case 'saving-link':
+      return 'Saving link…'
+    case 'extracting-page':
+      return 'Reading page…'
+    case 'generating-summary':
+      return downloadingModel ? 'Downloading…' : 'Generating summary…'
+    case 'saving-page-text':
+      return 'Saving page text…'
+    case 'saving-update':
+      return 'Adding summary…'
+  }
+}
+
 export function CapturePopup(): ReactElement {
   const captured = useCapturedPage()
   const [note, setNote] = useState('')
@@ -235,12 +268,18 @@ export function CapturePopup(): ReactElement {
     summaryAvailability === 'downloading'
   const waitingForSummaryAvailability = includePageSummary && summaryAvailability === 'checking'
   const summaryRequested = includePageSummary && summarySupported
+  const downloadingModel = downloadProgress !== null && downloadProgress < 100
+  const linkCaptured = save.phase === 'working' && summaryRequested && save.step !== 'saving-link'
+  const showWorkingStatus =
+    save.phase === 'working' && summaryRequested && (linkCaptured || downloadingModel)
   const busy =
     save.phase === 'working' ||
     !includePageTextPreferenceLoaded ||
     !includePageSummaryPreferenceLoaded ||
     waitingForSummaryAvailability
   const lockedAfterSummaryFailure = save.phase === 'summary-failed'
+  const captureOptionsDisabled = busy || lockedAfterSummaryFailure
+  const summaryOptionDisabled = captureOptionsDisabled || !summarySupported
 
   function onIncludePageTextChange(checked: boolean): void {
     includePageTextTouched.current = true
@@ -260,29 +299,17 @@ export function CapturePopup(): ReactElement {
     })
   }
 
-  function workingMessage(step: CaptureFlowPhase): string | null {
-    const downloadingModel = downloadProgress !== null && downloadProgress < 100
-    switch (step) {
-      case 'saving-link':
-        return downloadingModel
-          ? `Saving link. Downloading Chrome’s local model… ${downloadProgress}%`
-          : null
-      case 'extracting-page':
-        return summaryRequested
-          ? downloadingModel
-            ? `Link captured. Downloading Chrome’s local model… ${downloadProgress}%`
-            : 'Link captured. Reading page…'
-          : null
-      case 'generating-summary':
-        return downloadingModel
-          ? `Link captured. Downloading Chrome’s local model… ${downloadProgress}%`
-          : 'Link captured. Generating summary…'
-      case 'saving-update':
-        return 'Link captured. Adding summary…'
-      default:
-        return null
-    }
-  }
+  const buttonLabel =
+    save.phase === 'working'
+      ? workingButtonLabel(save.step, downloadingModel)
+      : waitingForSummaryAvailability
+        ? 'Checking summarizer…'
+        : !includePageTextPreferenceLoaded || !includePageSummaryPreferenceLoaded
+          ? 'Loading…'
+          : save.phase === 'summary-failed'
+            ? 'Link captured'
+            : 'Save to Reflect'
+  const showButtonSpinner = busy
 
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-3 p-3">
@@ -308,56 +335,95 @@ export function CapturePopup(): ReactElement {
         onChange={(event) => setNote(event.target.value)}
         placeholder="Add a note (optional)"
         autoFocus
-        disabled={busy || lockedAfterSummaryFailure}
+        disabled={captureOptionsDisabled}
         className="rounded-md border border-border bg-input-bg px-2 py-1.5 text-sm text-text outline-none placeholder:text-text-muted focus:ring-2 focus:ring-focus-ring"
       />
-      <label className="flex items-center gap-2 text-xs text-text-secondary">
-        <input
-          type="checkbox"
-          checked={includePageText}
-          onChange={(event) => onIncludePageTextChange(event.target.checked)}
-          disabled={busy || lockedAfterSummaryFailure}
-          className="size-3.5 rounded border-border text-accent focus:ring-focus-ring"
-        />
-        Capture page text
-      </label>
-      <label
-        className="flex items-center gap-2 text-xs text-text-secondary"
-        title={
-          summarySupported
-            ? 'Runs locally with Chrome built-in AI'
-            : 'Chrome built-in page summaries are unavailable on this device'
-        }
-      >
-        <input
-          type="checkbox"
-          checked={summarySupported && includePageSummary}
-          onChange={(event) => onIncludePageSummaryChange(event.target.checked)}
-          disabled={busy || lockedAfterSummaryFailure || !summarySupported}
-          className="size-3.5 rounded border-border text-accent focus:ring-focus-ring"
-        />
-        Capture page summary
-        {summaryAvailability === 'unsupported'
-          ? ' (requires Chrome 138+)'
-          : summaryAvailability === 'unavailable'
-            ? ' (unavailable)'
-            : ''}
-      </label>
+      <div className="flex flex-col gap-0.5">
+        <label
+          className="capture-option -mx-1 flex min-h-8 items-center gap-2.5 rounded-lg px-2 text-[13px] font-medium text-text"
+          data-disabled={captureOptionsDisabled}
+        >
+          <input
+            type="checkbox"
+            checked={includePageText}
+            onChange={(event) => onIncludePageTextChange(event.target.checked)}
+            disabled={captureOptionsDisabled}
+            className="size-4 shrink-0 accent-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-1"
+          />
+          <span className="min-w-0 flex-1">Capture page text</span>
+        </label>
+        <label
+          className="capture-option -mx-1 flex min-h-8 items-center gap-2.5 rounded-lg px-2 text-[13px] font-medium text-text"
+          data-disabled={summaryOptionDisabled}
+          title={
+            summarySupported
+              ? 'Runs locally with Chrome built-in AI'
+              : 'Chrome built-in page summaries are unavailable on this device'
+          }
+        >
+          <input
+            type="checkbox"
+            checked={summarySupported && includePageSummary}
+            onChange={(event) => onIncludePageSummaryChange(event.target.checked)}
+            disabled={summaryOptionDisabled}
+            className="size-4 shrink-0 accent-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-1"
+          />
+          <span className="min-w-0 flex-1">Capture page summary</span>
+          {summaryAvailability === 'unsupported' ? (
+            <span className="text-[11px] font-normal text-text-muted">Chrome 138+</span>
+          ) : summaryAvailability === 'unavailable' ? (
+            <span className="text-[11px] font-normal text-text-muted">Unavailable</span>
+          ) : null}
+        </label>
+      </div>
       <button
         type="submit"
-        disabled={busy || lockedAfterSummaryFailure}
-        className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-text-on-brand hover:bg-accent-hover disabled:opacity-60"
+        disabled={captureOptionsDisabled}
+        className="capture-button h-8 w-full rounded-lg bg-accent px-3 text-sm font-medium text-text-on-brand disabled:opacity-60"
       >
-        {save.phase === 'working'
-          ? save.step === 'generating-summary'
-            ? 'Generating…'
-            : 'Saving…'
-          : save.phase === 'summary-failed'
-            ? 'Link captured'
-            : 'Save to Reflect'}
+        <span
+          key={buttonLabel}
+          className="capture-state-enter inline-flex items-center justify-center gap-2"
+        >
+          {showButtonSpinner ? <Spinner /> : null}
+          <span>{buttonLabel}</span>
+        </span>
       </button>
-      {save.phase === 'working' && workingMessage(save.step) ? (
-        <p className="text-xs text-text-muted">{workingMessage(save.step)}</p>
+      {showWorkingStatus ? (
+        <div
+          key={`${linkCaptured ? 'captured' : 'saving'}-${downloadingModel ? 'downloading' : 'ready'}`}
+          className="capture-state-enter flex flex-col gap-2 px-0.5 text-xs text-text-muted"
+        >
+          {linkCaptured ? (
+            <div role="status" className="flex items-center gap-1.5 text-text-secondary">
+              <span className="text-accent">
+                <CheckIcon />
+              </span>
+              <span>Link captured</span>
+            </div>
+          ) : null}
+          {downloadingModel ? (
+            <div className="flex flex-col gap-1.5">
+              <div className="flex items-center justify-between gap-3">
+                <span>Downloading summarizer</span>
+                <span className="tabular-nums">{downloadProgress}%</span>
+              </div>
+              <div
+                role="progressbar"
+                aria-label="Downloading summarizer"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={downloadProgress}
+                className="h-0.5 overflow-hidden rounded-full bg-border"
+              >
+                <div
+                  className="capture-progress-fill h-full w-full origin-left rounded-full bg-accent"
+                  style={{ transform: `scaleX(${downloadProgress / 100})` }}
+                />
+              </div>
+            </div>
+          ) : null}
+        </div>
       ) : null}
       {save.phase === 'held' ? (
         <p className="text-xs text-text-muted">

--- a/apps/extension/entrypoints/popup/app.tsx
+++ b/apps/extension/entrypoints/popup/app.tsx
@@ -195,7 +195,7 @@ export function CapturePopup(): ReactElement {
       } else if (result.kind === 'update-rejected') {
         setSave({
           phase: 'summary-failed',
-          message: 'Link captured, but the summary update was rejected — please report this.',
+          message: 'Link captured, but the capture update was rejected — please report this.',
           result: result.linkOutcome.fate === 'held' ? result.linkOutcome.result : undefined,
         })
       } else if (result.kind === 'summary-failed') {

--- a/apps/extension/entrypoints/popup/capture-flow.test.ts
+++ b/apps/extension/entrypoints/popup/capture-flow.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PageSummaryTask } from '@/lib/page-summary'
+import type { SaveOutcome } from '@/lib/save-capture'
+import {
+  runCaptureFlow,
+  type CaptureFlowCallbacks,
+  type CaptureFlowDependencies,
+  type CaptureFlowInput,
+} from './capture-flow'
+
+const CAPTURED_AT = new Date('2026-08-22T09:30:00.000Z')
+const FIRST_ID = '00000000-0000-4000-8000-000000000001'
+const SECOND_ID = '00000000-0000-4000-8000-000000000002'
+const QUEUED: SaveOutcome = { fate: 'queued' }
+
+const INPUT: CaptureFlowInput = {
+  page: {
+    url: 'https://example.com/article',
+    title: 'An article',
+    selection: 'quoted text',
+    screenshotDataUrl: 'data:image/jpeg;base64,aGVsbG8=',
+  },
+  tabId: 42,
+  note: 'read later',
+  includePageText: false,
+  includePageSummary: true,
+}
+
+function callbacks(): CaptureFlowCallbacks & {
+  phases: ReturnType<typeof vi.fn<CaptureFlowCallbacks['onPhase']>>
+} {
+  const phases = vi.fn<CaptureFlowCallbacks['onPhase']>()
+  return { onPhase: phases, phases, onDownloadProgress: vi.fn() }
+}
+
+function dependencies(overrides: Partial<CaptureFlowDependencies> = {}): {
+  dependencies: CaptureFlowDependencies
+  saveCapture: ReturnType<typeof vi.fn<CaptureFlowDependencies['saveCapture']>>
+  summarize: ReturnType<typeof vi.fn<PageSummaryTask['summarize']>>
+  cancel: ReturnType<typeof vi.fn<PageSummaryTask['cancel']>>
+} {
+  const saveCapture = vi.fn<CaptureFlowDependencies['saveCapture']>().mockResolvedValue(QUEUED)
+  const summarize = vi
+    .fn<PageSummaryTask['summarize']>()
+    .mockResolvedValue('- First key point\n- Second key point')
+  const cancel = vi.fn<PageSummaryTask['cancel']>()
+  const ids = [FIRST_ID, SECOND_ID]
+  const defaults: CaptureFlowDependencies = {
+    now: () => CAPTURED_AT,
+    randomId: () => ids.shift() ?? crypto.randomUUID(),
+    extractPageText: vi.fn().mockResolvedValue('First paragraph.\n\nSecond paragraph.'),
+    saveCapture,
+    startPageSummary: () => ({ summarize, cancel }),
+  }
+  return {
+    dependencies: { ...defaults, ...overrides },
+    saveCapture,
+    summarize,
+    cancel,
+  }
+}
+
+describe('runCaptureFlow', () => {
+  it('queues the raw link before extraction, then sends a same-time summary update', async () => {
+    let resolvePageText: ((value: string | undefined) => void) | undefined
+    const pageText = new Promise<string | undefined>((resolve) => {
+      resolvePageText = resolve
+    })
+    const setup = dependencies({ extractPageText: () => pageText })
+    const events = callbacks()
+
+    const resultPromise = runCaptureFlow(INPUT, events, setup.dependencies)
+
+    expect(setup.saveCapture).toHaveBeenCalledOnce()
+    expect(setup.saveCapture.mock.calls[0]?.[0]).toMatchObject({
+      id: FIRST_ID,
+      capturedAt: CAPTURED_AT,
+      url: INPUT.page.url,
+      selection: INPUT.page.selection,
+      screenshotDataUrl: INPUT.page.screenshotDataUrl,
+      note: INPUT.note,
+    })
+    expect(setup.saveCapture.mock.calls[0]?.[0].contentText).toBeUndefined()
+    expect(setup.saveCapture.mock.calls[0]?.[0].summary).toBeUndefined()
+
+    resolvePageText?.('First paragraph.\n\nSecond paragraph.')
+    await expect(resultPromise).resolves.toEqual({ kind: 'saved', outcome: QUEUED })
+
+    expect(setup.saveCapture).toHaveBeenCalledTimes(2)
+    expect(setup.saveCapture.mock.calls[1]?.[0]).toMatchObject({
+      id: SECOND_ID,
+      capturedAt: CAPTURED_AT,
+      summary: '- First key point\n- Second key point',
+    })
+    expect(setup.saveCapture.mock.calls[1]?.[0].contentText).toBeUndefined()
+    expect(events.phases.mock.calls.map(([phase]) => phase)).toEqual([
+      'saving-link',
+      'extracting-page',
+      'generating-summary',
+      'saving-update',
+    ])
+  })
+
+  it('captures page text and summary together when both options are selected', async () => {
+    const setup = dependencies()
+
+    await runCaptureFlow({ ...INPUT, includePageText: true }, callbacks(), setup.dependencies)
+
+    expect(setup.saveCapture.mock.calls[1]?.[0]).toMatchObject({
+      contentText: 'First paragraph.\n\nSecond paragraph.',
+      summary: '- First key point\n- Second key point',
+    })
+  })
+
+  it('keeps the existing single-phase page-text capture when summary is off', async () => {
+    const setup = dependencies()
+
+    await expect(
+      runCaptureFlow(
+        { ...INPUT, includePageText: true, includePageSummary: false },
+        callbacks(),
+        setup.dependencies,
+      ),
+    ).resolves.toEqual({ kind: 'saved', outcome: QUEUED })
+
+    expect(setup.saveCapture).toHaveBeenCalledOnce()
+    expect(setup.saveCapture.mock.calls[0]?.[0].contentText).toBe(
+      'First paragraph.\n\nSecond paragraph.',
+    )
+    expect(setup.summarize).not.toHaveBeenCalled()
+  })
+
+  it('still saves requested page text when summary generation fails', async () => {
+    const summaryFailure = new Error('model failed')
+    const summarize = vi.fn<PageSummaryTask['summarize']>().mockRejectedValue(summaryFailure)
+    const setup = dependencies({ startPageSummary: () => ({ summarize, cancel: vi.fn() }) })
+
+    const result = await runCaptureFlow(
+      { ...INPUT, includePageText: true },
+      callbacks(),
+      setup.dependencies,
+    )
+
+    expect(result).toEqual({
+      kind: 'summary-failed',
+      cause: summaryFailure,
+      linkOutcome: QUEUED,
+      pageTextOutcome: QUEUED,
+    })
+    expect(setup.saveCapture).toHaveBeenCalledTimes(2)
+    expect(setup.saveCapture.mock.calls[1]?.[0].contentText).toBe(
+      'First paragraph.\n\nSecond paragraph.',
+    )
+    expect(setup.saveCapture.mock.calls[1]?.[0].summary).toBeUndefined()
+  })
+
+  it('cancels model work when the raw link is rejected', async () => {
+    const rejected: SaveOutcome = { fate: 'rejected' }
+    const saveCapture = vi.fn<CaptureFlowDependencies['saveCapture']>().mockResolvedValue(rejected)
+    const setup = dependencies({ saveCapture })
+
+    await expect(runCaptureFlow(INPUT, callbacks(), setup.dependencies)).resolves.toEqual({
+      kind: 'link-rejected',
+    })
+    expect(setup.cancel).toHaveBeenCalledOnce()
+    expect(setup.summarize).not.toHaveBeenCalled()
+  })
+})

--- a/apps/extension/entrypoints/popup/capture-flow.test.ts
+++ b/apps/extension/entrypoints/popup/capture-flow.test.ts
@@ -154,6 +154,19 @@ describe('runCaptureFlow', () => {
     expect(setup.saveCapture.mock.calls[1]?.[0].summary).toBeUndefined()
   })
 
+  it('reports a rejected page-text fallback update instead of implying it landed', async () => {
+    const rejected: SaveOutcome = { fate: 'rejected' }
+    const summarize = vi
+      .fn<PageSummaryTask['summarize']>()
+      .mockRejectedValue(new Error('model failed'))
+    const setup = dependencies({ startPageSummary: () => ({ summarize, cancel: vi.fn() }) })
+    setup.saveCapture.mockResolvedValueOnce(QUEUED).mockResolvedValueOnce(rejected)
+
+    await expect(
+      runCaptureFlow({ ...INPUT, includePageText: true }, callbacks(), setup.dependencies),
+    ).resolves.toEqual({ kind: 'update-rejected', linkOutcome: QUEUED })
+  })
+
   it('cancels model work when extraction returns no readable page text', async () => {
     const setup = dependencies({ extractPageText: vi.fn().mockResolvedValue(undefined) })
 

--- a/apps/extension/entrypoints/popup/capture-flow.test.ts
+++ b/apps/extension/entrypoints/popup/capture-flow.test.ts
@@ -134,10 +134,11 @@ describe('runCaptureFlow', () => {
     const summaryFailure = new Error('model failed')
     const summarize = vi.fn<PageSummaryTask['summarize']>().mockRejectedValue(summaryFailure)
     const setup = dependencies({ startPageSummary: () => ({ summarize, cancel: vi.fn() }) })
+    const events = callbacks()
 
     const result = await runCaptureFlow(
       { ...INPUT, includePageText: true },
-      callbacks(),
+      events,
       setup.dependencies,
     )
 
@@ -152,6 +153,12 @@ describe('runCaptureFlow', () => {
       'First paragraph.\n\nSecond paragraph.',
     )
     expect(setup.saveCapture.mock.calls[1]?.[0].summary).toBeUndefined()
+    expect(events.phases.mock.calls.map(([phase]) => phase)).toEqual([
+      'saving-link',
+      'extracting-page',
+      'generating-summary',
+      'saving-page-text',
+    ])
   })
 
   it('reports a rejected page-text fallback update instead of implying it landed', async () => {

--- a/apps/extension/entrypoints/popup/capture-flow.test.ts
+++ b/apps/extension/entrypoints/popup/capture-flow.test.ts
@@ -154,6 +154,45 @@ describe('runCaptureFlow', () => {
     expect(setup.saveCapture.mock.calls[1]?.[0].summary).toBeUndefined()
   })
 
+  it('cancels model work when extraction returns no readable page text', async () => {
+    const setup = dependencies({ extractPageText: vi.fn().mockResolvedValue(undefined) })
+
+    const result = await runCaptureFlow(INPUT, callbacks(), setup.dependencies)
+
+    expect(result).toMatchObject({ kind: 'summary-failed', linkOutcome: QUEUED })
+    expect(result.kind === 'summary-failed' ? result.cause : null).toEqual(
+      new Error('The page did not contain any readable text to summarize'),
+    )
+    expect(setup.cancel).toHaveBeenCalledOnce()
+    expect(setup.summarize).not.toHaveBeenCalled()
+    expect(setup.saveCapture).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the raw link without an update when a summary-only capture fails', async () => {
+    const summaryFailure = new Error('model failed')
+    const summarize = vi.fn<PageSummaryTask['summarize']>().mockRejectedValue(summaryFailure)
+    const setup = dependencies({ startPageSummary: () => ({ summarize, cancel: vi.fn() }) })
+
+    await expect(runCaptureFlow(INPUT, callbacks(), setup.dependencies)).resolves.toEqual({
+      kind: 'summary-failed',
+      cause: summaryFailure,
+      linkOutcome: QUEUED,
+    })
+    expect(setup.saveCapture).toHaveBeenCalledOnce()
+  })
+
+  it('reports a rejected enrichment update without losing the queued link', async () => {
+    const rejected: SaveOutcome = { fate: 'rejected' }
+    const setup = dependencies()
+    setup.saveCapture.mockResolvedValueOnce(QUEUED).mockResolvedValueOnce(rejected)
+
+    await expect(runCaptureFlow(INPUT, callbacks(), setup.dependencies)).resolves.toEqual({
+      kind: 'update-rejected',
+      linkOutcome: QUEUED,
+    })
+    expect(setup.saveCapture).toHaveBeenCalledTimes(2)
+  })
+
   it('cancels model work when the raw link is rejected', async () => {
     const rejected: SaveOutcome = { fate: 'rejected' }
     const saveCapture = vi.fn<CaptureFlowDependencies['saveCapture']>().mockResolvedValue(rejected)

--- a/apps/extension/entrypoints/popup/capture-flow.ts
+++ b/apps/extension/entrypoints/popup/capture-flow.ts
@@ -118,6 +118,9 @@ export async function runCaptureFlow(
     const pageTextOutcome = await dependencies.saveCapture(
       captureInput(input, dependencies, capturedAt, { contentText }),
     )
+    if (pageTextOutcome.fate === 'rejected') {
+      return { kind: 'update-rejected', linkOutcome }
+    }
     return { kind: 'summary-failed', cause, linkOutcome, pageTextOutcome }
   }
 

--- a/apps/extension/entrypoints/popup/capture-flow.ts
+++ b/apps/extension/entrypoints/popup/capture-flow.ts
@@ -1,0 +1,134 @@
+import type { BuildWireMessageInput, CapturedPage } from '@/lib/capture-message'
+import type { PageSummaryTask } from '@/lib/page-summary'
+import type { SaveOutcome } from '@/lib/save-capture'
+
+export type CaptureFlowPhase =
+  | 'extracting-page'
+  | 'saving-link'
+  | 'generating-summary'
+  | 'saving-update'
+
+export interface CaptureFlowInput {
+  page: CapturedPage
+  tabId: number
+  note: string
+  includePageText: boolean
+  includePageSummary: boolean
+}
+
+export interface CaptureFlowCallbacks {
+  onPhase: (phase: CaptureFlowPhase) => void
+  onDownloadProgress: (progress: number) => void
+}
+
+export interface CaptureFlowDependencies {
+  now: () => Date
+  randomId: () => string
+  extractPageText: (tabId: number, expectedUrl: string) => Promise<string | undefined>
+  saveCapture: (capture: BuildWireMessageInput) => Promise<SaveOutcome>
+  startPageSummary: (options: {
+    title: string
+    onDownloadProgress: (progress: number) => void
+  }) => PageSummaryTask
+}
+
+export type CaptureFlowResult =
+  | { kind: 'saved'; outcome: SaveOutcome }
+  | { kind: 'link-rejected' }
+  | { kind: 'update-rejected'; linkOutcome: SaveOutcome }
+  | {
+      kind: 'summary-failed'
+      cause: unknown
+      linkOutcome: SaveOutcome
+      pageTextOutcome?: SaveOutcome | undefined
+    }
+
+function captureInput(
+  input: CaptureFlowInput,
+  dependencies: CaptureFlowDependencies,
+  capturedAt: Date,
+  extras: { contentText?: string | undefined; summary?: string | undefined } = {},
+): BuildWireMessageInput {
+  return {
+    ...input.page,
+    ...extras,
+    note: input.note,
+    id: dependencies.randomId(),
+    capturedAt,
+  }
+}
+
+/**
+ * Capture with popup-selected options. Summary captures are deliberately
+ * two-phase: the raw link is durable before page extraction or local model
+ * work begins, then a same-day recapture refreshes that note in place.
+ */
+export async function runCaptureFlow(
+  input: CaptureFlowInput,
+  callbacks: CaptureFlowCallbacks,
+  dependencies: CaptureFlowDependencies,
+): Promise<CaptureFlowResult> {
+  const capturedAt = dependencies.now()
+  const summaryTask = input.includePageSummary
+    ? dependencies.startPageSummary({
+        title: input.page.title,
+        onDownloadProgress: callbacks.onDownloadProgress,
+      })
+    : null
+
+  if (summaryTask === null) {
+    callbacks.onPhase(input.includePageText ? 'extracting-page' : 'saving-link')
+    const contentText = input.includePageText
+      ? await dependencies.extractPageText(input.tabId, input.page.url)
+      : undefined
+    callbacks.onPhase('saving-link')
+    const outcome = await dependencies.saveCapture(
+      captureInput(input, dependencies, capturedAt, { contentText }),
+    )
+    return outcome.fate === 'rejected' ? { kind: 'link-rejected' } : { kind: 'saved', outcome }
+  }
+
+  callbacks.onPhase('saving-link')
+  const linkOutcome = await dependencies.saveCapture(captureInput(input, dependencies, capturedAt))
+  if (linkOutcome.fate === 'rejected') {
+    summaryTask.cancel()
+    return { kind: 'link-rejected' }
+  }
+
+  callbacks.onPhase('extracting-page')
+  const contentText = await dependencies.extractPageText(input.tabId, input.page.url)
+  if (contentText === undefined) {
+    summaryTask.cancel()
+    return {
+      kind: 'summary-failed',
+      cause: new Error('The page did not contain any readable text to summarize'),
+      linkOutcome,
+    }
+  }
+
+  callbacks.onPhase('generating-summary')
+  let summary: string
+  try {
+    summary = await summaryTask.summarize(contentText)
+  } catch (cause) {
+    if (!input.includePageText) {
+      return { kind: 'summary-failed', cause, linkOutcome }
+    }
+    callbacks.onPhase('saving-update')
+    const pageTextOutcome = await dependencies.saveCapture(
+      captureInput(input, dependencies, capturedAt, { contentText }),
+    )
+    return { kind: 'summary-failed', cause, linkOutcome, pageTextOutcome }
+  }
+
+  callbacks.onPhase('saving-update')
+  const updateOutcome = await dependencies.saveCapture(
+    captureInput(input, dependencies, capturedAt, {
+      contentText: input.includePageText ? contentText : undefined,
+      summary,
+    }),
+  )
+  return updateOutcome.fate === 'rejected'
+    ? { kind: 'update-rejected', linkOutcome }
+    : { kind: 'saved', outcome: updateOutcome }
+}

--- a/apps/extension/entrypoints/popup/capture-flow.ts
+++ b/apps/extension/entrypoints/popup/capture-flow.ts
@@ -6,6 +6,7 @@ export type CaptureFlowPhase =
   | 'extracting-page'
   | 'saving-link'
   | 'generating-summary'
+  | 'saving-page-text'
   | 'saving-update'
 
 export interface CaptureFlowInput {
@@ -114,7 +115,7 @@ export async function runCaptureFlow(
     if (!input.includePageText) {
       return { kind: 'summary-failed', cause, linkOutcome }
     }
-    callbacks.onPhase('saving-update')
+    callbacks.onPhase('saving-page-text')
     const pageTextOutcome = await dependencies.saveCapture(
       captureInput(input, dependencies, capturedAt, { contentText }),
     )

--- a/apps/extension/entrypoints/popup/style.css
+++ b/apps/extension/entrypoints/popup/style.css
@@ -29,3 +29,97 @@ body {
   color: var(--text);
   font-family: var(--font-sans, system-ui, sans-serif);
 }
+
+.capture-option {
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard),
+    opacity var(--duration-fast) var(--ease-standard);
+}
+
+.capture-option[data-disabled='true'] {
+  cursor: default;
+  opacity: 0.58;
+}
+
+.capture-button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.capture-button {
+  transition:
+    background-color var(--duration-fast) var(--ease-standard),
+    opacity var(--duration-fast) var(--ease-standard),
+    transform var(--duration-base) var(--ease-standard);
+}
+
+.capture-button:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.capture-spinner {
+  border-color: currentColor;
+  border-right-color: transparent;
+  animation: capture-spin 650ms linear infinite;
+}
+
+.capture-state-enter {
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    opacity var(--duration-base) var(--ease-standard),
+    transform var(--duration-base) var(--ease-standard);
+}
+
+.capture-progress-fill {
+  transition: transform var(--duration-base) linear;
+}
+
+@starting-style {
+  .capture-state-enter {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+}
+
+@keyframes capture-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .capture-option[data-disabled='false']:hover {
+    background: var(--surface-hover);
+  }
+
+  .capture-button:hover:not(:disabled) {
+    background: var(--accent-hover);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .capture-option,
+  .capture-button,
+  .capture-progress-fill {
+    transition: none;
+  }
+
+  .capture-state-enter {
+    transform: none;
+    transition: opacity var(--duration-fast) var(--ease-standard);
+  }
+
+  .capture-spinner {
+    animation-duration: 1.2s;
+  }
+
+  @starting-style {
+    .capture-state-enter {
+      opacity: 0;
+      transform: none;
+    }
+  }
+}

--- a/apps/extension/lib/capture-message.test.ts
+++ b/apps/extension/lib/capture-message.test.ts
@@ -30,12 +30,14 @@ describe('buildWireMessage', () => {
       title: '  An article  ',
       selection: 'quoted',
       contentText: 'First paragraph.\n\nSecond paragraph.',
+      summary: '- First key point\n- Second key point',
       note: 'check later',
       screenshotDataUrl: 'data:image/jpeg;base64,aGVsbG8=',
     })
     expect(captureWireMessageSchema.parse(message)).toEqual(message)
     expect(message.envelope.title).toBe('An article')
     expect(message.envelope.contentText).toBe('First paragraph.\n\nSecond paragraph.')
+    expect(message.envelope.summary).toBe('- First key point\n- Second key point')
     expect(message.envelope.capturedAt).toBe('2026-06-12T15:30:22.845Z')
     expect(message.screenshotBase64).toBe('aGVsbG8=')
   })
@@ -48,10 +50,12 @@ describe('buildWireMessage', () => {
       title: 'Example',
       selection: '   ',
       contentText: '',
+      summary: ' ',
       note: '',
     })
     expect(message.envelope.selection).toBeUndefined()
     expect(message.envelope.contentText).toBeUndefined()
+    expect(message.envelope.summary).toBeUndefined()
     expect(message.envelope.note).toBeUndefined()
     expect(message.screenshotBase64).toBeUndefined()
   })

--- a/apps/extension/lib/capture-message.ts
+++ b/apps/extension/lib/capture-message.ts
@@ -16,6 +16,8 @@ export interface CapturedPage {
   selection?: string | undefined
   /** Defuddle-extracted page paragraphs, when the user asks to include them. */
   contentText?: string | undefined
+  /** On-device browser summary of the extracted page text. */
+  summary?: string | undefined
   /** The user's comment from the popup. */
   note?: string | undefined
 }
@@ -52,6 +54,7 @@ export function buildWireMessage(input: BuildWireMessageInput): CaptureWireMessa
       title: input.title.trim(),
       selection: presence(input.selection),
       contentText: presence(input.contentText),
+      summary: presence(input.summary),
       note: presence(input.note),
       capturedAt: input.capturedAt.toISOString(),
       source: 'extension',

--- a/apps/extension/lib/commands.test.ts
+++ b/apps/extension/lib/commands.test.ts
@@ -11,18 +11,21 @@ describe('openCapturePopupOrFallback', () => {
     expect(fallbackCapture).not.toHaveBeenCalled()
   })
 
-  it('falls back when openPopup is unavailable or rejected', async () => {
+  it('falls back only when openPopup is unavailable', async () => {
     const fallbackCapture = vi.fn().mockResolvedValue(undefined)
 
     await expect(openCapturePopupOrFallback(undefined, fallbackCapture)).resolves.toBe(
       'fallback-capture',
     )
     expect(fallbackCapture).toHaveBeenCalledOnce()
+  })
 
-    const rejectedPopup = vi.fn().mockRejectedValue(new Error('not supported'))
-    await expect(openCapturePopupOrFallback(rejectedPopup, fallbackCapture)).resolves.toBe(
-      'fallback-capture',
-    )
-    expect(fallbackCapture).toHaveBeenCalledTimes(2)
+  it('does not silently capture when an available openPopup call is rejected', async () => {
+    const popupFailure = new Error('the popup is already open')
+    const openPopup = vi.fn().mockRejectedValue(popupFailure)
+    const fallbackCapture = vi.fn().mockResolvedValue(undefined)
+
+    await expect(openCapturePopupOrFallback(openPopup, fallbackCapture)).rejects.toBe(popupFailure)
+    expect(fallbackCapture).not.toHaveBeenCalled()
   })
 })

--- a/apps/extension/lib/commands.test.ts
+++ b/apps/extension/lib/commands.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest'
+import { openCapturePopupOrFallback } from './commands'
+
+describe('openCapturePopupOrFallback', () => {
+  it('opens the action popup without taking the legacy capture path', async () => {
+    const openPopup = vi.fn().mockResolvedValue(undefined)
+    const fallbackCapture = vi.fn().mockResolvedValue(undefined)
+
+    await expect(openCapturePopupOrFallback(openPopup, fallbackCapture)).resolves.toBe('popup')
+    expect(openPopup).toHaveBeenCalledOnce()
+    expect(fallbackCapture).not.toHaveBeenCalled()
+  })
+
+  it('falls back when openPopup is unavailable or rejected', async () => {
+    const fallbackCapture = vi.fn().mockResolvedValue(undefined)
+
+    await expect(openCapturePopupOrFallback(undefined, fallbackCapture)).resolves.toBe(
+      'fallback-capture',
+    )
+    expect(fallbackCapture).toHaveBeenCalledOnce()
+
+    const rejectedPopup = vi.fn().mockRejectedValue(new Error('not supported'))
+    await expect(openCapturePopupOrFallback(rejectedPopup, fallbackCapture)).resolves.toBe(
+      'fallback-capture',
+    )
+    expect(fallbackCapture).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/extension/lib/commands.ts
+++ b/apps/extension/lib/commands.ts
@@ -1,6 +1,7 @@
 /** Chrome command id for opening the capture popup for the active page. */
 export const SAVE_CURRENT_PAGE_COMMAND = 'save-current-page'
 
+/** Whether the shortcut opened the popup or used the legacy instant-capture path. */
 export type OpenCaptureCommandOutcome = 'popup' | 'fallback-capture'
 
 /**

--- a/apps/extension/lib/commands.ts
+++ b/apps/extension/lib/commands.ts
@@ -1,2 +1,25 @@
-/** Chrome command id for saving the active page with default capture settings. */
+/** Chrome command id for opening the capture popup for the active page. */
 export const SAVE_CURRENT_PAGE_COMMAND = 'save-current-page'
+
+export type OpenCaptureCommandOutcome = 'popup' | 'fallback-capture'
+
+/**
+ * Open the action popup for the keyboard command. Chrome before 127 does not
+ * expose `action.openPopup`, so retain the old instant-capture behavior as a
+ * compatibility fallback.
+ */
+export async function openCapturePopupOrFallback(
+  openPopup: (() => Promise<void>) | undefined,
+  fallbackCapture: () => Promise<void>,
+): Promise<OpenCaptureCommandOutcome> {
+  if (openPopup) {
+    try {
+      await openPopup()
+      return 'popup'
+    } catch {
+      // A browser that exposes but rejects openPopup still gets a capture.
+    }
+  }
+  await fallbackCapture()
+  return 'fallback-capture'
+}

--- a/apps/extension/lib/commands.ts
+++ b/apps/extension/lib/commands.ts
@@ -14,12 +14,8 @@ export async function openCapturePopupOrFallback(
   fallbackCapture: () => Promise<void>,
 ): Promise<OpenCaptureCommandOutcome> {
   if (openPopup) {
-    try {
-      await openPopup()
-      return 'popup'
-    } catch {
-      // A browser that exposes but rejects openPopup still gets a capture.
-    }
+    await openPopup()
+    return 'popup'
   }
   await fallbackCapture()
   return 'fallback-capture'

--- a/apps/extension/lib/page-summary.test.ts
+++ b/apps/extension/lib/page-summary.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { pageSummaryAvailability, startPageSummary, supportsPageSummary } from './page-summary'
+
+function fakeSummarizer(overrides: Record<string, unknown> = {}) {
+  return {
+    inputQuota: 1_000,
+    measureInputUsage: vi.fn((input: string) => Promise.resolve(input.length)),
+    summarize: vi.fn((_input: string) => Promise.resolve('- A concise key point')),
+    destroy: vi.fn(),
+    ...overrides,
+  }
+}
+
+function installSummarizerApi(summarizer: ReturnType<typeof fakeSummarizer>) {
+  const availability = vi.fn<() => Promise<Availability>>().mockResolvedValue('available')
+  const create = vi.fn((options?: SummarizerCreateOptions) => {
+    if (options?.monitor) {
+      const monitor = new EventTarget()
+      Object.defineProperty(monitor, 'ondownloadprogress', { value: null, writable: true })
+      options.monitor(monitor as CreateMonitor)
+      const progress = new Event('downloadprogress')
+      Object.defineProperty(progress, 'loaded', { value: 0.42 })
+      monitor.dispatchEvent(progress)
+    }
+    return Promise.resolve(summarizer)
+  })
+  vi.stubGlobal('Summarizer', { availability, create })
+  return { availability, create }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('page summary availability', () => {
+  it('reports unsupported when Chrome does not expose the API', async () => {
+    expect(supportsPageSummary()).toBe(false)
+    await expect(pageSummaryAvailability()).resolves.toBe('unsupported')
+  })
+
+  it('forwards Chrome model availability with the configured summary shape', async () => {
+    const api = installSummarizerApi(fakeSummarizer())
+    api.availability.mockResolvedValue('downloadable')
+
+    await expect(pageSummaryAvailability()).resolves.toBe('downloadable')
+    expect(api.availability).toHaveBeenCalledWith({
+      type: 'key-points',
+      format: 'markdown',
+      length: 'medium',
+      preference: 'auto',
+    })
+  })
+})
+
+describe('startPageSummary', () => {
+  it('creates the configured session, reports download progress, and releases it', async () => {
+    const summarizer = fakeSummarizer()
+    const api = installSummarizerApi(summarizer)
+    const onDownloadProgress = vi.fn()
+
+    const task = startPageSummary({ title: 'An article', onDownloadProgress })
+    await expect(task.summarize(' First paragraph. ')).resolves.toBe('- A concise key point')
+
+    expect(api.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'key-points',
+        format: 'markdown',
+        length: 'medium',
+        preference: 'auto',
+        sharedContext: 'Readable text from a web page titled "An article".',
+      }),
+    )
+    expect(onDownloadProgress).toHaveBeenCalledWith(42)
+    expect(summarizer.measureInputUsage).toHaveBeenCalledWith('First paragraph.')
+    expect(summarizer.summarize).toHaveBeenCalledWith(
+      'First paragraph.',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+    expect(summarizer.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('trims over-quota input at a text boundary with headroom', async () => {
+    const summarize = vi.fn((_input: string) => Promise.resolve('- Summary'))
+    const summarizer = fakeSummarizer({ inputQuota: 45, summarize })
+    installSummarizerApi(summarizer)
+    const input =
+      'First paragraph contains the important introduction.\n\nSecond paragraph adds details that will not fit.'
+
+    await startPageSummary({ title: 'Long article' }).summarize(input)
+
+    const summarizedInput = summarize.mock.calls[0]?.[0]
+    expect(typeof summarizedInput).toBe('string')
+    expect(summarizedInput?.length).toBeLessThanOrEqual(45)
+    expect(summarizedInput).toBe('First paragraph contains the important')
+  })
+
+  it('rejects blank model output and still releases the session', async () => {
+    const summarizer = fakeSummarizer({
+      summarize: vi.fn((_input: string) => Promise.resolve('  ')),
+    })
+    installSummarizerApi(summarizer)
+
+    await expect(startPageSummary({ title: 'Article' }).summarize('Readable text')).rejects.toThrow(
+      'Chrome returned an empty summary',
+    )
+    expect(summarizer.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('aborts pending model creation and destroys a session that arrives afterward', async () => {
+    const summarizer = fakeSummarizer()
+    let resolveCreation: ((value: ReturnType<typeof fakeSummarizer>) => void) | undefined
+    const creation = new Promise<ReturnType<typeof fakeSummarizer>>((resolve) => {
+      resolveCreation = resolve
+    })
+    vi.stubGlobal('Summarizer', {
+      availability: vi.fn(() => Promise.resolve('available')),
+      create: vi.fn(() => creation),
+    })
+
+    const task = startPageSummary({ title: 'Article' })
+    task.cancel()
+    resolveCreation?.(summarizer)
+
+    await expect(task.summarize('Readable text')).rejects.toMatchObject({ name: 'AbortError' })
+    expect(summarizer.destroy).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/extension/lib/page-summary.test.ts
+++ b/apps/extension/lib/page-summary.test.ts
@@ -94,14 +94,25 @@ describe('startPageSummary', () => {
     expect(summarizedInput).toBe('First paragraph contains the important')
   })
 
+  it('hard-trims instead of collapsing to an early word boundary', async () => {
+    const summarize = vi.fn((_input: string) => Promise.resolve('- Summary'))
+    const summarizer = fakeSummarizer({ inputQuota: 50, summarize })
+    installSummarizerApi(summarizer)
+
+    await startPageSummary({ title: 'Blob-heavy article' }).summarize(`A ${'x'.repeat(200)}`)
+
+    expect(summarize.mock.calls[0]?.[0]).toHaveLength(45)
+    expect(summarize.mock.calls[0]?.[0].startsWith('A ')).toBe(true)
+  })
+
   it('rejects blank model output and still releases the session', async () => {
     const summarizer = fakeSummarizer({
       summarize: vi.fn((_input: string) => Promise.resolve('  ')),
     })
     installSummarizerApi(summarizer)
 
-    await expect(startPageSummary({ title: 'Article' }).summarize('Readable text')).rejects.toThrow(
-      'Chrome returned an empty summary',
+    await expect(startPageSummary({ title: 'Article' }).summarize('Readable text')).rejects.toEqual(
+      new Error('Chrome returned an empty summary'),
     )
     expect(summarizer.destroy).toHaveBeenCalledOnce()
   })

--- a/apps/extension/lib/page-summary.ts
+++ b/apps/extension/lib/page-summary.ts
@@ -72,7 +72,13 @@ function truncateAtTextBoundary(text: string, maximumLength: number): string {
   const prefix = text.slice(0, Math.max(1, maximumLength))
   const paragraphAt = prefix.lastIndexOf('\n\n')
   const wordAt = prefix.lastIndexOf(' ')
-  const boundary = paragraphAt >= prefix.length / 2 ? paragraphAt : wordAt
+  const minimumBoundary = prefix.length / 2
+  const boundary =
+    paragraphAt >= minimumBoundary
+      ? paragraphAt
+      : wordAt >= minimumBoundary
+        ? wordAt
+        : prefix.length
   return prefix.slice(0, boundary > 0 ? boundary : prefix.length).trimEnd()
 }
 
@@ -153,9 +159,13 @@ export function startPageSummary(options: StartPageSummaryOptions): PageSummaryT
       }
       try {
         const input = await fitToInputQuota(result.summarizer, contentText)
-        return summaryOutputSchema.parse(
+        const output = summaryOutputSchema.safeParse(
           await result.summarizer.summarize(input, { signal: abortController.signal }),
         )
+        if (!output.success) {
+          throw new Error(output.error.issues[0]?.message ?? 'Chrome returned an invalid summary')
+        }
+        return output.data
       } finally {
         if (activeSummarizer === result.summarizer) {
           result.summarizer.destroy()

--- a/apps/extension/lib/page-summary.ts
+++ b/apps/extension/lib/page-summary.ts
@@ -1,0 +1,169 @@
+import { z } from 'zod'
+
+const SUMMARY_OPTIONS = {
+  type: 'key-points',
+  format: 'markdown',
+  length: 'medium',
+  preference: 'auto',
+} as const satisfies SummarizerCreateCoreOptions
+
+const QUOTA_HEADROOM = 0.9
+const MAX_QUOTA_TRIM_ATTEMPTS = 4
+
+const summaryOutputSchema = z.string().trim().min(1, 'Chrome returned an empty summary')
+const summaryAvailabilitySchema = z.enum([
+  'unavailable',
+  'downloadable',
+  'downloading',
+  'available',
+])
+
+export type PageSummaryAvailability = z.infer<typeof summaryAvailabilitySchema> | 'unsupported'
+
+export interface PageSummaryTask {
+  /** Generate one summary and release the browser model session afterward. */
+  summarize(contentText: string): Promise<string>
+  /** Abort model creation or generation and release an initialized session. */
+  cancel(): void
+}
+
+export interface StartPageSummaryOptions {
+  title: string
+  onDownloadProgress?: ((progress: number) => void) | undefined
+}
+
+interface SummarySessionReady {
+  ok: true
+  summarizer: Summarizer
+}
+
+interface SummarySessionFailed {
+  ok: false
+  cause: unknown
+}
+
+type SummarySessionResult = SummarySessionReady | SummarySessionFailed
+
+/** Whether this document exposes Chrome's built-in Summarizer API. */
+export function supportsPageSummary(): boolean {
+  return 'Summarizer' in globalThis
+}
+
+/** Current model readiness, with an explicit state for older Chrome builds. */
+export async function pageSummaryAvailability(): Promise<PageSummaryAvailability> {
+  if (!supportsPageSummary()) {
+    return 'unsupported'
+  }
+  return summaryAvailabilitySchema.parse(await Summarizer.availability(SUMMARY_OPTIONS))
+}
+
+function cancelledError(): DOMException {
+  return new DOMException('Page summarization was cancelled', 'AbortError')
+}
+
+function truncateAtTextBoundary(text: string, maximumLength: number): string {
+  if (text.length <= maximumLength) {
+    return text
+  }
+  const prefix = text.slice(0, Math.max(1, maximumLength))
+  const paragraphAt = prefix.lastIndexOf('\n\n')
+  const wordAt = prefix.lastIndexOf(' ')
+  const boundary = paragraphAt >= prefix.length / 2 ? paragraphAt : wordAt
+  return prefix.slice(0, boundary > 0 ? boundary : prefix.length).trimEnd()
+}
+
+async function fitToInputQuota(summarizer: Summarizer, contentText: string): Promise<string> {
+  const normalized = contentText.trim()
+  if (normalized === '') {
+    throw new Error('The page did not contain any readable text to summarize')
+  }
+  const quota = summarizer.inputQuota
+  if (!Number.isFinite(quota) || quota <= 0) {
+    throw new Error('Chrome reported an invalid summarizer input quota')
+  }
+
+  const initialUsage = await summarizer.measureInputUsage(normalized)
+  if (initialUsage <= quota) {
+    return normalized
+  }
+
+  let candidate = truncateAtTextBoundary(
+    normalized,
+    Math.floor(normalized.length * ((quota * QUOTA_HEADROOM) / initialUsage)),
+  )
+  for (let attempt = 0; attempt < MAX_QUOTA_TRIM_ATTEMPTS; attempt += 1) {
+    const usage = await summarizer.measureInputUsage(candidate)
+    if (usage <= quota) {
+      return candidate
+    }
+    candidate = truncateAtTextBoundary(
+      candidate,
+      Math.floor(candidate.length * ((quota * QUOTA_HEADROOM) / usage)),
+    )
+  }
+  throw new Error('The readable page text is too long for Chrome to summarize')
+}
+
+/**
+ * Start model initialization while the popup still has transient user activation.
+ * The returned task absorbs creation failures until the caller requests its result,
+ * so the raw link can finish queueing first without an unhandled rejection.
+ */
+export function startPageSummary(options: StartPageSummaryOptions): PageSummaryTask {
+  const abortController = new AbortController()
+  let cancelled = false
+  let activeSummarizer: Summarizer | null = null
+
+  const sessionResult: Promise<SummarySessionResult> = supportsPageSummary()
+    ? Summarizer.create({
+        ...SUMMARY_OPTIONS,
+        sharedContext: `Readable text from a web page titled "${options.title.trim()}".`,
+        signal: abortController.signal,
+        monitor(monitor) {
+          monitor.addEventListener('downloadprogress', (event) => {
+            const progress = Math.round(Math.min(1, Math.max(0, event.loaded)) * 100)
+            options.onDownloadProgress?.(progress)
+          })
+        },
+      }).then(
+        (summarizer): SummarySessionResult => {
+          if (cancelled) {
+            summarizer.destroy()
+            return { ok: false, cause: cancelledError() }
+          }
+          activeSummarizer = summarizer
+          return { ok: true, summarizer }
+        },
+        (cause: unknown): SummarySessionResult => ({ ok: false, cause }),
+      )
+    : Promise.resolve({
+        ok: false,
+        cause: new Error('Page summaries are not supported by this version of Chrome'),
+      })
+
+  return {
+    async summarize(contentText: string): Promise<string> {
+      const result = await sessionResult
+      if (!result.ok) {
+        throw result.cause
+      }
+      try {
+        const input = await fitToInputQuota(result.summarizer, contentText)
+        return summaryOutputSchema.parse(
+          await result.summarizer.summarize(input, { signal: abortController.signal }),
+        )
+      } finally {
+        if (activeSummarizer === result.summarizer) {
+          result.summarizer.destroy()
+          activeSummarizer = null
+        }
+      }
+    },
+    cancel(): void {
+      cancelled = true
+      abortController.abort()
+      activeSummarizer?.destroy()
+      activeSummarizer = null
+    },
+  }
+}

--- a/apps/extension/lib/page-summary.ts
+++ b/apps/extension/lib/page-summary.ts
@@ -18,6 +18,7 @@ const summaryAvailabilitySchema = z.enum([
   'available',
 ])
 
+/** Chrome model readiness, plus `unsupported` when the API is absent. */
 export type PageSummaryAvailability = z.infer<typeof summaryAvailabilitySchema> | 'unsupported'
 
 export interface PageSummaryTask {
@@ -27,8 +28,11 @@ export interface PageSummaryTask {
   cancel(): void
 }
 
+/** Context and progress reporting for one user-activated summary session. */
 export interface StartPageSummaryOptions {
+  /** Page title supplied as model context. */
   title: string
+  /** Receives whole-number model download percentages from zero through 100. */
   onDownloadProgress?: ((progress: number) => void) | undefined
 }
 

--- a/apps/extension/lib/popup-preferences.test.ts
+++ b/apps/extension/lib/popup-preferences.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { readIncludePageTextPreference, writeIncludePageTextPreference } from './popup-preferences'
+import {
+  readIncludePageSummaryPreference,
+  readIncludePageTextPreference,
+  writeIncludePageSummaryPreference,
+  writeIncludePageTextPreference,
+} from './popup-preferences'
 
 const store = new Map<string, unknown>()
 
@@ -20,6 +25,7 @@ vi.mock('wxt/browser', () => ({
 }))
 
 const INCLUDE_PAGE_TEXT_KEY = 'preference:includePageText'
+const INCLUDE_PAGE_SUMMARY_KEY = 'preference:includePageSummary'
 
 beforeEach(() => {
   store.clear()
@@ -50,5 +56,22 @@ describe('writeIncludePageTextPreference', () => {
 
     await writeIncludePageTextPreference(false)
     expect(store.get(INCLUDE_PAGE_TEXT_KEY)).toBe(false)
+  })
+})
+
+describe('page summary preference', () => {
+  it('defaults to false and reads a persisted choice', async () => {
+    await expect(readIncludePageSummaryPreference()).resolves.toBe(false)
+
+    store.set(INCLUDE_PAGE_SUMMARY_KEY, true)
+    await expect(readIncludePageSummaryPreference()).resolves.toBe(true)
+  })
+
+  it('persists the latest checkbox value', async () => {
+    await writeIncludePageSummaryPreference(true)
+    expect(store.get(INCLUDE_PAGE_SUMMARY_KEY)).toBe(true)
+
+    await writeIncludePageSummaryPreference(false)
+    expect(store.get(INCLUDE_PAGE_SUMMARY_KEY)).toBe(false)
   })
 })

--- a/apps/extension/lib/popup-preferences.ts
+++ b/apps/extension/lib/popup-preferences.ts
@@ -2,9 +2,11 @@ import { z } from 'zod'
 import { browser } from 'wxt/browser'
 
 const INCLUDE_PAGE_TEXT_KEY = 'preference:includePageText'
+const INCLUDE_PAGE_SUMMARY_KEY = 'preference:includePageSummary'
 
 const popupPreferencesSchema = z.object({
   [INCLUDE_PAGE_TEXT_KEY]: z.boolean().optional(),
+  [INCLUDE_PAGE_SUMMARY_KEY]: z.boolean().optional(),
 })
 
 /** Read the persisted popup choice for full-page text capture. */
@@ -17,4 +19,18 @@ export async function readIncludePageTextPreference(): Promise<boolean> {
 /** Persist the popup choice for full-page text capture. */
 export async function writeIncludePageTextPreference(includePageText: boolean): Promise<void> {
   await browser.storage.local.set({ [INCLUDE_PAGE_TEXT_KEY]: includePageText })
+}
+
+/** Read the persisted popup choice for on-device page summarization. */
+export async function readIncludePageSummaryPreference(): Promise<boolean> {
+  const stored = await browser.storage.local.get(INCLUDE_PAGE_SUMMARY_KEY)
+  const parsed = popupPreferencesSchema.safeParse(stored)
+  return parsed.success ? (parsed.data[INCLUDE_PAGE_SUMMARY_KEY] ?? false) : false
+}
+
+/** Persist the popup choice for on-device page summarization. */
+export async function writeIncludePageSummaryPreference(
+  includePageSummary: boolean,
+): Promise<void> {
+  await browser.storage.local.set({ [INCLUDE_PAGE_SUMMARY_KEY]: includePageSummary })
 }

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.3",
+    "@types/dom-chromium-ai": "^0.0.17",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@wxt-dev/module-react": "^1.2.2",

--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@ocavue/tsconfig/dom/app.json",
   "compilerOptions": {
     "jsx": "react-jsx",
+    "types": ["node", "dom-chromium-ai"],
     "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
     commands: {
       [SAVE_CURRENT_PAGE_COMMAND]: {
         suggested_key: { default: 'Ctrl+Shift+K', mac: 'Command+Shift+K' },
-        description: 'Save the current page to Reflect',
+        description: 'Open Reflect capture options for the current page',
       },
     },
   },

--- a/apps/native-host/src/envelope.rs
+++ b/apps/native-host/src/envelope.rs
@@ -22,6 +22,8 @@ pub struct Envelope {
     pub selection: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
     /// In-page meta description; only the iOS share extension sets it, so a
     /// Chrome wire message carrying one passes through untouched.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -218,8 +220,21 @@ mod tests {
     fn accepts_a_minimal_message() {
         let capture = ValidatedCapture::parse(&payload(|_| {})).unwrap();
         assert_eq!(capture.envelope.title, "Example");
+        assert_eq!(capture.envelope.summary, None);
         assert_eq!(capture.envelope.screenshot_ref, None);
         assert!(capture.screenshot.is_none());
+    }
+
+    #[test]
+    fn preserves_an_on_device_summary() {
+        let capture = ValidatedCapture::parse(&payload(|message| {
+            message["envelope"]["summary"] = "- First key point\n- Second key point".into();
+        }))
+        .unwrap();
+        assert_eq!(
+            capture.envelope.summary.as_deref(),
+            Some("- First key point\n- Second key point")
+        );
     }
 
     #[test]

--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -6,6 +6,11 @@
 > relays + drains them on launch/foreground. See
 > [the porting doc](../porting/reflect-mobile/share-extension.md).
 >
+> **Update (2026-08-22):** Chrome captures can optionally use Chrome's built-in
+> on-device Summarizer. The extension queues the raw link first, then sends a
+> same-day deduplicating update with a dedicated summary; no model key or cloud
+> AI provider is involved.
+>
 > **Status (2026-06-14): Implemented.** The pipeline below is built end-to-end:
 > `apps/extension` (WXT MV3, popup + queue + ⌘⇧K), `apps/native-host`
 > (`reflect-capture-host`, bundled as a second sidecar), the capture inbox +
@@ -55,8 +60,9 @@ extraction / read-later (deferred), dedup-heavy clipping (basic dedup only).
 
 V1 called a Reflect-hosted `link-description-api`. V2 must not. Instead:
 
-- The **extension** captures and forwards; it stores **no model keys** and makes **no AI
-  calls** — enrichment never happens in the extension.
+- The **extension** captures and forwards; it stores **no model keys** and makes no
+  cloud AI calls. Opt-in page summaries may run in Chrome's built-in on-device model;
+  provider-backed enrichment still never happens in the extension.
 - The **desktop app** owns durable writes, file paths, asset storage, keychain access,
   BYOK AI calls, and the `private: true` check.
 
@@ -107,7 +113,8 @@ Every capture lands in two phases so saving never waits on the network or AI:
 
 1. **Chrome extension** (`apps/extension`, MV3): action button + `⌘⇧P` (or `⌘⇧K` if reserved)
    to capture the active tab's URL, title, user-selected text/highlights, and a
-   screenshot (`captureVisibleTab`). Minimal UI: confirm + optional note. No keys, no AI.
+   screenshot (`captureVisibleTab`). Minimal UI: confirm + optional note, page text,
+   or on-device page summary. No keys or provider-backed AI.
    If the host is missing (app not installed) the extension explains + links the
    download, queues the capture in `chrome.storage`, and retries later. Status states
    are honest: **queued** (spooled into inbox or held in `chrome.storage` — the host
@@ -191,7 +198,8 @@ Every capture lands in two phases so saving never waits on the network or AI:
 
 ## Key decisions / contracts
 
-- **Desktop owns all writes, AI, and keys; the extension only captures + forwards.**
+- **Desktop owns all writes, provider-backed AI, and keys; the extension only captures,
+  optionally summarizes on-device, and forwards.**
 - **The native-messaging host is a spooler; the capture inbox is the IPC.** Capture
   works with the app closed; no socket, no port, no daemon.
 - **Two-phase write:** raw entry saved synchronously on drain; meta scrape + AI

--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -137,7 +137,13 @@ Every capture lands in two phases so saving never waits on the network or AI:
    in `actions/capture` — `{version, id, url, title, selection?, contentText?, summary?,
    metaDescription?, note?, screenshotRef?, capturedAt, source}` — written identically
    by the desktop host today and by the future iOS share extension (app-group inbox) /
-   Android intent handler. `drainCaptureInbox` executes these steps **in order**:
+   Android intent handler. A Chrome summary capture emits two envelopes in order: the
+   raw link without `summary`, then a new-ID refresh with the same `capturedAt`, URL,
+   selection, note, and screenshot plus `summary` (and `contentText` when selected).
+   Same-day dedup treats them as one capture; if desktop enrichment observes the raw
+   write in between, the managed refresh remains pending for a retry. Capture-flow,
+   drain, and enrichment-race tests pin this contract. `drainCaptureInbox` executes
+   these steps **in order**:
    1. Resolve the capture target (today's daily note, or a chosen note).
    2. **Privacy gate:** if the target is `private: true`, skip all enrichment and all
       outbound traffic (no URL fetch, no meta scrape, no screenshot/selection/note

--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -8,8 +8,9 @@
 >
 > **Update (2026-08-22):** Chrome captures can optionally use Chrome's built-in
 > on-device Summarizer. The extension queues the raw link first, then sends a
-> same-day deduplicating update with a dedicated summary; no model key or cloud
-> AI provider is involved.
+> same-day deduplicating update with a dedicated summary; summary generation uses
+> no model key or cloud AI provider. Separate desktop BYOK enrichment remains as
+> described below.
 >
 > **Status (2026-06-14): Implemented.** The pipeline below is built end-to-end:
 > `apps/extension` (WXT MV3, popup + queue + ⌘⇧K), `apps/native-host`
@@ -113,8 +114,9 @@ Every capture lands in two phases so saving never waits on the network or AI:
 
 1. **Chrome extension** (`apps/extension`, MV3): action button + `⌘⇧P` (or `⌘⇧K` if reserved)
    to capture the active tab's URL, title, user-selected text/highlights, and a
-   screenshot (`captureVisibleTab`). Minimal UI: confirm + optional note, page text,
-   or on-device page summary. No keys or provider-backed AI.
+   screenshot (`captureVisibleTab`). Minimal UI: confirm + optional note and
+   independently selectable page text and on-device page summary (including both
+   together). No extension-held keys or provider-backed AI in this browser flow.
    If the host is missing (app not installed) the extension explains + links the
    download, queues the capture in `chrome.storage`, and retries later. Status states
    are honest: **queued** (spooled into inbox or held in `chrome.storage` — the host

--- a/docs/plans/11-link-capture.md
+++ b/docs/plans/11-link-capture.md
@@ -134,10 +134,10 @@ Every capture lands in two phases so saving never waits on the network or AI:
    manifests for detected browsers on every launch.
 
 3. **Capture inbox + drain (core action).** A platform-agnostic capture envelope (zod)
-   in `actions/capture` — `{url, title, selection?, screenshotRef?, note?, capturedAt,
-   source}` — written identically by the desktop host today and by the future iOS
-   share extension (app-group inbox) / Android intent handler. `drainCaptureInbox`
-   executes these steps **in order**:
+   in `actions/capture` — `{version, id, url, title, selection?, contentText?, summary?,
+   metaDescription?, note?, screenshotRef?, capturedAt, source}` — written identically
+   by the desktop host today and by the future iOS share extension (app-group inbox) /
+   Android intent handler. `drainCaptureInbox` executes these steps **in order**:
    1. Resolve the capture target (today's daily note, or a chosen note).
    2. **Privacy gate:** if the target is `private: true`, skip all enrichment and all
       outbound traffic (no URL fetch, no meta scrape, no screenshot/selection/note

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -60,17 +60,19 @@ disk at call time), and it is covered by tests.
 
 ## Browser capture (the Chrome extension)
 
-- **Where:** nowhere on the network. The **Reflect Capture** extension hands each
+- **Where:** captured content goes nowhere on the network. The **Reflect Capture** extension hands each
   capture to a local native-messaging host (`reflect-capture-host`) that the desktop
   app registers on your machine; the host spools it to the capture inbox on disk
-  (`<graph>/.reflect/inbox/`) and the app drains it on next launch. **No Reflect-hosted
-  server, no third party, and no other destination is ever contacted** — the extension
-  stores no keys and makes no AI or network calls of its own.
+  (`<graph>/.reflect/inbox/`) and the app drains it on next launch. Optional page
+  summaries use Chrome's built-in on-device model; the page text is processed locally
+  and is not sent to Reflect or an AI provider. Chrome may download that model before
+  its first use, but the download carries no captured content. The extension stores no
+  keys and makes no page-content network request of its own.
 - **What:** only the page you explicitly capture (toolbar button or ⌘⇧K) — its URL,
   title, your current text selection, a screenshot of the visible tab, and, only when
-  you tick "Capture page text", the page's extracted text. Nothing is read in the
-  background; the extension requests no broad host permissions and acts on the active
-  tab only at the moment you trigger it.
+  you opt in, the page's extracted text and/or an on-device summary generated from it.
+  Nothing is read in the background; the extension requests no broad host permissions
+  and acts on the active tab only at the moment you trigger it.
 - **When:** when you capture. If the desktop app isn't reachable yet, the capture is
   held in the browser's local extension storage and retried automatically until it
   spools — it is never sent anywhere else in the meantime.
@@ -160,7 +162,7 @@ API keys and tokens live in the **OS keychain only** — never in markdown, neve
 | Backup | Your git repository | Yes — including private notes | Yes (needs connecting) |
 | Key validation | The provider | No | — (only when adding a key) |
 | Update check | GitHub Releases | No | On in packaged builds |
-| Browser capture | Nowhere (local host on disk) | — (stays on your machine) | — (only when you capture) |
+| Browser capture and on-device summary | Nowhere for captured content (Chrome may download its local model) | — (stays on your machine) | — (only when you capture) |
 | Capture metadata and preview | The captured website, via Reflect and Apple LinkPresentation | URL only; private captures are blocked | No (after an explicit capture) |
 | Contacts lookup | Nowhere (on-device OS store) | — (stays on your machine) | Yes (opt-in) |
 | Exception diagnostics | Sentry | No — free-form messages and context are redacted | No (official releases) |

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -60,14 +60,16 @@ disk at call time), and it is covered by tests.
 
 ## Browser capture (the Chrome extension)
 
-- **Where:** captured content goes nowhere on the network. The **Reflect Capture** extension hands each
-  capture to a local native-messaging host (`reflect-capture-host`) that the desktop
-  app registers on your machine; the host spools it to the capture inbox on disk
+- **Where:** during browser capture and summary generation, captured content goes
+  nowhere on the network. The **Reflect Capture** extension hands each capture to a
+  local native-messaging host (`reflect-capture-host`) that the desktop app registers
+  on your machine; the host spools it to the capture inbox on disk
   (`<graph>/.reflect/inbox/`) and the app drains it on next launch. Optional page
   summaries use Chrome's built-in on-device model; the page text is processed locally
   and is not sent to Reflect or an AI provider. Chrome may download that model before
   its first use, but the download carries no captured content. The extension stores no
-  keys and makes no page-content network request of its own.
+  keys and makes no page-content network request of its own. After this local phase,
+  the desktop enrichment rules below apply.
 - **What:** only the page you explicitly capture (toolbar button or ⌘⇧K) — its URL,
   title, your current text selection, a screenshot of the visible tab, and, only when
   you opt in, the page's extracted text and/or an on-device summary generated from it.
@@ -162,7 +164,7 @@ API keys and tokens live in the **OS keychain only** — never in markdown, neve
 | Backup | Your git repository | Yes — including private notes | Yes (needs connecting) |
 | Key validation | The provider | No | — (only when adding a key) |
 | Update check | GitHub Releases | No | On in packaged builds |
-| Browser capture and on-device summary | Nowhere for captured content (Chrome may download its local model) | — (stays on your machine) | — (only when you capture) |
+| Browser capture and on-device summary | Local native host and Chrome model; optional later desktop enrichment may use your BYOK provider | Local capture stays on your machine; eligible content may later enter optional BYOK enrichment | — (only when you capture) |
 | Capture metadata and preview | The captured website, via Reflect and Apple LinkPresentation | URL only; private captures are blocked | No (after an explicit capture) |
 | Contacts lookup | Nowhere (on-device OS store) | — (stays on your machine) | Yes (opt-in) |
 | Exception diagnostics | Sentry | No — free-form messages and context are redacted | No (official releases) |

--- a/packages/core/src/actions/capture-drain.test.ts
+++ b/packages/core/src/actions/capture-drain.test.ts
@@ -54,7 +54,13 @@ beforeEach(() => {
 
 describe('drainCaptureInbox', () => {
   it('writes the capture note, daily entry, and asset — then removes the spool', async () => {
-    addSpool(envelope({ selection: 'quoted text', note: 'check later' }))
+    addSpool(
+      envelope({
+        selection: 'quoted text',
+        note: 'check later',
+        summary: '- First key point',
+      }),
+    )
 
     const outcome = await drain()
 
@@ -74,7 +80,10 @@ describe('drainCaptureInbox', () => {
     expect(note).toContain('- Type: #link')
     expect(note).not.toContain('Highlights')
     expect(note).toContain('## Note\n\ncheck later')
+    expect(note).toContain('## Summary\n\n- First key point')
     expect(note).toContain('## Selection\n\nquoted text')
+    expect((note ?? '').indexOf('## Note')).toBeLessThan((note ?? '').indexOf('## Summary'))
+    expect((note ?? '').indexOf('## Summary')).toBeLessThan((note ?? '').indexOf('## Selection'))
     expect(note).toContain(`## Screenshot\n\n![An article](${IDENTITY.assetPath})`)
 
     const daily = files.get(DAILY)
@@ -95,6 +104,19 @@ describe('drainCaptureInbox', () => {
     const note = files.get(IDENTITY.notePath)
     expect(note).toContain(
       '## Page Text\n\n<!-- reflect-capture-page-text:start -->\nFirst paragraph.\n\nSecond paragraph.\n<!-- reflect-capture-page-text:end -->',
+    )
+  })
+
+  it('writes an on-device page summary into its own capture-note section', async () => {
+    addSpool(envelope({ summary: '- First key point\n- Second key point' }), {
+      screenshot: false,
+    })
+
+    const outcome = await drain()
+
+    expect(outcome).toEqual({ pending: 1, drained: 1, deduped: 0, invalid: 0, stopped: null })
+    expect(files.get(IDENTITY.notePath)).toContain(
+      '## Summary\n\n- First key point\n- Second key point',
     )
   })
 
@@ -323,6 +345,25 @@ describe('drainCaptureInbox', () => {
     const daily = files.get(DAILY) ?? ''
     expect(daily.match(/capture-2026-06-11-093000-000-0000/g)).toHaveLength(1)
     expect(daily).not.toContain('capture-2026-06-11-153022-845')
+  })
+
+  it('adds a deferred summary to the original same-day capture note', async () => {
+    addSpool(
+      envelope({
+        id: '00000000-0000-4000-8000-000000000001',
+        capturedAt: new Date(2026, 5, 11, 9, 30, 0, 0).toISOString(),
+      }),
+    )
+    await drain()
+    const originalNotePath = 'notes/capture-2026-06-11-093000-000-0000.md'
+
+    addSpool(envelope({ summary: '- Deferred key point' }))
+    const outcome = await drain()
+
+    expect(outcome.deduped).toBe(1)
+    expect(files.get(originalNotePath)).toContain('## Summary\n\n- Deferred key point')
+    expect(files.has(IDENTITY.notePath)).toBe(false)
+    expect((files.get(DAILY) ?? '').match(/capture-2026-06-11-093000-000-0000/g)).toHaveLength(1)
   })
 
   it('a dedup refresh re-syncs the daily link text with the fresh tab title', async () => {

--- a/packages/core/src/actions/capture-drain.test.ts
+++ b/packages/core/src/actions/capture-drain.test.ts
@@ -80,9 +80,8 @@ describe('drainCaptureInbox', () => {
     expect(note).toContain('- Type: #link')
     expect(note).not.toContain('Highlights')
     expect(note).toContain('## Note\n\ncheck later')
-    expect(note).toContain(
-      '## Summary\n\n<!-- reflect-capture-summary:start -->\n- First key point',
-    )
+    expect(note).toContain('## Summary\n\n- First key point')
+    expect(note).toContain('captureSummary:')
     expect(note).toContain('## Selection\n\nquoted text')
     expect((note ?? '').indexOf('## Note')).toBeLessThan((note ?? '').indexOf('## Summary'))
     expect((note ?? '').indexOf('## Summary')).toBeLessThan((note ?? '').indexOf('## Selection'))
@@ -118,7 +117,7 @@ describe('drainCaptureInbox', () => {
 
     expect(outcome).toEqual({ pending: 1, drained: 1, deduped: 0, invalid: 0, stopped: null })
     expect(files.get(IDENTITY.notePath)).toContain(
-      '## Summary\n\n<!-- reflect-capture-summary:start -->\n- First key point\n- Second key point\n<!-- reflect-capture-summary:end -->',
+      '## Summary\n\n- First key point\n- Second key point',
     )
   })
 
@@ -363,9 +362,7 @@ describe('drainCaptureInbox', () => {
     const outcome = await drain()
 
     expect(outcome.deduped).toBe(1)
-    expect(files.get(originalNotePath)).toContain(
-      '## Summary\n\n<!-- reflect-capture-summary:start -->\n- Deferred key point',
-    )
+    expect(files.get(originalNotePath)).toContain('## Summary\n\n- Deferred key point')
     expect(files.has(IDENTITY.notePath)).toBe(false)
     expect((files.get(DAILY) ?? '').match(/capture-2026-06-11-093000-000-0000/g)).toHaveLength(1)
   })
@@ -374,7 +371,8 @@ describe('drainCaptureInbox', () => {
     addSpool(
       envelope({
         id: '00000000-0000-4000-8000-000000000001',
-        summary: '- Deferred key point',
+        summary:
+          '- Deferred key point\n\n<!-- reflect-capture-summary:end -->\n\n- Marker-like text stays intact',
         contentText: 'Readable page text',
         metaDescription: 'Scraped page description',
       }),
@@ -391,7 +389,7 @@ describe('drainCaptureInbox', () => {
     const note = files.get('notes/capture-2026-06-11-153022-845-0000.md')
     expect(note).toContain('- Description: Scraped page description')
     expect(note).toContain(
-      '## Summary\n\n<!-- reflect-capture-summary:start -->\n- Deferred key point',
+      '## Summary\n\n- Deferred key point\n\n<!-- reflect-capture-summary:end -->\n\n- Marker-like text stays intact',
     )
     expect(note).toContain(
       '## Page Text\n\n<!-- reflect-capture-page-text:start -->\nReadable page text',
@@ -401,7 +399,8 @@ describe('drainCaptureInbox', () => {
   })
 
   it('does not promote a user-authored Summary heading during a dedup refresh', async () => {
-    const note = 'My note\n\n## Summary\n\nThis heading belongs to the user.'
+    const note =
+      'My note\n\n## Summary\n\n<!-- reflect-capture-summary:start -->\nThis heading belongs to the user.\n<!-- reflect-capture-summary:end -->'
     addSpool(envelope({ id: '00000000-0000-4000-8000-000000000001', note }), {
       screenshot: false,
       modifiedMs: 0,
@@ -416,8 +415,8 @@ describe('drainCaptureInbox', () => {
     expect(outcome.deduped).toBe(1)
     const refreshed = files.get('notes/capture-2026-06-11-153022-845-0000.md') ?? ''
     expect(refreshed.match(/## Summary/g)).toHaveLength(1)
-    expect(refreshed).toContain('## Summary\n\nThis heading belongs to the user.')
-    expect(refreshed).not.toContain('reflect-capture-summary:start')
+    expect(refreshed).toContain(note)
+    expect(refreshed).not.toContain('captureSummary:')
   })
 
   it('a dedup refresh re-syncs the daily link text with the fresh tab title', async () => {

--- a/packages/core/src/actions/capture-drain.test.ts
+++ b/packages/core/src/actions/capture-drain.test.ts
@@ -10,6 +10,7 @@ import {
   IDENTITY,
   inboxRemoveMock,
   promoteMock,
+  reconcile,
   rejected,
   scrapeMock,
   spool,
@@ -367,6 +368,74 @@ describe('drainCaptureInbox', () => {
     expect((files.get(DAILY) ?? '').match(/capture-2026-06-11-093000-000-0000/g)).toHaveLength(1)
   })
 
+  it('does not overwrite a capture edited before its deferred summary arrives', async () => {
+    addSpool(
+      envelope({
+        id: '00000000-0000-4000-8000-000000000001',
+        capturedAt: new Date(2026, 5, 11, 9, 30, 0, 0).toISOString(),
+      }),
+      { screenshot: false },
+    )
+    await drain()
+    const originalNotePath = 'notes/capture-2026-06-11-093000-000-0000.md'
+    const edited = `${files.get(originalNotePath) ?? ''}\nMy own follow-up.\n`
+    files.set(originalNotePath, edited)
+
+    addSpool(envelope({ summary: '- Deferred key point' }), { screenshot: false })
+    const outcome = await drain()
+
+    expect(outcome).toEqual({ pending: 1, drained: 1, deduped: 1, invalid: 0, stopped: null })
+    expect(files.get(originalNotePath)).toBe(edited)
+    expect(spool.size).toBe(0)
+  })
+
+  it('does not overwrite a capture made private before its deferred summary arrives', async () => {
+    addSpool(
+      envelope({
+        id: '00000000-0000-4000-8000-000000000001',
+        capturedAt: new Date(2026, 5, 11, 9, 30, 0, 0).toISOString(),
+      }),
+      { screenshot: false },
+    )
+    await drain()
+    const originalNotePath = 'notes/capture-2026-06-11-093000-000-0000.md'
+    const privateSource = (files.get(originalNotePath) ?? '').replace(
+      '---\n',
+      '---\nprivate: true\n',
+    )
+    files.set(originalNotePath, privateSource)
+
+    addSpool(envelope({ summary: '- Deferred key point' }), { screenshot: false })
+    const outcome = await drain()
+
+    expect(outcome).toEqual({ pending: 1, drained: 1, deduped: 1, invalid: 0, stopped: null })
+    expect(files.get(originalNotePath)).toBe(privateSource)
+    expect(spool.size).toBe(0)
+  })
+
+  it('preserves unrelated frontmatter during a safe deferred refresh', async () => {
+    addSpool(
+      envelope({
+        id: '00000000-0000-4000-8000-000000000001',
+        capturedAt: new Date(2026, 5, 11, 9, 30, 0, 0).toISOString(),
+      }),
+      { screenshot: false },
+    )
+    await drain()
+    const originalNotePath = 'notes/capture-2026-06-11-093000-000-0000.md'
+    files.set(
+      originalNotePath,
+      (files.get(originalNotePath) ?? '').replace('---\n', '---\ntags:\n  - reading\n'),
+    )
+
+    addSpool(envelope({ summary: '- Deferred key point' }), { screenshot: false })
+    await drain()
+
+    const refreshed = files.get(originalNotePath) ?? ''
+    expect(refreshed).toContain('tags:\n  - reading')
+    expect(refreshed).toContain('## Summary\n\n- Deferred key point')
+  })
+
   it('preserves deferred fields when the enriched spool sorts before the raw link', async () => {
     addSpool(
       envelope({
@@ -427,10 +496,10 @@ describe('drainCaptureInbox', () => {
       }),
     )
     await drain()
-    // Simulate a completed enrichment: H1 and daily link text carry the AI title.
+    // Complete enrichment so the managed hash, H1, and daily link text all carry the AI title.
     const notePath = 'notes/capture-2026-06-11-093000-000-0000.md'
-    files.set(notePath, (files.get(notePath) ?? '').replace('# An article', '# AI Title'))
-    files.set(DAILY, (files.get(DAILY) ?? '').replace('|An article]]', '|AI Title]]'))
+    describeMock.mockResolvedValue({ title: 'AI Title', description: '' })
+    expect((await reconcile()).enriched).toBe(1)
 
     addSpool(envelope()) // same URL re-capture, 15:30
     const outcome = await drain()

--- a/packages/core/src/actions/capture-drain.test.ts
+++ b/packages/core/src/actions/capture-drain.test.ts
@@ -366,6 +366,34 @@ describe('drainCaptureInbox', () => {
     expect((files.get(DAILY) ?? '').match(/capture-2026-06-11-093000-000-0000/g)).toHaveLength(1)
   })
 
+  it('preserves deferred fields when the enriched spool sorts before the raw link', async () => {
+    addSpool(
+      envelope({
+        id: '00000000-0000-4000-8000-000000000001',
+        summary: '- Deferred key point',
+        contentText: 'Readable page text',
+        metaDescription: 'Scraped page description',
+      }),
+      { screenshot: false, modifiedMs: 0 },
+    )
+    addSpool(envelope({ id: 'ffff0000-0000-4000-8000-000000000002' }), {
+      screenshot: false,
+      modifiedMs: 0,
+    })
+
+    const outcome = await drain()
+
+    expect(outcome).toEqual({ pending: 2, drained: 2, deduped: 1, invalid: 0, stopped: null })
+    const note = files.get('notes/capture-2026-06-11-153022-845-0000.md')
+    expect(note).toContain('- Description: Scraped page description')
+    expect(note).toContain('## Summary\n\n- Deferred key point')
+    expect(note).toContain(
+      '## Page Text\n\n<!-- reflect-capture-page-text:start -->\nReadable page text',
+    )
+    expect(files.has('notes/capture-2026-06-11-153022-845-ffff.md')).toBe(false)
+    expect((files.get(DAILY) ?? '').match(/capture-2026-06-11-153022-845-0000/g)).toHaveLength(1)
+  })
+
   it('a dedup refresh re-syncs the daily link text with the fresh tab title', async () => {
     addSpool(
       envelope({

--- a/packages/core/src/actions/capture-drain.test.ts
+++ b/packages/core/src/actions/capture-drain.test.ts
@@ -104,6 +104,7 @@ describe('drainCaptureInbox', () => {
 
     expect(outcome).toEqual({ pending: 1, drained: 1, deduped: 0, invalid: 0, stopped: null })
     const note = files.get(IDENTITY.notePath)
+    expect(note).toContain('capturePageTextHash:')
     expect(note).toContain(
       '## Page Text\n\n<!-- reflect-capture-page-text:start -->\nFirst paragraph.\n\nSecond paragraph.\n<!-- reflect-capture-page-text:end -->',
     )
@@ -486,6 +487,35 @@ describe('drainCaptureInbox', () => {
     expect(refreshed.match(/## Summary/g)).toHaveLength(1)
     expect(refreshed).toContain(note)
     expect(refreshed).not.toContain('captureSummary:')
+  })
+
+  it('does not promote a user-authored Page Text marker during a summary refresh', async () => {
+    const note =
+      'My note\n\n## Page Text\n\n<!-- reflect-capture-page-text:start -->\nThis text belongs to the user.\n<!-- reflect-capture-page-text:end -->'
+    addSpool(envelope({ id: '00000000-0000-4000-8000-000000000001', note }), {
+      screenshot: false,
+      modifiedMs: 0,
+    })
+    addSpool(
+      envelope({
+        id: 'ffff0000-0000-4000-8000-000000000002',
+        note,
+        summary: '- A generated key point',
+      }),
+      { screenshot: false, modifiedMs: 0 },
+    )
+
+    const outcome = await drain()
+
+    expect(outcome.deduped).toBe(1)
+    const refreshed = files.get('notes/capture-2026-06-11-153022-845-0000.md') ?? ''
+    expect(refreshed.match(/## Page Text/g)).toHaveLength(1)
+    expect(refreshed).toContain(note)
+    expect(refreshed).toContain('## Summary\n\n- A generated key point')
+    expect(refreshed).not.toContain('capturePageTextHash:')
+
+    expect((await reconcile()).enriched).toBe(1)
+    expect(describeMock).toHaveBeenCalledWith(expect.objectContaining({ contentText: undefined }))
   })
 
   it('a dedup refresh re-syncs the daily link text with the fresh tab title', async () => {

--- a/packages/core/src/actions/capture-drain.test.ts
+++ b/packages/core/src/actions/capture-drain.test.ts
@@ -80,7 +80,9 @@ describe('drainCaptureInbox', () => {
     expect(note).toContain('- Type: #link')
     expect(note).not.toContain('Highlights')
     expect(note).toContain('## Note\n\ncheck later')
-    expect(note).toContain('## Summary\n\n- First key point')
+    expect(note).toContain(
+      '## Summary\n\n<!-- reflect-capture-summary:start -->\n- First key point',
+    )
     expect(note).toContain('## Selection\n\nquoted text')
     expect((note ?? '').indexOf('## Note')).toBeLessThan((note ?? '').indexOf('## Summary'))
     expect((note ?? '').indexOf('## Summary')).toBeLessThan((note ?? '').indexOf('## Selection'))
@@ -116,7 +118,7 @@ describe('drainCaptureInbox', () => {
 
     expect(outcome).toEqual({ pending: 1, drained: 1, deduped: 0, invalid: 0, stopped: null })
     expect(files.get(IDENTITY.notePath)).toContain(
-      '## Summary\n\n- First key point\n- Second key point',
+      '## Summary\n\n<!-- reflect-capture-summary:start -->\n- First key point\n- Second key point\n<!-- reflect-capture-summary:end -->',
     )
   })
 
@@ -361,7 +363,9 @@ describe('drainCaptureInbox', () => {
     const outcome = await drain()
 
     expect(outcome.deduped).toBe(1)
-    expect(files.get(originalNotePath)).toContain('## Summary\n\n- Deferred key point')
+    expect(files.get(originalNotePath)).toContain(
+      '## Summary\n\n<!-- reflect-capture-summary:start -->\n- Deferred key point',
+    )
     expect(files.has(IDENTITY.notePath)).toBe(false)
     expect((files.get(DAILY) ?? '').match(/capture-2026-06-11-093000-000-0000/g)).toHaveLength(1)
   })
@@ -386,12 +390,34 @@ describe('drainCaptureInbox', () => {
     expect(outcome).toEqual({ pending: 2, drained: 2, deduped: 1, invalid: 0, stopped: null })
     const note = files.get('notes/capture-2026-06-11-153022-845-0000.md')
     expect(note).toContain('- Description: Scraped page description')
-    expect(note).toContain('## Summary\n\n- Deferred key point')
+    expect(note).toContain(
+      '## Summary\n\n<!-- reflect-capture-summary:start -->\n- Deferred key point',
+    )
     expect(note).toContain(
       '## Page Text\n\n<!-- reflect-capture-page-text:start -->\nReadable page text',
     )
     expect(files.has('notes/capture-2026-06-11-153022-845-ffff.md')).toBe(false)
     expect((files.get(DAILY) ?? '').match(/capture-2026-06-11-153022-845-0000/g)).toHaveLength(1)
+  })
+
+  it('does not promote a user-authored Summary heading during a dedup refresh', async () => {
+    const note = 'My note\n\n## Summary\n\nThis heading belongs to the user.'
+    addSpool(envelope({ id: '00000000-0000-4000-8000-000000000001', note }), {
+      screenshot: false,
+      modifiedMs: 0,
+    })
+    addSpool(envelope({ id: 'ffff0000-0000-4000-8000-000000000002', note }), {
+      screenshot: false,
+      modifiedMs: 0,
+    })
+
+    const outcome = await drain()
+
+    expect(outcome.deduped).toBe(1)
+    const refreshed = files.get('notes/capture-2026-06-11-153022-845-0000.md') ?? ''
+    expect(refreshed.match(/## Summary/g)).toHaveLength(1)
+    expect(refreshed).toContain('## Summary\n\nThis heading belongs to the user.')
+    expect(refreshed).not.toContain('reflect-capture-summary:start')
   })
 
   it('a dedup refresh re-syncs the daily link text with the fresh tab title', async () => {

--- a/packages/core/src/actions/capture-drain.ts
+++ b/packages/core/src/actions/capture-drain.ts
@@ -35,8 +35,11 @@ import {
   type TextCaptureEnvelope,
 } from './capture-envelope'
 import {
+  captureDescriptionFromBody,
   captureNoteMeta,
   captureNoteSource,
+  capturePageTextFromBody,
+  captureSummaryFromBody,
   displayTitle,
   notePrivate,
   noteSource,
@@ -83,6 +86,8 @@ interface SameDayCapture {
   identity: CaptureIdentity
   /** The existing note's display title — what the daily's link text mirrors. */
   title: string
+  /** Existing managed fields survive a later link-only envelope in the same batch. */
+  body: string
 }
 
 /**
@@ -132,9 +137,14 @@ async function findSameDayCapture(
       }
       throw cause
     }
-    const meta = captureNoteMeta(parseFrontmatter(splitFrontmatter(source).raw).data)
+    const split = splitFrontmatter(source)
+    const meta = captureNoteMeta(parseFrontmatter(split.raw).data)
     if (meta && meta.captureUrl === url && meta.captureSelectionHash === selectionHash) {
-      return { identity, title: parseNote({ path: identity.notePath, source }).title }
+      return {
+        identity,
+        title: parseNote({ path: identity.notePath, source }).title,
+        body: split.body,
+      }
     }
   }
   return null
@@ -213,6 +223,14 @@ export async function drainCaptureInbox(
       )
       const identity = existing?.identity ?? fresh
       const status: CaptureStatus = notePrivate(dailySource) ? 'skipped' : 'pending'
+      const mergedEnvelope = existing
+        ? {
+            ...envelope,
+            contentText: envelope.contentText ?? capturePageTextFromBody(existing.body),
+            summary: envelope.summary ?? captureSummaryFromBody(existing.body),
+            metaDescription: envelope.metaDescription ?? captureDescriptionFromBody(existing.body),
+          }
+        : envelope
 
       let hasScreenshot = false
       if (envelope.screenshotRef) {
@@ -234,14 +252,14 @@ export async function drainCaptureInbox(
 
       await writeNote(
         identity.notePath,
-        await captureNoteSource(envelope, identity, {
+        await captureNoteSource(mergedEnvelope, identity, {
           hasScreenshot,
           status,
           selectionHash,
         }),
         input.generation,
       )
-      const freshTitle = displayTitle(envelope)
+      const freshTitle = displayTitle(mergedEnvelope)
       let updatedDaily = dailySource
       if (existing !== null) {
         // The refresh reset the note's H1 to the fresh tab title; keep the

--- a/packages/core/src/actions/capture-drain.ts
+++ b/packages/core/src/actions/capture-drain.ts
@@ -39,7 +39,6 @@ import {
   captureNoteMeta,
   captureNoteSource,
   capturePageTextFromBody,
-  captureSummaryFromBody,
   displayTitle,
   notePrivate,
   noteSource,
@@ -88,6 +87,8 @@ interface SameDayCapture {
   title: string
   /** Existing managed fields survive a later link-only envelope in the same batch. */
   body: string
+  /** Structured summary backing the managed Summary body section. */
+  summary?: string | undefined
 }
 
 /**
@@ -144,6 +145,7 @@ async function findSameDayCapture(
         identity,
         title: parseNote({ path: identity.notePath, source }).title,
         body: split.body,
+        summary: meta.captureSummary,
       }
     }
   }
@@ -227,7 +229,7 @@ export async function drainCaptureInbox(
         ? {
             ...envelope,
             contentText: envelope.contentText ?? capturePageTextFromBody(existing.body),
-            summary: envelope.summary ?? captureSummaryFromBody(existing.body),
+            summary: envelope.summary ?? existing.summary,
             metaDescription: envelope.metaDescription ?? captureDescriptionFromBody(existing.body),
           }
         : envelope

--- a/packages/core/src/actions/capture-drain.ts
+++ b/packages/core/src/actions/capture-drain.ts
@@ -90,6 +90,8 @@ interface SameDayCapture {
   title: string
   /** Existing managed fields survive a later link-only envelope in the same batch. */
   body: string
+  /** Page text validated against its structured managed-content hash. */
+  pageText?: string | undefined
   /** Structured summary backing the managed Summary body section. */
   summary?: string | undefined
   /** Full source used to preserve unrelated frontmatter during a safe refresh. */
@@ -123,6 +125,7 @@ async function readSameDayCapture(
     identity,
     title: parseNote({ path: identity.notePath, source }).title,
     body: split.body,
+    pageText: await capturePageTextFromBody(split.body, meta.capturePageTextHash),
     summary: meta.captureSummary,
     source,
     refreshable: !frontmatter.private && (await hashContent(split.body)) === meta.captureHash,
@@ -302,7 +305,7 @@ export async function drainCaptureInbox(
       const mergedEnvelope = existing
         ? {
             ...envelope,
-            contentText: envelope.contentText ?? capturePageTextFromBody(existing.body),
+            contentText: envelope.contentText ?? existing.pageText,
             summary: envelope.summary ?? existing.summary,
             metaDescription: envelope.metaDescription ?? captureDescriptionFromBody(existing.body),
           }

--- a/packages/core/src/actions/capture-drain.ts
+++ b/packages/core/src/actions/capture-drain.ts
@@ -31,6 +31,7 @@ import {
 } from './capture-identity'
 import {
   inboxEnvelopeSchema,
+  type CaptureEnvelope,
   type InboxEnvelope,
   type TextCaptureEnvelope,
 } from './capture-envelope'
@@ -67,12 +68,14 @@ export interface DrainCaptureInboxInput {
 export interface DrainCaptureInboxOutcome {
   /** Spooled envelopes present when the pass started. */
   pending: number
-  /** Captures written (fresh notes plus dedup refreshes). */
+  /** Captures consumed (fresh notes plus handled same-day duplicates). */
   drained: number
   /**
-   * Of `drained`, how many link captures refreshed an existing same-day
-   * entry in place. Text captures never count here: duplicates are allowed
-   * by design (Plan 24), so every text envelope appends.
+   * Of `drained`, how many link captures matched an existing same-day entry.
+   * A match normally refreshes in place; if the note was edited or made
+   * private, the duplicate is discarded instead. Text captures never count
+   * here: duplicates are allowed by design (Plan 24), so every text envelope
+   * appends.
    */
   deduped: number
   /** Unparseable spool files quarantined under `.reflect/inbox-rejected/`. */
@@ -89,6 +92,41 @@ interface SameDayCapture {
   body: string
   /** Structured summary backing the managed Summary body section. */
   summary?: string | undefined
+  /** Full source used to preserve unrelated frontmatter during a safe refresh. */
+  source: string
+  /** Whether a refresh can replace the managed body without losing user data. */
+  refreshable: boolean
+}
+
+async function readSameDayCapture(
+  identity: CaptureIdentity,
+  url: string,
+  selectionHash: string | undefined,
+  generation: number,
+): Promise<SameDayCapture | null> {
+  let source: string
+  try {
+    source = await readNote(identity.notePath, generation)
+  } catch (cause) {
+    if (isAppError(cause) && cause.kind === 'notFound') {
+      return null
+    }
+    throw cause
+  }
+  const split = splitFrontmatter(source)
+  const frontmatter = parseFrontmatter(split.raw).data
+  const meta = captureNoteMeta(frontmatter)
+  if (meta === null || meta.captureUrl !== url || meta.captureSelectionHash !== selectionHash) {
+    return null
+  }
+  return {
+    identity,
+    title: parseNote({ path: identity.notePath, source }).title,
+    body: split.body,
+    summary: meta.captureSummary,
+    source,
+    refreshable: !frontmatter.private && (await hashContent(split.body)) === meta.captureHash,
+  }
 }
 
 /**
@@ -129,27 +167,23 @@ async function findSameDayCapture(
     if (identity === null) {
       continue
     }
-    let source: string
-    try {
-      source = await readNote(identity.notePath, generation)
-    } catch (cause) {
-      if (isAppError(cause) && cause.kind === 'notFound') {
-        continue
-      }
-      throw cause
-    }
-    const split = splitFrontmatter(source)
-    const meta = captureNoteMeta(parseFrontmatter(split.raw).data)
-    if (meta && meta.captureUrl === url && meta.captureSelectionHash === selectionHash) {
-      return {
-        identity,
-        title: parseNote({ path: identity.notePath, source }).title,
-        body: split.body,
-        summary: meta.captureSummary,
-      }
+    const capture = await readSameDayCapture(identity, url, selectionHash, generation)
+    if (capture !== null) {
+      return capture
     }
   }
   return null
+}
+
+async function removeCaptureSpool(
+  name: string,
+  envelope: CaptureEnvelope,
+  generation: number,
+): Promise<void> {
+  await captureInboxRemove(name, generation)
+  if (envelope.screenshotRef) {
+    await captureInboxRemove(envelope.screenshotRef, generation)
+  }
 }
 
 /**
@@ -216,7 +250,7 @@ export async function drainCaptureInbox(
       const dailySource = await noteSource(daily, input.generation)
       const selection = envelope.selection?.trim()
       const selectionHash = selection ? await hashContent(selection) : undefined
-      const existing = await findSameDayCapture(
+      let existing = await findSameDayCapture(
         dailySource,
         [linksNoteTitle, LINKS_NOTE_TITLE],
         envelope.url,
@@ -225,14 +259,13 @@ export async function drainCaptureInbox(
       )
       const identity = existing?.identity ?? fresh
       const status: CaptureStatus = notePrivate(dailySource) ? 'skipped' : 'pending'
-      const mergedEnvelope = existing
-        ? {
-            ...envelope,
-            contentText: envelope.contentText ?? capturePageTextFromBody(existing.body),
-            summary: envelope.summary ?? existing.summary,
-            metaDescription: envelope.metaDescription ?? captureDescriptionFromBody(existing.body),
-          }
-        : envelope
+
+      if (existing !== null && !existing.refreshable) {
+        await removeCaptureSpool(name, envelope, input.generation)
+        drained += 1
+        deduped += 1
+        continue
+      }
 
       let hasScreenshot = false
       if (envelope.screenshotRef) {
@@ -252,12 +285,36 @@ export async function drainCaptureInbox(
         }
       }
 
+      if (existing !== null) {
+        existing = await readSameDayCapture(
+          existing.identity,
+          envelope.url,
+          selectionHash,
+          input.generation,
+        )
+        if (existing === null || !existing.refreshable) {
+          await removeCaptureSpool(name, envelope, input.generation)
+          drained += 1
+          deduped += 1
+          continue
+        }
+      }
+      const mergedEnvelope = existing
+        ? {
+            ...envelope,
+            contentText: envelope.contentText ?? capturePageTextFromBody(existing.body),
+            summary: envelope.summary ?? existing.summary,
+            metaDescription: envelope.metaDescription ?? captureDescriptionFromBody(existing.body),
+          }
+        : envelope
+
       await writeNote(
         identity.notePath,
         await captureNoteSource(mergedEnvelope, identity, {
           hasScreenshot,
           status,
           selectionHash,
+          existingSource: existing?.source,
         }),
         input.generation,
       )
@@ -280,10 +337,7 @@ export async function drainCaptureInbox(
       if (updatedDaily !== dailySource) {
         await writeNote(daily, updatedDaily, input.generation)
       }
-      await captureInboxRemove(name, input.generation)
-      if (envelope.screenshotRef) {
-        await captureInboxRemove(envelope.screenshotRef, input.generation)
-      }
+      await removeCaptureSpool(name, envelope, input.generation)
       drained += 1
       if (existing !== null) {
         deduped += 1

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -1009,7 +1009,7 @@ describe('reconcileCaptureEnrichment', () => {
     expect(note).toContain('captureStatus: skipped')
   })
 
-  it('leaves a managed summary refresh pending when it arrives during AI enrichment', async () => {
+  it('persists a finished AI result across a managed summary refresh', async () => {
     await drainOne()
     describeMock.mockImplementationOnce(async () => {
       addSpool(
@@ -1022,22 +1022,14 @@ describe('reconcileCaptureEnrichment', () => {
       return { title: 'An AI title', description: 'An AI description.' }
     })
 
-    const interrupted = await reconcile()
+    const outcome = await reconcile()
 
-    expect(interrupted).toEqual({ pending: 1, enriched: 0, skipped: 0, stopped: null })
-    const refreshed = files.get(IDENTITY.notePath) ?? ''
-    expect(refreshed).toContain('captureStatus: pending')
-    expect(refreshed).toContain('## Summary\n\n- A locally generated key point')
-    expect(refreshed).not.toContain('An AI description.')
-
-    describeMock.mockResolvedValue({ title: 'An AI title', description: 'An AI description.' })
-    const retry = await reconcile()
-
-    expect(retry).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
+    expect(outcome).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
     const enriched = files.get(IDENTITY.notePath) ?? ''
     expect(enriched).toContain('## Summary\n\n- A locally generated key point')
     expect(enriched).toContain('- Description: An AI description.')
     expect(enriched).toContain('captureStatus: done')
+    expect(describeMock).toHaveBeenCalledOnce()
   })
 
   it('leaves a user-edited daily link text alone while still retitling the note', async () => {

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -1009,6 +1009,37 @@ describe('reconcileCaptureEnrichment', () => {
     expect(note).toContain('captureStatus: skipped')
   })
 
+  it('leaves a managed summary refresh pending when it arrives during AI enrichment', async () => {
+    await drainOne()
+    describeMock.mockImplementationOnce(async () => {
+      addSpool(
+        envelope({
+          id: '00000000-0000-4000-8000-000000000002',
+          summary: '- A locally generated key point',
+        }),
+      )
+      expect((await drain()).deduped).toBe(1)
+      return { title: 'An AI title', description: 'An AI description.' }
+    })
+
+    const interrupted = await reconcile()
+
+    expect(interrupted).toEqual({ pending: 1, enriched: 0, skipped: 0, stopped: null })
+    const refreshed = files.get(IDENTITY.notePath) ?? ''
+    expect(refreshed).toContain('captureStatus: pending')
+    expect(refreshed).toContain('## Summary\n\n- A locally generated key point')
+    expect(refreshed).not.toContain('An AI description.')
+
+    describeMock.mockResolvedValue({ title: 'An AI title', description: 'An AI description.' })
+    const retry = await reconcile()
+
+    expect(retry).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
+    const enriched = files.get(IDENTITY.notePath) ?? ''
+    expect(enriched).toContain('## Summary\n\n- A locally generated key point')
+    expect(enriched).toContain('- Description: An AI description.')
+    expect(enriched).toContain('captureStatus: done')
+  })
+
   it('leaves a user-edited daily link text alone while still retitling the note', async () => {
     await drainOne()
     files.set(DAILY, (files.get(DAILY) ?? '').replace('|An article]]', '|my own link text]]'))

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -1027,9 +1027,7 @@ describe('reconcileCaptureEnrichment', () => {
     expect(interrupted).toEqual({ pending: 1, enriched: 0, skipped: 0, stopped: null })
     const refreshed = files.get(IDENTITY.notePath) ?? ''
     expect(refreshed).toContain('captureStatus: pending')
-    expect(refreshed).toContain(
-      '## Summary\n\n<!-- reflect-capture-summary:start -->\n- A locally generated key point',
-    )
+    expect(refreshed).toContain('## Summary\n\n- A locally generated key point')
     expect(refreshed).not.toContain('An AI description.')
 
     describeMock.mockResolvedValue({ title: 'An AI title', description: 'An AI description.' })
@@ -1037,9 +1035,7 @@ describe('reconcileCaptureEnrichment', () => {
 
     expect(retry).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
     const enriched = files.get(IDENTITY.notePath) ?? ''
-    expect(enriched).toContain(
-      '## Summary\n\n<!-- reflect-capture-summary:start -->\n- A locally generated key point',
-    )
+    expect(enriched).toContain('## Summary\n\n- A locally generated key point')
     expect(enriched).toContain('- Description: An AI description.')
     expect(enriched).toContain('captureStatus: done')
   })

--- a/packages/core/src/actions/capture-enrichment.test.ts
+++ b/packages/core/src/actions/capture-enrichment.test.ts
@@ -1027,7 +1027,9 @@ describe('reconcileCaptureEnrichment', () => {
     expect(interrupted).toEqual({ pending: 1, enriched: 0, skipped: 0, stopped: null })
     const refreshed = files.get(IDENTITY.notePath) ?? ''
     expect(refreshed).toContain('captureStatus: pending')
-    expect(refreshed).toContain('## Summary\n\n- A locally generated key point')
+    expect(refreshed).toContain(
+      '## Summary\n\n<!-- reflect-capture-summary:start -->\n- A locally generated key point',
+    )
     expect(refreshed).not.toContain('An AI description.')
 
     describeMock.mockResolvedValue({ title: 'An AI title', description: 'An AI description.' })
@@ -1035,7 +1037,9 @@ describe('reconcileCaptureEnrichment', () => {
 
     expect(retry).toEqual({ pending: 1, enriched: 1, skipped: 0, stopped: null })
     const enriched = files.get(IDENTITY.notePath) ?? ''
-    expect(enriched).toContain('## Summary\n\n- A locally generated key point')
+    expect(enriched).toContain(
+      '## Summary\n\n<!-- reflect-capture-summary:start -->\n- A locally generated key point',
+    )
     expect(enriched).toContain('- Description: An AI description.')
     expect(enriched).toContain('captureStatus: done')
   })

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -487,7 +487,7 @@ export async function reconcileCaptureEnrichment(
         return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })
       }
 
-      snapshot = await currentCapture(identity, metadataHash)
+      snapshot = await currentCapture(identity)
       if (snapshot === null) {
         continue
       }
@@ -503,7 +503,7 @@ export async function reconcileCaptureEnrichment(
       }
       const captureHash = await persistCaptureEnrichment({
         identity,
-        expectedHash: metadataHash,
+        expectedHash: snapshot.meta.captureHash,
         body: newBody,
         fromTitle: snapshot.title,
         toTitle: enrichedTitle,

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -235,7 +235,12 @@ export async function reconcileCaptureEnrichment(
   }
   const skipPending = async (identity: CaptureIdentity): Promise<void> => {
     const snapshot = await readPendingCaptureSnapshot(identity, input.generation)
-    if (snapshot !== null) {
+    if (snapshot === null) {
+      return
+    }
+    const dailySource = await noteSource(dailyPath(identity.date), input.generation)
+    const bodyHash = await hashContent(snapshot.body)
+    if (snapshot.isPrivate || notePrivate(dailySource) || bodyHash !== snapshot.meta.captureHash) {
       await markSkipped(snapshot.source, identity)
     }
   }
@@ -249,12 +254,14 @@ export async function reconcileCaptureEnrichment(
     }
     const dailySource = await noteSource(dailyPath(identity.date), input.generation)
     const bodyHash = await hashContent(snapshot.body)
-    if (
-      snapshot.isPrivate ||
-      notePrivate(dailySource) ||
-      bodyHash !== (expectedHash ?? snapshot.meta.captureHash)
-    ) {
+    if (snapshot.isPrivate || notePrivate(dailySource) || bodyHash !== snapshot.meta.captureHash) {
       await markSkipped(snapshot.source, identity)
+      return null
+    }
+    if (expectedHash !== undefined && snapshot.meta.captureHash !== expectedHash) {
+      // Another drain-managed recapture refreshed this note while enrichment
+      // was in flight. Its own captureHash still matches, so leave it pending
+      // for the next pass instead of treating it as a user edit.
       return null
     }
     return snapshot

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -127,7 +127,7 @@ async function generateEnrichment(input: GenerateEnrichmentInput): Promise<PageE
       metaTitle: input.scraped?.title ?? undefined,
       siteName: input.scraped?.siteName ?? undefined,
       metaDescription: input.scraped?.description ?? undefined,
-      contentText: capturePageTextFromBody(input.body),
+      contentText: await capturePageTextFromBody(input.body, input.meta.capturePageTextHash),
       screenshotBase64: input.screenshotBase64,
     })
   } catch (cause) {

--- a/packages/core/src/actions/capture-envelope.fixtures.json
+++ b/packages/core/src/actions/capture-envelope.fixtures.json
@@ -15,7 +15,7 @@
       }
     },
     {
-      "name": "full with selection, page text, note, and screenshot",
+      "name": "full with selection, page text, summary, note, and screenshot",
       "message": {
         "envelope": {
           "version": 1,
@@ -24,6 +24,7 @@
           "title": "Local page",
           "selection": "quoted text",
           "contentText": "First paragraph.\n\nSecond paragraph.",
+          "summary": "- First key point\n- Second key point",
           "note": "check later",
           "capturedAt": "2026-06-12T15:30:22.845Z",
           "source": "extension"

--- a/packages/core/src/actions/capture-envelope.test.ts
+++ b/packages/core/src/actions/capture-envelope.test.ts
@@ -22,11 +22,12 @@ describe('captureEnvelopeSchema', () => {
     expect(captureEnvelopeSchema.parse(VALID)).toEqual(VALID)
   })
 
-  it('accepts the full shape with selection, page text, note, and screenshot', () => {
+  it('accepts the full shape with selection, page text, summary, note, and screenshot', () => {
     const full = {
       ...VALID,
       selection: 'quoted text',
       contentText: 'First paragraph.\n\nSecond paragraph.',
+      summary: '- First key point\n- Second key point',
       note: 'check this later',
       screenshotRef: `${VALID.id}.jpg`,
     }

--- a/packages/core/src/actions/capture-envelope.ts
+++ b/packages/core/src/actions/capture-envelope.ts
@@ -49,6 +49,8 @@ export const captureEnvelopeSchema = z.object({
   selection: z.string().optional(),
   /** Plain text paragraphs extracted from the captured page. */
   contentText: z.string().optional(),
+  /** Markdown summary generated on-device by the capturing browser. */
+  summary: z.string().optional(),
   /**
    * The page's own meta/OpenGraph description, extracted in-page at capture
    * time (the iOS share extension's Safari preprocessor). The drain writes it

--- a/packages/core/src/actions/capture-note.ts
+++ b/packages/core/src/actions/capture-note.ts
@@ -73,6 +73,10 @@ function captureNoteBody(
   if (note) {
     parts.push(`## Note\n\n${note}`)
   }
+  const summary = envelope.summary?.trim()
+  if (summary) {
+    parts.push(`## Summary\n\n${summary}`)
+  }
   const selection = envelope.selection?.trim()
   if (selection) {
     parts.push(`## Selection\n\n${selection}`)

--- a/packages/core/src/actions/capture-note.ts
+++ b/packages/core/src/actions/capture-note.ts
@@ -119,19 +119,39 @@ function firstSectionStart(body: string): number {
   return body.length
 }
 
+interface CaptureNoteSourceOptions {
+  /** Whether this write successfully promoted a screenshot asset. */
+  hasScreenshot: boolean
+  /** Enrichment state for the generated note. */
+  status: CaptureStatus
+  /** Hash distinguishing otherwise-identical captures with different selections. */
+  selectionHash?: string | undefined
+  /** Existing managed capture whose unrelated frontmatter should survive a refresh. */
+  existingSource?: string | undefined
+}
+
 export async function captureNoteSource(
   envelope: CaptureEnvelope,
   identity: CaptureIdentity,
-  options: { hasScreenshot: boolean; status: CaptureStatus; selectionHash?: string | undefined },
+  options: CaptureNoteSourceOptions,
 ): Promise<string> {
   const body = captureNoteBody(envelope, identity, options.hasScreenshot)
   const summary = envelope.summary?.trim()
-  return upsertFrontmatter(body, {
+  const source =
+    options.existingSource === undefined
+      ? body
+      : options.existingSource.slice(0, splitFrontmatter(options.existingSource).bodyOffset) + body
+  return upsertFrontmatter(source, {
     aliases: [identity.base],
     captureUrl: envelope.url,
     capturedAt: envelope.capturedAt,
     captureSource: envelope.source,
     captureStatus: options.status,
+    captureMetadataStatus: undefined,
+    captureDailyFromTitle: undefined,
+    captureFinalizeStatus: undefined,
+    captureProvider: undefined,
+    captureModel: undefined,
     captureHash: await hashContent(body),
     captureSelectionHash: options.selectionHash,
     captureScreenshot: options.hasScreenshot ? identity.assetPath : undefined,

--- a/packages/core/src/actions/capture-note.ts
+++ b/packages/core/src/actions/capture-note.ts
@@ -30,6 +30,8 @@ const captureNoteMetaSchema = z.object({
   captureHash: z.string(),
   captureSelectionHash: z.string().optional(),
   captureScreenshot: z.string().optional(),
+  /** Identifies the exact managed Page Text block without trusting note markers alone. */
+  capturePageTextHash: z.string().optional(),
   /** Structured copy used to preserve the managed body section across recaptures. */
   captureSummary: z.string().optional(),
 })
@@ -93,19 +95,29 @@ function captureNoteBody(
   return `${parts.join('\n\n')}\n`
 }
 
-export function capturePageTextFromBody(body: string): string | undefined {
-  const marker = `\n## Page Text\n\n${PAGE_TEXT_START}\n`
-  const markerAt = body.indexOf(marker)
-  if (markerAt === -1) {
+/** Read only a Page Text block whose content matches the structured managed hash. */
+export async function capturePageTextFromBody(
+  body: string,
+  expectedHash: string | undefined,
+): Promise<string | undefined> {
+  if (expectedHash === undefined) {
     return undefined
   }
-  const contentStart = markerAt + marker.length
-  const endAt = body.indexOf(PAGE_TEXT_END, contentStart)
-  if (endAt === -1) {
-    throw new Error('capture note is missing page text end marker')
+  const marker = `\n## Page Text\n\n${PAGE_TEXT_START}\n`
+  let markerAt = body.indexOf(marker)
+  while (markerAt !== -1) {
+    const contentStart = markerAt + marker.length
+    let endAt = body.indexOf(PAGE_TEXT_END, contentStart)
+    while (endAt !== -1) {
+      const content = body.slice(contentStart, endAt).trim()
+      if (content !== '' && (await hashContent(content)) === expectedHash) {
+        return content
+      }
+      endAt = body.indexOf(PAGE_TEXT_END, endAt + PAGE_TEXT_END.length)
+    }
+    markerAt = body.indexOf(marker, contentStart)
   }
-  const content = body.slice(contentStart, endAt).trim()
-  return content === '' ? undefined : content
+  return undefined
 }
 
 function firstSectionStart(body: string): number {
@@ -137,6 +149,7 @@ export async function captureNoteSource(
 ): Promise<string> {
   const body = captureNoteBody(envelope, identity, options.hasScreenshot)
   const summary = envelope.summary?.trim()
+  const pageText = envelope.contentText?.trim()
   const source =
     options.existingSource === undefined
       ? body
@@ -155,6 +168,7 @@ export async function captureNoteSource(
     captureHash: await hashContent(body),
     captureSelectionHash: options.selectionHash,
     captureScreenshot: options.hasScreenshot ? identity.assetPath : undefined,
+    capturePageTextHash: pageText ? await hashContent(pageText) : undefined,
     captureSummary: summary === '' ? undefined : summary,
   })
 }

--- a/packages/core/src/actions/capture-note.ts
+++ b/packages/core/src/actions/capture-note.ts
@@ -30,6 +30,8 @@ const captureNoteMetaSchema = z.object({
   captureHash: z.string(),
   captureSelectionHash: z.string().optional(),
   captureScreenshot: z.string().optional(),
+  /** Structured copy used to preserve the managed body section across recaptures. */
+  captureSummary: z.string().optional(),
 })
 
 export type CaptureNoteMeta = z.infer<typeof captureNoteMetaSchema>
@@ -50,8 +52,6 @@ function urlHost(url: string): string {
 
 const PAGE_TEXT_START = '<!-- reflect-capture-page-text:start -->'
 const PAGE_TEXT_END = '<!-- reflect-capture-page-text:end -->'
-const SUMMARY_START = '<!-- reflect-capture-summary:start -->'
-const SUMMARY_END = '<!-- reflect-capture-summary:end -->'
 
 /** The capture's display title: the page title, else the URL's host. */
 export function displayTitle(envelope: Pick<CaptureEnvelope, 'title' | 'url'>): string {
@@ -77,7 +77,7 @@ function captureNoteBody(
   }
   const summary = envelope.summary?.trim()
   if (summary) {
-    parts.push(`## Summary\n\n${SUMMARY_START}\n${summary}\n${SUMMARY_END}`)
+    parts.push(`## Summary\n\n${summary}`)
   }
   const selection = envelope.selection?.trim()
   if (selection) {
@@ -108,22 +108,6 @@ export function capturePageTextFromBody(body: string): string | undefined {
   return content === '' ? undefined : content
 }
 
-/** The on-device summary written in the managed Summary section, when present. */
-export function captureSummaryFromBody(body: string): string | undefined {
-  const marker = `## Summary\n\n${SUMMARY_START}\n`
-  const markerAt = body.indexOf(marker)
-  if (markerAt === -1) {
-    return undefined
-  }
-  const contentStart = markerAt + marker.length
-  const endAt = body.indexOf(SUMMARY_END, contentStart)
-  if (endAt === -1) {
-    throw new Error('capture note is missing summary end marker')
-  }
-  const summary = body.slice(contentStart, endAt).trim()
-  return summary === '' ? undefined : summary
-}
-
 function firstSectionStart(body: string): number {
   let offset = 0
   for (const line of body.split('\n')) {
@@ -141,6 +125,7 @@ export async function captureNoteSource(
   options: { hasScreenshot: boolean; status: CaptureStatus; selectionHash?: string | undefined },
 ): Promise<string> {
   const body = captureNoteBody(envelope, identity, options.hasScreenshot)
+  const summary = envelope.summary?.trim()
   return upsertFrontmatter(body, {
     aliases: [identity.base],
     captureUrl: envelope.url,
@@ -150,6 +135,7 @@ export async function captureNoteSource(
     captureHash: await hashContent(body),
     captureSelectionHash: options.selectionHash,
     captureScreenshot: options.hasScreenshot ? identity.assetPath : undefined,
+    captureSummary: summary === '' ? undefined : summary,
   })
 }
 

--- a/packages/core/src/actions/capture-note.ts
+++ b/packages/core/src/actions/capture-note.ts
@@ -3,7 +3,9 @@ import { isAppError } from '../errors'
 import { readNote } from '../graph/commands'
 import { hashContent } from '../indexing/hash'
 import { wikiLinkSafe } from '../markdown/edit'
+import { parseNote } from '../markdown/extract'
 import { parseFrontmatter, splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
+import { sectionEnd, topLevelHeadings } from '../markdown/heading-blocks'
 import type { Frontmatter } from '../markdown/model'
 import type { CaptureIdentity } from './capture-identity'
 import type { CaptureEnvelope } from './capture-envelope'
@@ -104,6 +106,21 @@ export function capturePageTextFromBody(body: string): string | undefined {
   }
   const content = body.slice(contentStart, endAt).trim()
   return content === '' ? undefined : content
+}
+
+/** The on-device summary written in the managed Summary section, when present. */
+export function captureSummaryFromBody(body: string): string | undefined {
+  const headings = topLevelHeadings(parseNote({ path: '', source: body }).headings)
+  const summaryHeading = headings.find(
+    (heading) => heading.level === 2 && heading.text.trim() === 'Summary',
+  )
+  if (!summaryHeading) {
+    return undefined
+  }
+  const summary = body
+    .slice(summaryHeading.to, sectionEnd(headings, summaryHeading, body.length))
+    .trim()
+  return summary === '' ? undefined : summary
 }
 
 function firstSectionStart(body: string): number {

--- a/packages/core/src/actions/capture-note.ts
+++ b/packages/core/src/actions/capture-note.ts
@@ -3,9 +3,7 @@ import { isAppError } from '../errors'
 import { readNote } from '../graph/commands'
 import { hashContent } from '../indexing/hash'
 import { wikiLinkSafe } from '../markdown/edit'
-import { parseNote } from '../markdown/extract'
 import { parseFrontmatter, splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
-import { sectionEnd, topLevelHeadings } from '../markdown/heading-blocks'
 import type { Frontmatter } from '../markdown/model'
 import type { CaptureIdentity } from './capture-identity'
 import type { CaptureEnvelope } from './capture-envelope'
@@ -52,6 +50,8 @@ function urlHost(url: string): string {
 
 const PAGE_TEXT_START = '<!-- reflect-capture-page-text:start -->'
 const PAGE_TEXT_END = '<!-- reflect-capture-page-text:end -->'
+const SUMMARY_START = '<!-- reflect-capture-summary:start -->'
+const SUMMARY_END = '<!-- reflect-capture-summary:end -->'
 
 /** The capture's display title: the page title, else the URL's host. */
 export function displayTitle(envelope: Pick<CaptureEnvelope, 'title' | 'url'>): string {
@@ -77,7 +77,7 @@ function captureNoteBody(
   }
   const summary = envelope.summary?.trim()
   if (summary) {
-    parts.push(`## Summary\n\n${summary}`)
+    parts.push(`## Summary\n\n${SUMMARY_START}\n${summary}\n${SUMMARY_END}`)
   }
   const selection = envelope.selection?.trim()
   if (selection) {
@@ -110,16 +110,17 @@ export function capturePageTextFromBody(body: string): string | undefined {
 
 /** The on-device summary written in the managed Summary section, when present. */
 export function captureSummaryFromBody(body: string): string | undefined {
-  const headings = topLevelHeadings(parseNote({ path: '', source: body }).headings)
-  const summaryHeading = headings.find(
-    (heading) => heading.level === 2 && heading.text.trim() === 'Summary',
-  )
-  if (!summaryHeading) {
+  const marker = `## Summary\n\n${SUMMARY_START}\n`
+  const markerAt = body.indexOf(marker)
+  if (markerAt === -1) {
     return undefined
   }
-  const summary = body
-    .slice(summaryHeading.to, sectionEnd(headings, summaryHeading, body.length))
-    .trim()
+  const contentStart = markerAt + marker.length
+  const endAt = body.indexOf(SUMMARY_END, contentStart)
+  if (endAt === -1) {
+    throw new Error('capture note is missing summary end marker')
+  }
+  const summary = body.slice(contentStart, endAt).trim()
   return summary === '' ? undefined : summary
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@8.2.0)
+      '@types/dom-chromium-ai':
+        specifier: ^0.0.17
+        version: 0.0.17
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -2218,6 +2221,9 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/dom-chromium-ai@0.0.17':
+    resolution: {integrity: sha512-UnSAIVKONaY2vTAM4TkPpwdKeGgg3tPCwNP3KxR+U8bLYC2rQU7UrgW9LIVx0B02dKZxuPA6a0Q5wvyW5Rk6nw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -8347,6 +8353,8 @@ snapshots:
       '@types/ms': 2.1.0
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/dom-chromium-ai@0.0.17': {}
 
   '@types/esrecurse@4.3.1': {}
 


### PR DESCRIPTION
## Problem

Reflect's Chrome extension can capture a page's complete readable text, but it cannot turn that text into a concise local summary. Waiting for a summary before saving would also make link capture fragile: closing the popup or waiting for Chrome's local model download could lose the user's primary action.

The keyboard shortcut currently bypasses the popup, which leaves no document context or fresh Enter/click gesture for Chrome's Summarizer API. The API is unavailable in the MV3 service worker.

## Before -> After

| Before | After |
| --- | --- |
| Capture the link or full page text | Independently capture full text, an on-device summary, or both |
| Wait for optional page-text extraction before the only save | Queue the raw link first, then refresh the same capture with the summary |
| Command-Shift-K saves immediately with stored defaults | Command-Shift-K opens the focused popup; Enter saves with the visible options |
| Captured notes have Note, Selection, Page Text, and Screenshot sections | Browser-generated summaries have a dedicated Summary section |

## Changes

1. **On-device summary flow**
   - Feature-detects Chrome's Summarizer API and model availability without raising the extension's minimum Chrome version.
   - Starts model creation from the form submission gesture, reports model-download/generation progress, observes the model input quota, and releases or aborts the session with the popup lifecycle.
   - Persists an independent Capture page summary preference. Summary captures queue the raw link first and send a same-timestamp recapture afterward so existing URL/selection deduplication updates the original note.
   - Preserves the existing page-text option; if summary generation fails, requested page text still lands and the raw link is never lost.

2. **Capture contract and note shape**
   - Adds an optional `summary` field to the additive version-1 capture envelope, extension wire builder, Rust native host, and shared parity fixtures.
   - Renders the generated Markdown under `## Summary`, after the user's note and before selection/page text.
   - Treats a drain-managed summary refresh during desktop enrichment as a pending managed update rather than a user edit, so metadata/BYOK enrichment can retry without clobbering the summary.

3. **Shortcut and disclosures**
   - Uses `action.openPopup()` for the keyboard command, with the old instant capture as a pre-Chrome-127/rejected-popup fallback.
   - Updates extension/store copy, the link-capture design record, and privacy disclosures to distinguish local Chrome AI from provider-backed AI and explain the one-time model download.

## Tests

- Summarizer feature detection, availability, configuration, download progress, quota trimming, empty output, cancellation, and cleanup.
- Two-phase ordering, stable capture time, independent text/summary options, failure fallback, and rejected raw links.
- Shortcut popup opening and legacy fallback.
- Extension wire shaping, preferences, shared TypeScript/Rust envelope parity, summary note rendering, same-day deduplication, and summary/enrichment races.

## Verification

- `pnpm check`
- `pnpm test --run apps/extension/lib/page-summary.test.ts apps/extension/entrypoints/popup/capture-flow.test.ts apps/extension/lib/commands.test.ts apps/extension/lib/popup-preferences.test.ts apps/extension/lib/capture-message.test.ts packages/core/src/actions/capture-envelope.test.ts packages/core/src/actions/capture-envelope.parity.test.ts packages/core/src/actions/capture-drain.test.ts packages/core/src/actions/capture-enrichment.test.ts` — 161 passed
- `cargo test -p reflect-capture-host` — 23 passed
- `pnpm --filter @reflect/extension build`

## Risk / Rollout

- This is an additive envelope change with no data migration. The extension and desktop/native host should ship together; older hosts tolerate but discard the unknown summary field, while the already-queued raw link remains safe.
- Chrome may download its built-in model on first use. Captured page text stays on-device and is not sent to Reflect or an AI provider.
- Browsers without usable built-in summarization see a disabled option and retain all existing capture behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional on-device page summaries during browser capture, with selectable page text, summaries, or both.
  * Added progress indicators for model downloads and summary generation.
  * Added a saved preference for enabling summaries.
  * Summaries are included in notes and preserved during queued processing.
  * Keyboard capture opens capture options, with direct-save fallback when unavailable.

* **Bug Fixes**
  * Improved handling of capture failures, cancellations, retries, and concurrent updates.

* **Documentation**
  * Clarified local processing, privacy protections, permissions, and summary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->