### PR TITLE
fix(mobile): load notes before subscription checks finish

### DIFF
--- a/apps/desktop/src/mobile/mobile-app.tsx
+++ b/apps/desktop/src/mobile/mobile-app.tsx
@@ -53,17 +53,12 @@ export function MobileApp(): ReactElement {
     return installBackgroundFlush()
   }, [])
 
-  // The subscription gate deliberately comes before everything else,
-  // onboarding included: the paywall is the first screen of a fresh install,
-  // and onboarding runs after a purchase or "Remind me later" lifts the
-  // gate. While the gate is still deciding (entitlement queries, settings
-  // hydration) hold the loading screen instead of flashing the paywall at a
-  // subscribed or snoozed user.
+  // Subscription verification runs beside startup, never in its critical
+  // path: while StoreKit or settings are unresolved the gate stays hidden and
+  // the local app boots normally. A settled negative answer can replace the
+  // current surface with the paywall later; a purchase or snooze lifts it.
   if (paywallGate === 'show') {
     return <PaywallScreen />
-  }
-  if (paywallGate === 'pending') {
-    return <LoadingScreen />
   }
 
   if (status === 'ready' && graph) {

--- a/apps/desktop/src/mobile/use-active-subscription.ts
+++ b/apps/desktop/src/mobile/use-active-subscription.ts
@@ -18,6 +18,7 @@ const ACTIVE_SUBSCRIPTION_MAX_AGE_MS = 2 * 24 * 60 * 60 * 1000
 const ENTITLEMENT_LOOKUP_TIMEOUT_MS = 5_000
 
 type SubscriptionPlan = Exclude<ActiveSubscription, null>
+const pendingEntitlementLookups = new Map<string, Promise<boolean>>()
 
 function readActiveSubscriptionSeed(): ActiveSubscription | undefined {
   const seed = getLocalStorageStore(ACTIVE_SUBSCRIPTION_STORAGE_KEY).getJson(
@@ -52,6 +53,23 @@ function withEntitlementTimeout(operation: Promise<boolean>): Promise<boolean> {
       },
     )
   })
