### PR TITLE
chore: add cargo `min-publish-age` config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[registry]
+# Requires cargo 1.100+ (stable on 2026-11-12); older cargo ignores this key.
+global-min-publish-age = "7 days"


### PR DESCRIPTION
***DO NOT MERGE THIS BEFORE 2026-11-12***

Adds a 7-day `min-publish-age` cooldown for cargo dependency resolution, so `cargo add`/`cargo update` skip crate versions published less than a week ago (the window in which supply-chain compromises are typically detected and yanked).

**Note: this feature is not available yet.** It requires cargo 1.100, which ships with stable Rust 1.100.0 on **2026-11-12** (stabilized in https://github.com/rust-lang/cargo/pull/17335, RFC https://github.com/rust-lang/rfcs/pull/3923). Until then the key is inert: today's stable cargo ignores it silently and current nightly prints a one-line warning. Merging early is safe because versions already in `Cargo.lock` are exempt, so builds and CI are unaffected; enforcement starts automatically once toolchains reach 1.100 (CI installs the latest stable at run time, local machines need `rustup update` after the release date).

For an urgent bump inside the cooldown window: `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow cargo update -p <crate>`.
