### PR TITLE
fix: stop iCloud graph watches from pinning fileproviderd

### DIFF
--- a/apps/desktop/src-tauri/src/icloud/watch.rs
+++ b/apps/desktop/src-tauri/src/icloud/watch.rs
@@ -159,6 +159,13 @@ mod platform {
     /// of batches.
     const UPDATE_BATCHING_INTERVAL_S: f64 = 2.0;
 
+    /// Graph-local runtime trees that are deliberately excluded from every
+    /// file-sync provider. They have no File Provider identity, so asking a
+    /// ubiquitous metadata query to watch them makes CloudDocs repeatedly
+    /// retry an item it can never resolve. Keep the provider-side query off
+    /// these paths; filtering results later is too late to avoid that work.
+    const SYNC_EXCLUDED_DIRS: [&str; 2] = [".reflect", ".git"];
+
     /// The live query plus everything that must stay alive (and on the main
     /// thread) with it.
     struct Watch {
@@ -315,6 +322,49 @@ mod platform {
         variants
     }
 
+    /// Build the provider-side path predicate for one graph. Each root is
+    /// slash-terminated by [`root_variants`], so the positive clauses cannot
+    /// claim a sibling graph. The exclusions cover both the directory item
+    /// itself and its descendants without blacking out similarly named user
+    /// paths such as `.reflect-old`.
+    fn query_predicate(roots: &[String]) -> Retained<NSPredicate> {
+        let path_key: Retained<NSString> = unsafe { NSMetadataItemPathKey.copy() };
+        let included = (0..roots.len())
+            .map(|_| "(%K BEGINSWITH %@)")
+            .collect::<Vec<_>>()
+            .join(" OR ");
+        let exclusions = roots
+            .iter()
+            .flat_map(|_| SYNC_EXCLUDED_DIRS)
+            .map(|_| "(%K != %@) AND (NOT (%K BEGINSWITH %@))")
+            .collect::<Vec<_>>()
+            .join(" AND ");
+        let format = NSString::from_str(&format!("({included}) AND {exclusions}"));
+
+        let mut arg_list: Vec<Retained<NSString>> = Vec::new();
+        for root in roots {
+            arg_list.push(path_key.copy());
+            arg_list.push(NSString::from_str(root));
+        }
+        for root in roots {
+            for directory in SYNC_EXCLUDED_DIRS {
+                let excluded = format!("{root}{directory}");
+                arg_list.push(path_key.copy());
+                arg_list.push(NSString::from_str(&excluded));
+                arg_list.push(path_key.copy());
+                arg_list.push(NSString::from_str(&format!("{excluded}/")));
+            }
+        }
+        let args = NSArray::from_retained_slice(&arg_list);
+        unsafe {
+            msg_send![
+                objc2::class!(NSPredicate),
+                predicateWithFormat: &*format,
+                argumentArray: &*args
+            ]
+        }
+    }
+
     /// Build, wire, and start the query. Main thread only. Tears down any
     /// live watch first (installs and stops all run here, serially), and
     /// aborts when a later `start`/`stop` has superseded this one's epoch —
@@ -353,26 +403,7 @@ mod platform {
         }
 
         let roots = root_variants(&root);
-        let path_key: Retained<NSString> = unsafe { NSMetadataItemPathKey.copy() };
-        let format = NSString::from_str(
-            &(0..roots.len())
-                .map(|_| "(%K BEGINSWITH %@)")
-                .collect::<Vec<_>>()
-                .join(" OR "),
-        );
-        let mut arg_list: Vec<Retained<NSString>> = Vec::new();
-        for variant in &roots {
-            arg_list.push(path_key.copy());
-            arg_list.push(NSString::from_str(variant));
-        }
-        let args = NSArray::from_retained_slice(&arg_list);
-        let predicate: Retained<NSPredicate> = unsafe {
-            msg_send![
-                objc2::class!(NSPredicate),
-                predicateWithFormat: &*format,
-                argumentArray: &*args
-            ]
-        };
+        let predicate = query_predicate(&roots);
         query.setPredicate(Some(&predicate));
 
         let queue = NSOperationQueue::new();
@@ -895,8 +926,11 @@ mod platform {
     mod tests {
         use super::{
             apply_conflict_delta, apply_update_delta, fold_conflicts_into_view, plan_nudges,
-            root_variants, tracked_note_relpath, ConflictView, ItemState, TrackedState,
+            query_predicate, root_variants, tracked_note_relpath, ConflictView, ItemState,
+            TrackedState,
         };
+        use objc2::runtime::AnyObject;
+        use objc2_foundation::{NSDictionary, NSMetadataItemPathKey, NSString};
         use std::collections::{HashMap, HashSet};
 
         fn state(entries: &[(&str, TrackedState)]) -> HashMap<String, TrackedState> {
@@ -931,6 +965,16 @@ mod platform {
                 .collect();
             shapes.sort();
             shapes
+        }
+
+        fn predicate_matches_path(predicate: &objc2_foundation::NSPredicate, path: &str) -> bool {
+            let value = NSString::from_str(path);
+            let item = NSDictionary::<NSString, NSString>::from_slices(
+                &[unsafe { NSMetadataItemPathKey }],
+                &[&value],
+            );
+            let item: &AnyObject = &item;
+            unsafe { predicate.evaluateWithObject(Some(item)) }
         }
 
         fn conflicted_item(rel: &str) -> ItemState {
@@ -1186,6 +1230,40 @@ mod platform {
             assert!(variants.contains(&canonical));
             let unique: std::collections::BTreeSet<&String> = variants.iter().collect();
             assert_eq!(unique.len(), variants.len(), "variants must not repeat");
+        }
+
+        #[test]
+        fn metadata_query_excludes_sync_excluded_runtime_trees() {
+            let roots = vec![
+                "/var/mobile/Containers/Notes/".to_string(),
+                "/private/var/mobile/Containers/Notes/".to_string(),
+            ];
+            let predicate = query_predicate(&roots);
+
+            for root in &roots {
+                assert!(predicate_matches_path(
+                    &predicate,
+                    &format!("{root}notes/idea.md")
+                ));
+                for directory in [".reflect", ".git"] {
+                    assert!(!predicate_matches_path(
+                        &predicate,
+                        &format!("{root}{directory}")
+                    ));
+                    assert!(!predicate_matches_path(
+                        &predicate,
+                        &format!("{root}{directory}/nested/item")
+                    ));
+                }
+                assert!(predicate_matches_path(
+                    &predicate,
+                    &format!("{root}.reflect-old/note.md")
+                ));
+            }
+            assert!(!predicate_matches_path(
+                &predicate,
+                "/var/mobile/Containers/Notes-old/notes/idea.md"
+            ));
         }
 
         #[test]

--- a/docs/icloud-sync.md
+++ b/docs/icloud-sync.md
@@ -77,31 +77,19 @@ in CI. What *needs a real container* (and the two-device manual matrix in
 the plan doc) is the `NSMetadataQuery` watch, `NSFileVersion` conflict
 delivery, and download/eviction behavior.
 
-## Known log noise: `BRItemCollectionGatherer - Repeatedly can't watch item`
+## Metadata-query boundary
 
-With a graph open, the app process logs CloudDocs errors — a burst while the
-`NSMetadataQuery` watch gathers, then one round per graph write:
+The live `NSMetadataQuery` predicates out `.reflect` and `.git` before File
+Provider gathers the graph. Both directories are deliberately local-only (see
+`mark_dir_local_only` in `fs/io.rs`) and therefore have no identity in the
+provider database. Filtering them only after delivery is too late: CloudDocs
+tries to install per-item watches first, retries the unresolvable items after
+local runtime writes, and can keep `fileproviderd` busy indefinitely.
 
-```text
-[ERROR] … NSError: NSFileProviderInternalErrorDomain 15 … while gathering
-[CRIT] UNREACHABLE: … BRItemCollectionGatherer - Repeatedly can't watch item …
-```
-
-This is Apple's query machinery tripping over the directories Reflect
-deliberately excludes from sync (`.reflect`, and `.git` on desktop — see
-`mark_dir_local_only` in `fs/io.rs`): they exist on disk inside the watched
-root, but carry no identity in the provider database, so the gatherer's
-per-item watch fails, retries, and gives up with the `UNREACHABLE` fault.
-Any FS event under an excluded tree re-attempts once — on desktop that means
-every note save, because the local Git history engine commits into `.git`.
-
-Verified benign (2026-08-02): touching a file inside `.git` reproduces the
-error within milliseconds, the failing watches are exactly the items sync
-must ignore, and the query demonstrably keeps delivering update rounds (and
-the conflict view keeps functioning) after the faults. Don't chase this
-signature; a real watcher failure looks different — `startQuery` returning
-false (logged as `iCloud metadata query failed to start`, surfaced via the
-`icloud:watch-failed` event) or update rounds ceasing entirely.
+The predicate excludes both directory entries and their descendants for every
+canonical spelling of the graph root. The ordinary `notify` watcher still
+observes the graph on macOS, while the metadata query continues to deliver
+iCloud note state and unresolved-conflict updates on both Apple platforms.
 
 ## Deliberately not here (yet)
 


### PR DESCRIPTION
## Problem

Opening an iCloud-backed graph installs an `NSMetadataQuery` whose path predicate previously covered every descendant of the graph root. Reflect separately marks `.reflect` and `.git` local-only with `com.apple.fileprovider.ignore#P`, so those directories exist on disk but have no File Provider identity.

Filtering delivered metadata items in Rust did not protect File Provider itself: CloudDocs had already attempted to gather and watch the excluded items, and local index or Git writes could make it retry. On affected Macs this leaves `fileproviderd` and Reflect consuming sustained CPU while the graph is idle.

Closes #1180.

## Before -> After

| | Before | After |
|---|---|---|
| Metadata query | Includes every path below the graph root | Excludes `.reflect`, `.git`, and all descendants before File Provider gathers |
| Local-only runtime writes | Can retrigger CloudDocs work for unresolvable items | Stay outside the metadata query while normal note/conflict updates remain covered |
| Path boundaries | Graph root only | Graph root plus exact excluded-directory boundaries for every canonical root spelling |

## Changes

1. Extract `query_predicate` as the single construction point for the live query's provider-side path filter.
2. Exclude both the local-only directory entries and their descendants for the spelled and canonical graph roots, without excluding similarly named paths such as `.reflect-old`.
3. Add a macOS Foundation-backed regression test that evaluates the actual `NSPredicate` across included notes, both excluded trees, canonical root variants, and sibling-boundary cases.
4. Update the iCloud implementation notes to document the corrected metadata-query boundary.

## Tests

- The new predicate test verifies ordinary notes still match under either root spelling.
- It verifies `.reflect`, `.git`, and nested contents do not match.
- It verifies `.reflect-old` remains in scope and a sibling graph with a shared string prefix remains out of scope.
- The complete `icloud::watch` test selection passes (15 tests).

## Verification

- `pnpm check`
- `cargo fmt --check`
- `cargo test -p reflect-open --lib icloud::watch -- --nocapture`
- `pnpm release:macos --flavor=beta --no-notarize` (optimized signed beta build; app signature, embedded-profile identity entitlements, and sidecars verified)
- Launched the signed beta bundle against the existing `reflect-notes` iCloud graph on macOS, confirmed the real `.reflect` and `.git` directories carry `com.apple.fileprovider.ignore#P`, exercised 150 rapid writes under `.reflect`, and observed both the app and `fileproviderd` return to 0% CPU rather than remain pinned.

The reporter's sustained 30-minute runaway did not reproduce reliably with the older installed beta on this Mac, so the live check validates idle recovery and the exact query boundary rather than claiming a full hardware-specific reproduction.

## Risk / Rollout

No migration or data rewrite. The query continues to cover every graph path it covered before except the two trees Reflect already treats as unsynced, hidden runtime state; downstream note classification already rejected both trees. The ordinary macOS `notify` watcher remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * iCloud metadata queries now exclude `.reflect` and `.git` directories and their contents, while preserving similarly named paths such as `.reflect-old`.
  * Standard filesystem watching remains active, and iCloud note-state and conflict updates continue to be delivered on Apple platforms.

* **Documentation**
  * Updated iCloud synchronization documentation to describe the metadata-query boundaries and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->