### PR TITLE
feat: add Gemini 3.8 Flash support

### DIFF
--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -24,14 +24,6 @@ describe('AI_PROVIDERS', () => {
     ])
   })
 
-  it('offers the current Gemini lineup in capability order', () => {
-    expect(aiProvider('google').models.slice(0, 3)).toEqual([
-      { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
-      { id: 'gemini-3.8-flash', label: 'Gemini 3.8 Flash', contextWindow: 1_000_000 },
-      { id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash', contextWindow: 1_000_000 },
-    ])
-  })
-
   it('includes OpenRouter in the settings catalog', () => {
     expect(aiProvider('openrouter')).toMatchObject({
       id: 'openrouter',

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -24,6 +24,14 @@ describe('AI_PROVIDERS', () => {
     ])
   })
 
+  it('offers the current Gemini lineup in capability order', () => {
+    expect(aiProvider('google').models.slice(0, 3)).toEqual([
+      { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
+      { id: 'gemini-3.8-flash', label: 'Gemini 3.8 Flash', contextWindow: 1_000_000 },
+      { id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash', contextWindow: 1_000_000 },
+    ])
+  })
+
   it('includes OpenRouter in the settings catalog', () => {
     expect(aiProvider('openrouter')).toMatchObject({
       id: 'openrouter',

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -75,6 +75,7 @@ const ANTHROPIC_MODELS: NonEmptyArray<AiModelOption<AnthropicModelId>> = [
 // https://github.com/vercel/ai/blob/ai@7.0.66/packages/google/src/google-language-model-options.ts#L8
 const GOOGLE_MODELS: NonEmptyArray<AiModelOption<GoogleModelId>> = [
   { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
+  { id: 'gemini-3.8-flash', label: 'Gemini 3.8 Flash', contextWindow: 1_000_000 },
   { id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash', contextWindow: 1_000_000 },
   { id: 'gemini-3.6-flash', label: 'Gemini 3.6 Flash', contextWindow: 1_000_000 },
   { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', contextWindow: 1_000_000 },

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -47,9 +47,7 @@ export interface AiProviderInfo {
 type KnownId<T> = T extends string ? (string extends T ? never : T) : never
 
 type AnthropicModelId = KnownId<Parameters<AnthropicProvider>[0]>
-// @ai-sdk/google (through 4.0.62) has not added gemini-3.8-flash yet;
-// keep it in the catalog anyway so the picker can send the id verbatim.
-type GoogleModelId = KnownId<Parameters<GoogleProvider>[0]> | 'gemini-3.8-flash'
+type GoogleModelId = KnownId<Parameters<GoogleProvider>[0]>
 type OpenAIModelId = KnownId<Parameters<OpenAIProvider>[0]>
 
 // https://github.com/vercel/ai/blob/ai@7.0.66/packages/openai/src/responses/openai-responses-language-model-options.ts#L88
@@ -75,6 +73,7 @@ const ANTHROPIC_MODELS: NonEmptyArray<AiModelOption<AnthropicModelId>> = [
 ]
 
 // https://github.com/vercel/ai/blob/ai@7.0.66/packages/google/src/google-language-model-options.ts#L8
+// @ts-expect-error gemini-3.8-flash is not in @ai-sdk/google yet
 const GOOGLE_MODELS: NonEmptyArray<AiModelOption<GoogleModelId>> = [
   { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
   { id: 'gemini-3.8-flash', label: 'Gemini 3.8 Flash', contextWindow: 1_000_000 },

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -47,7 +47,9 @@ export interface AiProviderInfo {
 type KnownId<T> = T extends string ? (string extends T ? never : T) : never
 
 type AnthropicModelId = KnownId<Parameters<AnthropicProvider>[0]>
-type GoogleModelId = KnownId<Parameters<GoogleProvider>[0]>
+// @ai-sdk/google (through 4.0.62) has not added gemini-3.8-flash yet;
+// keep it in the catalog anyway so the picker can send the id verbatim.
+type GoogleModelId = KnownId<Parameters<GoogleProvider>[0]> | 'gemini-3.8-flash'
 type OpenAIModelId = KnownId<Parameters<OpenAIProvider>[0]>
 
 // https://github.com/vercel/ai/blob/ai@7.0.66/packages/openai/src/responses/openai-responses-language-model-options.ts#L88


### PR DESCRIPTION
Add Gemini 3.8 Flash to the Google BYOK catalog, after Gemini 3.1 Pro and before 3.7 Flash (most capable first).

`gemini-3.8-flash` is not in `GoogleModelId` on the published `@ai-sdk/google` yet, so the catalog uses `@ts-expect-error` until the SDK types catch up.

Upstream: https://github.com/vercel/ai/pull/20223


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Gemini 3.8 Flash model to the available Google AI model list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->