### PR TITLE
refactor: drop manual dialog focus-restore effects

### DIFF
--- a/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
+++ b/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactElement } from 'react'
+import type { ReactElement } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import {
   AI_PROVIDERS,
@@ -69,20 +69,6 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
     onAdd,
     onDone: onClose,
   })
-
-  // The dialog is conditionally mounted by its parent (not kept alive with
-  // open=false), so Radix's Presence/onCloseAutoFocus path is bypassed when
-  // Cancel or a successful submit calls onClose() directly.  Capturing focus
-  // here and restoring it in the cleanup ensures the opener always gets focus
-  // back regardless of which close path runs.
-  useEffect(() => {
-    const opener = document.activeElement
-    return () => {
-      if (opener instanceof HTMLElement) {
-        opener.focus()
-      }
-    }
-  }, [])
 
   const providerId = useWatch({ control, name: 'provider' })
   const selectedModel = useWatch({ control, name: 'model' })

--- a/apps/desktop/src/components/settings/ai-prompt-dialog.tsx
+++ b/apps/desktop/src/components/settings/ai-prompt-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactElement } from 'react'
+import type { ReactElement } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import type { AiPrompt, AiPromptMode } from '@reflect/core'
 import { Button } from '@/components/ui/button'
@@ -45,18 +45,6 @@ export function AiPromptDialog({ prompt, onSave, onClose }: AiPromptDialogProps)
     },
   })
   const mode = useWatch({ control, name: 'mode' })
-
-  // The dialog is conditionally mounted by its parent, so Radix's close-focus
-  // path is bypassed when Cancel or a successful submit calls onClose()
-  // directly; restore the opener's focus ourselves.
-  useEffect(() => {
-    const opener = document.activeElement
-    return () => {
-      if (opener instanceof HTMLElement) {
-        opener.focus()
-      }
-    }
-  }, [])
 
   const submit = handleSubmit((values) => {
     onSave({ label: values.label.trim(), body: values.body.trim(), mode: values.mode })

--- a/apps/desktop/src/components/settings/ai-providers-section.test.tsx
+++ b/apps/desktop/src/components/settings/ai-providers-section.test.tsx
@@ -366,6 +366,24 @@ describe('AiProvidersSection', () => {
     })
   })
 
+  it('returns focus to the opener when the dialog closes', async () => {
+    await renderSection()
+    await expect.element(page.getByText(/No AI providers configured/)).toBeInTheDocument()
+
+    // WebKit does not focus buttons on click, so anchor focus explicitly:
+    // both engines then open the dialog with the opener as the previously
+    // focused element, which Base UI restores after the popup unmounts.
+    const opener = page.getByRole('button', { name: /add provider/i })
+    opener.element().focus()
+    const dialog = await openDialog()
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click()
+    // The restore runs in a microtask after the popup unmounts; poll for it.
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(opener.element())
+    })
+  })
+
   it('falls back to the first entry when the default id dangles', async () => {
     stored = { ...twoStoredModels(), defaultAiProviderId: 'gone' }
     await renderSection()


### PR DESCRIPTION
Base UI's focus manager already returns focus to the opener when an always-open dialog unmounts, so the hand-rolled restore effects (and their stale Radix comments) can go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus handling when closing AI provider and AI prompt dialogs.
  * Focus now returns to the appropriate control after closing the AI provider dialog.

* **Tests**
  * Added coverage to verify focus restoration after closing the AI provider dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->