+}
+
+function lookupEntitlement(productId: string): Promise<boolean> {
+  const pending = pendingEntitlementLookups.get(productId)
+  if (pending !== undefined) {
+    return pending
+  }
+
+  const lookup = iapIsOwned(productId)
+  pendingEntitlementLookups.set(productId, lookup)
+  function clearPendingLookup(): void {
+    if (pendingEntitlementLookups.get(productId) === lookup) {
+      pendingEntitlementLookups.delete(productId)
+    }
+  }
+  void lookup.then(clearPendingLookup, clearPendingLookup)
+  return lookup
 }
 
 function resolveActiveSubscription(
@@ -93,10 +111,10 @@ function resolveActiveSubscription(
 
 async function fetchActiveSubscription(): Promise<ActiveSubscription> {
   const subscription = await resolveActiveSubscription([
-    withEntitlementTimeout(iapIsOwned(IAP_PRODUCT_IDS.yearly)).then((owned) =>
+    withEntitlementTimeout(lookupEntitlement(IAP_PRODUCT_IDS.yearly)).then((owned) =>
       owned ? 'yearly' : null,
     ),
-    withEntitlementTimeout(iapIsOwned(IAP_PRODUCT_IDS.monthly)).then((owned) =>
+    withEntitlementTimeout(lookupEntitlement(IAP_PRODUCT_IDS.monthly)).then((owned) =>
       owned ? 'monthly' : null,
     ),
   ])

--- a/apps/desktop/src/mobile/use-active-subscription.ts
+++ b/apps/desktop/src/mobile/use-active-subscription.ts
@@ -15,6 +15,9 @@ const activeSubscriptionSeedSchema = z.object({
 })
 const ACTIVE_SUBSCRIPTION_STORAGE_KEY = 'reflect.iap.active-subscription'
 const ACTIVE_SUBSCRIPTION_MAX_AGE_MS = 2 * 24 * 60 * 60 * 1000
+const ENTITLEMENT_LOOKUP_TIMEOUT_MS = 5_000
+
+type SubscriptionPlan = Exclude<ActiveSubscription, null>
 
 function readActiveSubscriptionSeed(): ActiveSubscription | undefined {
   const seed = getLocalStorageStore(ACTIVE_SUBSCRIPTION_STORAGE_KEY).getJson(
@@ -32,12 +35,71 @@ function writeActiveSubscriptionSeed(value: ActiveSubscription): void {
   })
 }
 
+function withEntitlementTimeout(operation: Promise<boolean>): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('StoreKit entitlement lookup timed out'))
+    }, ENTITLEMENT_LOOKUP_TIMEOUT_MS)
+
+    void operation.then(
+      (value) => {
+        clearTimeout(timeout)
+        resolve(value)
+      },
+      (error: unknown) => {
+        clearTimeout(timeout)
+        reject(error)
+      },
+    )
+  })
+}
+
+function resolveActiveSubscription(
+  lookups: readonly Promise<SubscriptionPlan | null>[],
+): Promise<ActiveSubscription> {
+  return new Promise((resolve, reject) => {
+    let pending = lookups.length
+    const errors: unknown[] = []
+
+    function settleEmptyLookup(): void {
+      pending -= 1
+      if (pending !== 0) {
+        return
+      }
+      if (errors.length > 0) {
+        reject(errors[0])
+      } else {
+        resolve(null)
+      }
+    }
+
+    for (const lookup of lookups) {
+      void lookup.then(
+        (plan) => {
+          if (plan !== null) {
+            resolve(plan)
+            return
+          }
+          settleEmptyLookup()
+        },
+        (error: unknown) => {
+          errors.push(error)
+          settleEmptyLookup()
+        },
+      )
+    }
+  })
+}
+
 async function fetchActiveSubscription(): Promise<ActiveSubscription> {
-  const [yearly, monthly] = await Promise.all([
-    iapIsOwned(IAP_PRODUCT_IDS.yearly),
-    iapIsOwned(IAP_PRODUCT_IDS.monthly),
+  const subscription = await resolveActiveSubscription([
+    withEntitlementTimeout(iapIsOwned(IAP_PRODUCT_IDS.yearly)).then((owned) =>
+      owned ? 'yearly' : null,
+    ),
+    withEntitlementTimeout(iapIsOwned(IAP_PRODUCT_IDS.monthly)).then((owned) =>
+      owned ? 'monthly' : null,
+    ),
   ])
-  const subscription = yearly ? 'yearly' : monthly ? 'monthly' : null
   writeActiveSubscriptionSeed(subscription)
   return subscription
 }
@@ -64,6 +126,7 @@ export function useActiveSubscription(): {
     initialDataUpdatedAt: 0,
     staleTime: 60_000,
     refetchOnWindowFocus: 'always',
+    retry: false,
     enabled,
   })
 

--- a/apps/desktop/src/mobile/use-paywall-gate.test.tsx
+++ b/apps/desktop/src/mobile/use-paywall-gate.test.tsx
@@ -201,7 +201,7 @@ describe('usePaywallGate', () => {
     await vi.waitFor(() => expect(result.current).toBe('hide'))
   })
 
-  it('stops waiting when StoreKit entitlement lookups time out', async () => {
+  it('shows the app while StoreKit is pending, then the paywall after the timeout', async () => {
     vi.useFakeTimers()
     try {
       let lookupCount = 0
@@ -210,7 +210,7 @@ describe('usePaywallGate', () => {
         return never()
       }
       const hook = await renderHook(() => usePaywallGate(), { wrapper })
-      expect(hook.result.current).toBe('pending')
+      expect(hook.result.current).toBe('hide')
       expect(lookupCount).toBe(2)
 
       await hook.act(() => vi.advanceTimersByTimeAsync(5_000))
@@ -358,10 +358,10 @@ describe('usePaywallGate', () => {
       owned = never
       const { result } = await renderHook(() => usePaywallGate(), { wrapper })
       // A remembered `yearly` would have let this launch straight in.
-      expect(result.current).toBe('pending')
+      expect(result.current).toBe('hide')
     })
 
-    it('waits for live verification before trusting a remembered null', async () => {
+    it('keeps the paywall hidden while verifying a remembered null', async () => {
       await runLaunch('show')
 
       environment = never
@@ -370,7 +370,7 @@ describe('usePaywallGate', () => {
       await vi.waitFor(() =>
         expect(queryClient.getQueryState(queryKeys.iap.entitlements)?.fetchStatus).toBe('fetching'),
       )
-      expect(result.current).toBe('pending')
+      expect(result.current).toBe('hide')
     })
 
     it('does not persist null when one entitlement fails and the sibling is negative', async () => {

--- a/apps/desktop/src/mobile/use-paywall-gate.test.tsx
+++ b/apps/desktop/src/mobile/use-paywall-gate.test.tsx
@@ -33,8 +33,12 @@ let stored: Record<string, unknown>
 let emitPurchaseUpdated: ((payload: unknown) => void) | null
 
 /** A promise that never settles, for the calls a case must not wait on. */
+const rejectNeverPromises = new Set<(reason?: unknown) => void>()
+
 function never<T>(): Promise<T> {
-  return new Promise<T>(() => {})
+  return new Promise<T>((_resolve, reject) => {
+    rejectNeverPromises.add(reject)
+  })
 }
 
 /**
@@ -121,7 +125,12 @@ beforeEach(() => {
   installFakeBridge()
 })
 
-afterEach(() => {
+afterEach(async () => {
+  for (const reject of rejectNeverPromises) {
+    reject(new Error('test cleanup'))
+  }
+  rejectNeverPromises.clear()
+  await Promise.resolve()
   focusManager.setFocused(undefined)
   setBridge(null)
   queryClient.clear()
@@ -195,12 +204,21 @@ describe('usePaywallGate', () => {
   it('stops waiting when StoreKit entitlement lookups time out', async () => {
     vi.useFakeTimers()
     try {
-      owned = never
+      let lookupCount = 0
+      owned = () => {
+        lookupCount += 1
+        return never()
+      }
       const hook = await renderHook(() => usePaywallGate(), { wrapper })
       expect(hook.result.current).toBe('pending')
+      expect(lookupCount).toBe(2)
 
       await hook.act(() => vi.advanceTimersByTimeAsync(5_000))
       expect(hook.result.current).toBe('show')
+
+      void queryClient.refetchQueries({ queryKey: queryKeys.iap.entitlements })
+      await hook.act(() => vi.advanceTimersByTimeAsync(0))
+      expect(lookupCount).toBe(2)
     } finally {
       vi.useRealTimers()
     }

--- a/apps/desktop/src/mobile/use-paywall-gate.test.tsx
+++ b/apps/desktop/src/mobile/use-paywall-gate.test.tsx
@@ -185,6 +185,27 @@ describe('usePaywallGate', () => {
     await vi.waitFor(() => expect(result.current).toBe('hide'))
   })
 
+  it('lets either confirmed subscription through without waiting on its sibling', async () => {
+    owned = (productId) =>
+      productId.endsWith('.yearly') ? Promise.resolve(true) : never<boolean>()
+    const { result } = await renderHook(() => usePaywallGate(), { wrapper })
+    await vi.waitFor(() => expect(result.current).toBe('hide'))
+  })
+
+  it('stops waiting when StoreKit entitlement lookups time out', async () => {
+    vi.useFakeTimers()
+    try {
+      owned = never
+      const hook = await renderHook(() => usePaywallGate(), { wrapper })
+      expect(hook.result.current).toBe('pending')
+
+      await hook.act(() => vi.advanceTimersByTimeAsync(5_000))
+      expect(hook.result.current).toBe('show')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('refetches entitlements through the TanStack focus path', async () => {
     owned = () => Promise.resolve(false)
     const { result } = await renderHook(() => usePaywallGate(), { wrapper })
@@ -216,6 +237,7 @@ describe('usePaywallGate', () => {
 
   it('respects a live "Remind me later" snooze', async () => {
     stored = { paywallSnoozeUntil: Date.now() + 60_000 }
+    owned = never
     const { result } = await renderHook(() => usePaywallGate(), { wrapper })
     await vi.waitFor(() => expect(result.current).toBe('hide'))
   })

--- a/apps/desktop/src/mobile/use-paywall-gate.ts
+++ b/apps/desktop/src/mobile/use-paywall-gate.ts
@@ -10,15 +10,13 @@ import { useSettings } from '@/providers/settings-provider'
 
 const appStartTime = Date.now()
 
-/**
- * What the gate says to do with the paywall.
- *
- * - `show`: render it.
- * - `hide`: let the app through.
- */
+/** Paywall visibility: `show` replaces the app; `hide` leaves the app visible. */
 export type PaywallGate = 'show' | 'hide'
 
-/** Whether to render the paywall. */
+/**
+ * Whether to render the paywall. Unsettled settings or subscription checks
+ * return `hide` so verification never blocks app startup.
+ */
 export function usePaywallGate(): PaywallGate {
   const { platform } = useGraph()
   const subscription = useActiveSubscription()

--- a/apps/desktop/src/mobile/use-paywall-gate.ts
+++ b/apps/desktop/src/mobile/use-paywall-gate.ts
@@ -55,10 +55,13 @@ export function usePaywallGate(): PaywallGate {
   if (!isAppStoreInstall(environment.value) && !paywallRequested) {
     return 'hide'
   }
-  if (subscription.isLoading || !settingsSettled) {
+  if (!settingsSettled) {
     return 'pending'
   }
-  return settings.paywallSnoozeUntil > appStartTime ? 'hide' : 'show'
+  if (settings.paywallSnoozeUntil > appStartTime) {
+    return 'hide'
+  }
+  return subscription.isLoading ? 'pending' : 'show'
 }
 
 /**

--- a/apps/desktop/src/mobile/use-paywall-gate.ts
+++ b/apps/desktop/src/mobile/use-paywall-gate.ts
@@ -15,9 +15,8 @@ const appStartTime = Date.now()
  *
  * - `show`: render it.
  * - `hide`: let the app through.
- * - `pending`: no answer yet.
  */
-export type PaywallGate = 'pending' | 'show' | 'hide'
+export type PaywallGate = 'show' | 'hide'
 
 /** Whether to render the paywall. */
 export function usePaywallGate(): PaywallGate {
@@ -56,12 +55,12 @@ export function usePaywallGate(): PaywallGate {
     return 'hide'
   }
   if (!settingsSettled) {
-    return 'pending'
+    return 'hide'
   }
   if (settings.paywallSnoozeUntil > appStartTime) {
     return 'hide'
   }
-  return subscription.isLoading ? 'pending' : 'show'
+  return subscription.isLoading ? 'hide' : 'show'
 }
 
 /**


### PR DESCRIPTION
## Problem

The iOS subscription gate was part of the startup critical path. Before the local app could render, it waited for settings hydration and both StoreKit product-status requests. When the phone was connected to Wi-Fi without internet access, StoreKit could leave those requests pending indefinitely, so the app remained on the bare `Loading…` screen until Wi-Fi was disconnected.

Subscription verification should happen in the background. Local notes must open at normal speed regardless of StoreKit or network state, and the paywall can appear afterward once the gate has enough information.

## Before -> After

| Scenario | Before | After |
| --- | --- | --- |
| StoreKit or settings still resolving | Bare `Loading…` screen | The local app renders immediately while verification continues |
| StoreKit remains unreachable | Bare `Loading…` screen indefinitely | The app renders immediately; the paywall appears after the five-second verification deadline |
| One subscription is confirmed while the sibling lookup hangs | Startup waits indefinitely | The confirmed subscription keeps the app open immediately |
| Active local paywall snooze | Startup still waits for StoreKit | The app opens from local state without waiting |

## Changes

1. Remove the paywall-specific `pending` state and its `Loading…` branch from `MobileApp`. Unresolved settings or entitlement checks now keep the paywall hidden instead of blocking startup.
2. Bound each StoreKit entitlement lookup to five seconds and disable automatic retry for the startup query. Foreground and purchase events still trigger later verification attempts.
3. Resolve a confirmed yearly or monthly subscription immediately. Persist `null` only when both products definitively report unowned; a timeout or error preserves the previous confirmed seed.
4. Keep each native product lookup single-flight until it settles, so refetches reuse an outstanding StoreKit request instead of accumulating uncancellable IPC work.
5. Evaluate the locally persisted paywall snooze before live entitlement verification can affect the UI.

## Tests

- `apps/desktop/src/mobile/use-paywall-gate.test.tsx`
  - The app remains visible while StoreKit is unresolved, then the paywall appears after the deadline.
  - Refetching after a timeout does not start overlapping native entitlement lookups.
  - Either confirmed product keeps the app open without waiting for its sibling.
  - A live snooze keeps the paywall hidden while StoreKit remains pending.
  - Existing cache, purchase-event, focus-refetch, install-channel, and failure-preservation cases remain covered.

## Verification

- `pnpm test --run apps/desktop/src/mobile/use-paywall-gate.test.tsx` — 25 tests passed after the final behavior change.
- `pnpm check` — typecheck and all configured format/lint checks passed after the final behavior change.
- `git diff --check` — passed after the final behavior change.

## Risk / Rollout

This intentionally allows the local app to render briefly before a paywall decision is available. Once StoreKit confirms no subscription—or cannot answer before the deadline—the paywall replaces the app surface. A confirmed subscription or active snooze keeps the app uninterrupted. Native StoreKit calls cannot be cancelled through the current IPC contract, so outstanding calls are reused until they settle. No data migration or rollout step is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate subscription entitlement lookups while an earlier request is pending.
  - Improved paywall behavior while settings or subscription details are loading.
  - Mobile app startup no longer blocks on pending subscription verification.
  - Snoozed paywalls remain hidden while subscription data is unavailable.
  - Paywall visibility now updates correctly after timed-out entitlement checks and refetches.
  - Preserved five-second timeouts for monthly and yearly subscription verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
