### PR TITLE
fix: reset the "New template" dialog when it closes

### DIFF
--- a/apps/desktop/src/components/templates/template-create-dialog.test.tsx
+++ b/apps/desktop/src/components/templates/template-create-dialog.test.tsx
@@ -1,0 +1,111 @@
+import type { ReactElement } from 'react'
+import { render } from 'vitest-browser-react'
+import { page } from 'vitest/browser'
+import { beforeEach, expect, it, vi } from 'vitest'
+import type { CommandContext } from '@/lib/commands/types'
+import { NoteTemplatesProvider, useNoteTemplates } from '@/providers/note-templates-provider'
+import { TemplateCreateDialog } from './template-create-dialog'
+
+const { createTemplateMock } = vi.hoisted(() => ({ createTemplateMock: vi.fn() }))
+vi.mock('@/lib/note-templates', () => ({ createTemplate: createTemplateMock }))
+
+function Opener(): ReactElement {
+  const { openTemplateCreate } = useNoteTemplates()
+  return (
+    <button type="button" onClick={openTemplateCreate}>
+      Open template dialog
+    </button>
+  )
+}
+
+async function renderDialog(): Promise<CommandContext> {
+  const context: CommandContext = {
+    navigate: vi.fn(),
+    route: () => ({ kind: 'today' }),
+    notePath: () => null,
+    back: vi.fn(),
+    forward: vi.fn(),
+    clearScrollState: vi.fn(),
+    toggleTheme: vi.fn(),
+    toggleSidebar: vi.fn(),
+    newChat: vi.fn(),
+    openNoteFind: vi.fn(),
+    findNextInNote: vi.fn(),
+    findPreviousInNote: vi.fn(),
+    switchGraph: vi.fn(),
+    toggleAudioMemo: vi.fn(),
+    generation: () => 1,
+    graphRoot: () => '/notes',
+    openPalette: vi.fn(),
+    openShortcuts: vi.fn(),
+    openTemplatePicker: vi.fn(),
+    openTemplateCreate: vi.fn(),
+    enableSemanticSearch: vi.fn(),
+  }
+  await render(
+    <NoteTemplatesProvider>
+      <Opener />
+      <TemplateCreateDialog context={context} />
+    </NoteTemplatesProvider>,
+  )
+  return context
+}
+
+async function openDialog(): Promise<void> {
+  await page.getByRole('button', { name: 'Open template dialog' }).click()
+  await expect.element(page.getByRole('dialog', { name: 'New template' })).toBeInTheDocument()
+}
+
+async function closeAndWaitForExit(): Promise<void> {
+  await page.getByRole('button', { name: 'Cancel' }).click()
+  await expect.element(page.getByRole('dialog', { name: 'New template' })).not.toBeInTheDocument()
+}
+
+beforeEach(() => {
+  createTemplateMock.mockReset()
+})
+
+it('starts empty again after cancelling a typed name', async () => {
+  await renderDialog()
+  await openDialog()
+  await page.getByPlaceholder('Template name').fill('Weekly review')
+  await closeAndWaitForExit()
+
+  await openDialog()
+  await expect.element(page.getByPlaceholder('Template name')).toHaveValue('')
+})
+
+it('drops the validation error between opens', async () => {
+  await renderDialog()
+  await openDialog()
+  await page.getByRole('button', { name: 'Create' }).click()
+  await expect.element(page.getByRole('alert')).toHaveTextContent('Enter a name.')
+  await closeAndWaitForExit()
+
+  await openDialog()
+  await expect.element(page.getByRole('alert')).not.toBeInTheDocument()
+})
+
+it('starts empty after a successful create, and drops a stale submit error', async () => {
+  createTemplateMock.mockRejectedValueOnce(new Error('disk full'))
+  createTemplateMock.mockResolvedValueOnce('templates/meeting-notes.md')
+  const context = await renderDialog()
+  await openDialog()
+
+  // First attempt fails and surfaces the submit error inline.
+  await page.getByPlaceholder('Template name').fill('Meeting notes')
+  await page.getByRole('button', { name: 'Create' }).click()
+  await expect.element(page.getByText('disk full')).toBeInTheDocument()
+
+  // Second attempt succeeds: the dialog closes and navigates.
+  await page.getByRole('button', { name: 'Create' }).click()
+  await expect.element(page.getByRole('dialog', { name: 'New template' })).not.toBeInTheDocument()
+  expect(context.navigate).toHaveBeenCalledWith({
+    kind: 'note',
+    path: 'templates/meeting-notes.md',
+  })
+
+  await openDialog()
+  await expect.element(page.getByPlaceholder('Template name')).toHaveValue('')
+  await expect.element(page.getByText('disk full')).not.toBeInTheDocument()
+})

--- a/apps/desktop/src/components/templates/template-create-dialog.tsx
+++ b/apps/desktop/src/components/templates/template-create-dialog.tsx
@@ -62,10 +62,6 @@ export function TemplateCreateDialog({ context }: TemplateCreateDialogProps): Re
         }
       }}
       onOpenChangeComplete={(isOpen) => {
-        // The component stays mounted across opens, so the previous name,
-        // validation error, and submit error would leak into the next open;
-        // clear them after the exit transition so the fields never blank
-        // mid-fade.
         if (!isOpen) {
           reset()
           setSubmitError(null)

--- a/apps/desktop/src/components/templates/template-create-dialog.tsx
+++ b/apps/desktop/src/components/templates/template-create-dialog.tsx
@@ -31,16 +31,12 @@ interface TemplateCreateForm {
   name: string
 }
 
-export function TemplateCreateDialog({ context }: TemplateCreateDialogProps): ReactElement | null {
+export function TemplateCreateDialog({ context }: TemplateCreateDialogProps): ReactElement {
   const { createOpen, closeTemplateCreate } = useNoteTemplates()
-  const { register, handleSubmit, formState } = useForm<TemplateCreateForm>({
+  const { register, handleSubmit, formState, reset } = useForm<TemplateCreateForm>({
     defaultValues: { name: '' },
   })
   const [submitError, setSubmitError] = useState<string | null>(null)
-
-  if (!createOpen) {
-    return null
-  }
 
   const submit = handleSubmit(async (values) => {
     setSubmitError(null)
@@ -59,10 +55,20 @@ export function TemplateCreateDialog({ context }: TemplateCreateDialogProps): Re
 
   return (
     <Dialog
-      open
+      open={createOpen}
       onOpenChange={(isOpen) => {
         if (!isOpen) {
           closeTemplateCreate()
+        }
+      }}
+      onOpenChangeComplete={(isOpen) => {
+        // The component stays mounted across opens, so the previous name,
+        // validation error, and submit error would leak into the next open;
+        // clear them after the exit transition so the fields never blank
+        // mid-fade.
+        if (!isOpen) {
+          reset()
+          setSubmitError(null)
         }
       }}
     >


### PR DESCRIPTION
Reopening the New template dialog kept the previously typed name, validation error, and submit error; drive Base UI's controlled `open` and reset the form after the close transition.


Before: 

https://github.com/user-attachments/assets/c78ba0d7-048e-4185-8d44-93004d6ab8db


After: 

https://github.com/user-attachments/assets/8f4f0888-3318-44ed-9bcd-c45442cd34ef



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template creation dialog behavior when canceling, closing, and reopening.
  * Cleared previously entered names and validation or submission errors after the dialog closes.
  * Ensured failed submissions can be retried successfully without stale state.

* **Tests**
  * Added coverage for cancelation, validation errors, failed submissions, successful retries, dialog closure, and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->