### PR TITLE
refactor: let dialogs play their exit transition before unmounting

### DIFF
--- a/apps/desktop/src/components/context-sidebar/add-meeting-dialog.tsx
+++ b/apps/desktop/src/components/context-sidebar/add-meeting-dialog.tsx
@@ -48,6 +48,8 @@ const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
  * are pre-filled from Apple Contacts by attendee email.
  */
 export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps): ReactElement {
+  const [open, setOpen] = useState(true)
+  const close = (): void => setOpen(false)
   const { settings } = useSettings()
   const { graph } = useGraph()
   const [name, setName] = useState(event.title)
@@ -144,7 +146,7 @@ export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps
         startTime: formatTimeOfDay(new Date(event.startsAt), settings.timeFormat),
         generation: graph.generation,
       })
-      onClose()
+      close()
     } catch (cause) {
       setError(errorMessage(cause))
       setSubmitting(false)
@@ -153,8 +155,13 @@ export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps
 
   return (
     <Dialog
-      open
+      open={open}
       onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          close()
+        }
+      }}
+      onOpenChangeComplete={(isOpen) => {
         if (!isOpen) {
           onClose()
         }
@@ -222,7 +229,7 @@ export function AddMeetingDialog({ date, event, onClose }: AddMeetingDialogProps
           </label>
           {error !== null && <InlineAlert tone="error">{error}</InlineAlert>}
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={onClose}>
+            <Button type="button" variant="outline" onClick={close}>
               Cancel
             </Button>
             <Button type="submit" disabled={!canSubmit}>

--- a/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
+++ b/apps/desktop/src/components/settings/add-ai-provider-dialog.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react'
+import { useState, type ReactElement } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import {
   AI_PROVIDERS,
@@ -56,6 +56,8 @@ const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
  * failure keeps the dialog open with the typed key intact for a retry.
  */
 export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps): ReactElement {
+  const [open, setOpen] = useState(true)
+  const close = (): void => setOpen(false)
   const { register, control, handleSubmit, setValue, formState } = useForm<AddAiProviderForm>({
     defaultValues: {
       provider: AI_PROVIDERS[0].id,
@@ -67,7 +69,7 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
   })
   const { submitError, unverified, resetUnverified, submit } = useAddAiProviderSubmit({
     onAdd,
-    onDone: onClose,
+    onDone: close,
   })
 
   const providerId = useWatch({ control, name: 'provider' })
@@ -83,9 +85,16 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
 
   return (
     <Dialog
-      open
+      open={open}
       onOpenChange={(isOpen) => {
-        if (!isOpen) onClose()
+        if (!isOpen) {
+          close()
+        }
+      }}
+      onOpenChangeComplete={(isOpen) => {
+        if (!isOpen) {
+          onClose()
+        }
       }}
     >
       <DialogContent showCloseButton={false} className="max-w-md">
@@ -231,7 +240,7 @@ export function AddAiProviderDialog({ onAdd, onClose }: AddAiProviderDialogProps
           ) : null}
 
           <div className="flex justify-end gap-2">
-            <Button type="button" variant="outline" size="sm" onClick={onClose}>
+            <Button type="button" variant="outline" size="sm" onClick={close}>
               Cancel
             </Button>
             <Button type="submit" size="sm" disabled={formState.isSubmitting}>

--- a/apps/desktop/src/components/settings/ai-prompt-dialog.tsx
+++ b/apps/desktop/src/components/settings/ai-prompt-dialog.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react'
+import { useState, type ReactElement } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import type { AiPrompt, AiPromptMode } from '@reflect/core'
 import { Button } from '@/components/ui/button'
@@ -37,6 +37,8 @@ const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
  * or is inserted below it.
  */
 export function AiPromptDialog({ prompt, onSave, onClose }: AiPromptDialogProps): ReactElement {
+  const [open, setOpen] = useState(true)
+  const close = (): void => setOpen(false)
   const { register, control, handleSubmit, setValue, formState } = useForm<AiPromptDraft>({
     defaultValues: {
       label: prompt?.label ?? '',
@@ -48,14 +50,21 @@ export function AiPromptDialog({ prompt, onSave, onClose }: AiPromptDialogProps)
 
   const submit = handleSubmit((values) => {
     onSave({ label: values.label.trim(), body: values.body.trim(), mode: values.mode })
-    onClose()
+    close()
   })
 
   return (
     <Dialog
-      open
+      open={open}
       onOpenChange={(isOpen) => {
-        if (!isOpen) onClose()
+        if (!isOpen) {
+          close()
+        }
+      }}
+      onOpenChangeComplete={(isOpen) => {
+        if (!isOpen) {
+          onClose()
+        }
       }}
     >
       <DialogContent
@@ -112,7 +121,7 @@ export function AiPromptDialog({ prompt, onSave, onClose }: AiPromptDialogProps)
             </Select>
           </label>
           <div className="flex justify-end gap-2">
-            <Button type="button" variant="ghost" onClick={onClose}>
+            <Button type="button" variant="ghost" onClick={close}>
               Cancel
             </Button>
             <Button type="submit">{prompt === null ? 'Add prompt' : 'Save'}</Button>

--- a/apps/desktop/src/components/settings/connect-github-dialog.test.tsx
+++ b/apps/desktop/src/components/settings/connect-github-dialog.test.tsx
@@ -89,11 +89,11 @@ describe('ConnectGithubDialog', () => {
       ),
     )
     await vi.waitFor(() => expect(sync.connectNewRepo).toHaveBeenCalledWith('my-notes'))
-    expect(onClose).toHaveBeenCalled()
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalled())
   })
 
   it('shows the signed-in identity on the finish step', async () => {
-    sync.connectExistingRepo.mockResolvedValueOnce('notFound')
+    sync.connectExistingRepo.mockResolvedValue('notFound')
     sync.connectNewRepo.mockResolvedValueOnce('manualCreateNeeded')
     await renderWizard()
 
@@ -103,7 +103,7 @@ describe('ConnectGithubDialog', () => {
   })
 
   it('hands off to github.com/new and connects by polling — no button to click', async () => {
-    sync.connectExistingRepo.mockResolvedValueOnce('notFound').mockResolvedValueOnce('notFound')
+    sync.connectExistingRepo.mockResolvedValue('notFound')
     sync.connectNewRepo.mockResolvedValueOnce('manualCreateNeeded')
     const onClose = await renderWizard()
 
@@ -117,6 +117,7 @@ describe('ConnectGithubDialog', () => {
     )
 
     // Once the repo exists, a poll connects it — the user clicks nothing.
+    sync.connectExistingRepo.mockResolvedValue('connected')
     await vi.waitFor(() =>
       expect(sync.connectExistingRepo).toHaveBeenLastCalledWith(
         { owner: 'alex', name: 'g-backup' },
@@ -200,7 +201,7 @@ describe('ConnectGithubDialog', () => {
         { allowPublic: true },
       ),
     )
-    expect(onClose).toHaveBeenCalled()
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalled())
   })
 
   it('surfaces a missing existing repo as an inline error, not a create guide', async () => {
@@ -240,7 +241,7 @@ describe('ConnectGithubDialog', () => {
         { allowPublic: false },
       ),
     )
-    expect(onClose).toHaveBeenCalled()
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalled())
   })
 
   it('surfaces the create URL when the browser cannot be opened', async () => {
@@ -264,9 +265,7 @@ describe('ConnectGithubDialog', () => {
     // access is the expected step (not an error), and the poll connects once it
     // lands — no retry button, no token language.
     storeCredential(appCredential())
-    sync.connectExistingRepo
-      .mockResolvedValueOnce('notFound') // initial lookup: app can't see it yet
-      .mockResolvedValueOnce('notFound') // poll: access still not granted
+    sync.connectExistingRepo.mockResolvedValue('notFound') // app can't see it until granted
     const onClose = await renderWizard()
 
     await page.getByRole('radio', { name: /use an existing repository/i }).click()
@@ -286,7 +285,12 @@ describe('ConnectGithubDialog', () => {
       'https://github.com/apps/reflect-github-app/installations/new',
     )
 
+    // Let the poll ride through at least one 404 before access lands.
+    await vi.waitFor(() =>
+      expect(sync.connectExistingRepo.mock.calls.length).toBeGreaterThanOrEqual(2),
+    )
     // Back from the browser with access granted — the poll connects, no click.
+    sync.connectExistingRepo.mockResolvedValue('connected')
     await vi.waitFor(() =>
       expect(sync.connectExistingRepo).toHaveBeenLastCalledWith(
         { owner: 'alex', name: 'notes' },
@@ -331,15 +335,18 @@ describe('ConnectGithubDialog', () => {
     // the handoff, but the app gains access to it only when they grant it.
     // The poll rides through the 404s and connects on the first success.
     storeCredential(appCredential())
-    sync.connectExistingRepo
-      .mockResolvedValueOnce('notFound') // initial lookup
-      .mockResolvedValueOnce('notFound') // poll: created, not granted yet
+    sync.connectExistingRepo.mockResolvedValue('notFound') // created, not granted yet
     sync.connectNewRepo.mockResolvedValueOnce('manualCreateNeeded')
     const onClose = await renderWizard()
 
     await page.getByRole('button', { name: 'Continue' }).click()
 
     await expect.element(page.getByText(/waiting for the repository/i)).toBeInTheDocument()
+    // Let the poll ride through at least one 404 before access lands.
+    await vi.waitFor(() =>
+      expect(sync.connectExistingRepo.mock.calls.length).toBeGreaterThanOrEqual(2),
+    )
+    sync.connectExistingRepo.mockResolvedValue('connected')
     await vi.waitFor(() => expect(onClose).toHaveBeenCalled())
     expect(sync.connectExistingRepo.mock.calls.length).toBeGreaterThanOrEqual(3)
     expect(sync.connectNewRepo).toHaveBeenCalledTimes(1)

--- a/apps/desktop/src/components/settings/connect-github-dialog.tsx
+++ b/apps/desktop/src/components/settings/connect-github-dialog.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react'
+import { useState, type ReactElement } from 'react'
 import { InlineAlert } from '@/components/inline-alert'
 import { ConnectGithubFinishStep } from '@/components/settings/connect-github-finish-step'
 import { GithubAuthStep } from '@/components/settings/github-auth-step'
@@ -40,14 +40,21 @@ export function ConnectGithubDialog({
   onClose,
   pollIntervalMs = 3000,
 }: ConnectGithubDialogProps): ReactElement {
-  const wizard = useConnectGithubWizard({ suggestedRepoName, onClose, pollIntervalMs })
+  const [open, setOpen] = useState(true)
+  const close = (): void => setOpen(false)
+  const wizard = useConnectGithubWizard({ suggestedRepoName, onClose: close, pollIntervalMs })
 
   useRestoreFocus()
 
   return (
     <Dialog
-      open
+      open={open}
       onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          close()
+        }
+      }}
+      onOpenChangeComplete={(isOpen) => {
         if (!isOpen) {
           onClose()
         }

--- a/apps/desktop/src/components/settings/describe-assets-field.tsx
+++ b/apps/desktop/src/components/settings/describe-assets-field.tsx
@@ -76,32 +76,30 @@ export function DescribeAssetsField(): ReactElement {
           <p className="mt-2 text-xs text-text-muted">Add an AI provider to enable this.</p>
         ) : null}
       </div>
-      {confirming ? (
-        <Dialog
-          open
-          onOpenChange={(isOpen) => {
-            if (!isOpen) setConfirming(false)
-          }}
-        >
-          <DialogContent showCloseButton={false} className="max-w-sm">
-            <DialogHeader>
-              <DialogTitle>Backfill assets?</DialogTitle>
-              <DialogDescription>
-                Images and PDFs in non-private notes will be sent to your AI provider so their text
-                can appear in search. Assets that already have OCR are skipped.
-              </DialogDescription>
-            </DialogHeader>
-            <DialogFooter>
-              <Button type="button" variant="ghost" size="sm" onClick={() => setConfirming(false)}>
-                Cancel
-              </Button>
-              <Button type="button" size="sm" onClick={() => void runBackfill()}>
-                Backfill assets
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      ) : null}
+      <Dialog
+        open={confirming}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) setConfirming(false)
+        }}
+      >
+        <DialogContent showCloseButton={false} className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Backfill assets?</DialogTitle>
+            <DialogDescription>
+              Images and PDFs in non-private notes will be sent to your AI provider so their text
+              can appear in search. Assets that already have OCR are skipped.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+              Cancel
+            </Button>
+            <Button type="button" size="sm" onClick={() => void runBackfill()}>
+              Backfill assets
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </SettingsField>
   )
 }

--- a/apps/desktop/src/components/settings/templates-section.tsx
+++ b/apps/desktop/src/components/settings/templates-section.tsx
@@ -109,6 +109,8 @@ interface TemplateDialogProps {
 
 /** Rename = move onto the new name's slug and rewrite the authored title. */
 function TemplateRenameDialog({ template, onClose }: TemplateDialogProps): ReactElement {
+  const [open, setOpen] = useState(true)
+  const close = (): void => setOpen(false)
   const { graph } = useGraph()
   const [name, setName] = useState(template.title)
   const [error, setError] = useState<string | null>(null)
@@ -122,7 +124,7 @@ function TemplateRenameDialog({ template, onClose }: TemplateDialogProps): React
     setError(null)
     try {
       await renameTemplate(template.path, trimmed, generation)
-      onClose()
+      close()
     } catch (cause) {
       setError(errorMessage(cause))
     }
@@ -130,8 +132,13 @@ function TemplateRenameDialog({ template, onClose }: TemplateDialogProps): React
 
   return (
     <Dialog
-      open
+      open={open}
       onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          close()
+        }
+      }}
+      onOpenChangeComplete={(isOpen) => {
         if (!isOpen) {
           onClose()
         }
@@ -163,7 +170,7 @@ function TemplateRenameDialog({ template, onClose }: TemplateDialogProps): React
             </span>
           ) : null}
           <DialogFooter>
-            <Button type="button" variant="outline" size="sm" onClick={onClose}>
+            <Button type="button" variant="outline" size="sm" onClick={close}>
               Cancel
             </Button>
             <Button type="submit" size="sm" disabled={name.trim() === ''}>
@@ -178,6 +185,8 @@ function TemplateRenameDialog({ template, onClose }: TemplateDialogProps): React
 
 /** Delete = move the file to the trash (recoverable), confirmed first. */
 function TemplateDeleteDialog({ template, onClose }: TemplateDialogProps): ReactElement {
+  const [open, setOpen] = useState(true)
+  const close = (): void => setOpen(false)
   const { graph } = useGraph()
   const [error, setError] = useState<string | null>(null)
 
@@ -191,7 +200,7 @@ function TemplateDeleteDialog({ template, onClose }: TemplateDialogProps): React
     try {
       await deleteOpenNote(template.path, generation)
       operation.done()
-      onClose()
+      close()
     } catch (cause) {
       operation.fail(errorMessage(cause))
       setError(errorMessage(cause))
@@ -200,8 +209,13 @@ function TemplateDeleteDialog({ template, onClose }: TemplateDialogProps): React
 
   return (
     <Dialog
-      open
+      open={open}
       onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          close()
+        }
+      }}
+      onOpenChangeComplete={(isOpen) => {
         if (!isOpen) {
           onClose()
         }


### PR DESCRIPTION
Dialogs their parents mount per session now hold their own `open` state and unmount only after Base UI's exit transition completes, replacing the always-open shells and redundant self-gates.