### PR TITLE
fix: build the macOS DMG as a writable image before compressing it

### DIFF
--- a/apps/desktop/scripts/release-macos.mjs
+++ b/apps/desktop/scripts/release-macos.mjs
@@ -522,8 +522,8 @@ function writeUpdaterArtifacts({ flavor, target, updater }) {
   }
 }
 
-/** Build the hdiutil arguments used to create the release DMG. */
-export function createDmgArgs({ dmg, sourceFolder, volumeName }) {
+/** Build the hdiutil arguments used to create the writable DMG that holds the staged app. */
+export function createDmgArgs({ dmg, sizeMb, sourceFolder, volumeName }) {
   return [
     'create',
     '-volname',
@@ -532,9 +532,16 @@ export function createDmgArgs({ dmg, sourceFolder, volumeName }) {
     sourceFolder,
     '-ov',
     '-format',
-    'UDZO',
+    'UDRW',
+    '-size',
+    `${sizeMb}m`,
     dmg,
   ]
+}
+
+/** Build the hdiutil arguments used to compress the writable DMG into the release DMG. */
+export function convertDmgArgs({ dmg, source }) {
+  return ['convert', source, '-format', 'UDZO', '-imagekey', 'zlib-level=9', '-ov', '-o', dmg]
 }
 
 /** Build the codesign arguments used for the DMG container. */
@@ -859,14 +866,27 @@ function createDmg({ flavor, identity, keychain, target }) {
 
     mkdirSync(dirname(dmg), { recursive: true })
     if (existsSync(dmg)) rmSync(dmg)
+    // hdiutil sizes a `-srcfolder` image from the folder's block count plus a slim margin,
+    // and `-format UDZO` streams straight into the compressed image, so the large main binary
+    // intermittently runs out of space inside the image. Build a writable image with explicit
+    // headroom first, then compress it.
+    const usedKb = Number(
+      execFileSync('du', ['-sk', stagingDir], { encoding: 'utf8' }).split('\t')[0],
+    )
+    const sizeMb = Math.ceil(usedKb / 1024) * 2 + 32
+    const writableDmg = join(stagingRoot, 'writable.dmg')
     log(`creating ${basename(dmg)} from ${basename(app)}…`)
     execFileSync(
       'hdiutil',
-      createDmgArgs({ dmg, sourceFolder: stagingDir, volumeName: conf.productName }),
-      {
-        stdio: 'inherit',
-      },
+      createDmgArgs({
+        dmg: writableDmg,
+        sizeMb,
+        sourceFolder: stagingDir,
+        volumeName: conf.productName,
+      }),
+      { stdio: 'inherit' },
     )
+    execFileSync('hdiutil', convertDmgArgs({ dmg, source: writableDmg }), { stdio: 'inherit' })
     log(`signing ${basename(dmg)}…`)
     execFileSync('codesign', signDmgArgs({ dmg, identity, keychain }), { stdio: 'inherit' })
   } finally {

--- a/apps/desktop/scripts/release-macos.test.mjs
+++ b/apps/desktop/scripts/release-macos.test.mjs
@@ -8,6 +8,7 @@ import {
   assertMacosProfileIdentityEntitlements,
   canLaunchTarget,
   compareReleaseVersions,
+  convertDmgArgs,
   createBetaFeedReleaseArgs,
   createBetaFeedUploadSteps,
   createDmgArgs,
@@ -543,9 +544,14 @@ test('updater manifest includes both macOS release targets', () => {
   }
 })
 
-test('DMG creation uses direct hdiutil packaging', () => {
+test('DMG creation builds a writable image with headroom, then compresses it', () => {
   expect(
-    createDmgArgs({ dmg: 'Reflect.dmg', sourceFolder: '/tmp/stage', volumeName: 'Reflect' }),
+    createDmgArgs({
+      dmg: 'writable.dmg',
+      sizeMb: 178,
+      sourceFolder: '/tmp/stage',
+      volumeName: 'Reflect',
+    }),
   ).toEqual([
     'create',
     '-volname',
@@ -554,7 +560,20 @@ test('DMG creation uses direct hdiutil packaging', () => {
     '/tmp/stage',
     '-ov',
     '-format',
+    'UDRW',
+    '-size',
+    '178m',
+    'writable.dmg',
+  ])
+  expect(convertDmgArgs({ dmg: 'Reflect.dmg', source: 'writable.dmg' })).toEqual([
+    'convert',
+    'writable.dmg',
+    '-format',
     'UDZO',
+    '-imagekey',
+    'zlib-level=9',
+    '-ov',
+    '-o',
     'Reflect.dmg',
   ])
 })


### PR DESCRIPTION
Create the DMG as a `UDRW` image sized with explicit headroom and then convert it to `UDZO`, so `hdiutil` no longer intermittently fails with `No space left on device` while packaging the Apple Silicon release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * macOS release disk images are now created with calculated space and compressed using maximum compression, helping produce reliable, optimized downloads.
* **Tests**
  * Added coverage to verify writable image creation and final compressed DMG conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->