### PR TITLE
refactor: keep the command dialog mounted so it can animate out

### DIFF
--- a/apps/desktop/src/components/templates/template-picker.tsx
+++ b/apps/desktop/src/components/templates/template-picker.tsx
@@ -30,17 +30,13 @@ interface TemplatePickerProps {
   context: CommandContext
 }
 
-export function TemplatePicker({ context }: TemplatePickerProps): ReactElement | null {
+export function TemplatePicker({ context }: TemplatePickerProps): ReactElement {
   const { pickerOpen, closeTemplatePicker, openTemplateCreate } = useNoteTemplates()
   const { graph } = useGraph()
   const { data: templates } = useQuery({
     ...createTemplatesQueryOptions(graph?.root),
     enabled: graph !== null && pickerOpen,
   })
-
-  if (!pickerOpen) {
-    return null
-  }
 
   const insert = (path: string): void => {
     closeTemplatePicker()

--- a/apps/desktop/src/components/ui/command.tsx
+++ b/apps/desktop/src/components/ui/command.tsx
@@ -41,14 +41,14 @@ function CommandDialog({
 }) {
   return (
     <Dialog {...props}>
-      <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
-      </DialogHeader>
       <DialogContent
         className={cn('top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0', className)}
         showCloseButton={showCloseButton}
       >
+        <DialogHeader className="sr-only">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
         {children}
       </DialogContent>
     </Dialog>


### PR DESCRIPTION


Before:


https://github.com/user-attachments/assets/e542b98f-6fba-4cc7-a713-63727b93d22e


After:



https://github.com/user-attachments/assets/fa2fd340-2625-410a-936e-b1ef34772c89



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template picker behavior so its dialog opens and closes reliably while preserving existing template search behavior.
  * Corrected dialog structure to improve accessibility and ensure the hidden heading is properly associated with the dialog content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->