### PR TITLE
fix: stop the iCloud metadata query from pinning fileproviderd on macOS

### DIFF
--- a/apps/desktop/src-tauri/src/icloud/sweep.rs
+++ b/apps/desktop/src-tauri/src/icloud/sweep.rs
@@ -79,9 +79,28 @@ pub enum SweepScope {
     /// ([`crate::icloud::watch::conflicted_paths`]) — each check is a
     /// synchronous file-coordination round-trip to `fileproviderd`, and a
     /// bulk-sync arrival sweep over a large graph paid one per note for a
-    /// listing the query already has. Degrades to `Full` whenever the watch
-    /// cannot answer completely (not installed, or pre-gather).
+    /// listing the query already has. Mobile's signal and arrival sweeps.
+    /// Degrades to `Full` whenever the watch cannot answer completely (not
+    /// installed, or pre-gather).
     Candidates,
+    /// Restrict the version checks to this sweep's `ingested_paths` — the
+    /// notes external writes just landed on. Desktop's arrival sweeps: no
+    /// metadata watch runs there (see [`crate::icloud::watch`]), and a
+    /// conflict whose remote side became the working file is by definition
+    /// among the arrivals. A conflict version that never touches the working
+    /// file is the resume sweep's (`Full`) job, exactly as for graphs kept
+    /// outside the app's container.
+    Ingested,
+}
+
+/// The version-check candidate set for `scope` ([`run_sweep`]'s
+/// `conflict_candidates`): `None` checks every note.
+fn conflict_candidates(scope: SweepScope, ingested_paths: &[String]) -> Option<HashSet<String>> {
+    match scope {
+        SweepScope::Full => None,
+        SweepScope::Candidates => crate::icloud::watch::conflicted_paths(),
+        SweepScope::Ingested => Some(ingested_paths.iter().cloned().collect()),
+    }
 }
 
 /// Command: run a conflict sweep over the generation-pinned graph.
@@ -105,10 +124,7 @@ pub async fn icloud_conflicts_scan(
     let root = crate::fs::root_for_generation(&state, generation)?;
     let sweep_root = root.clone();
     let outcome = crate::blocking::run_blocking(move || {
-        let candidates = match scope {
-            SweepScope::Full => None,
-            SweepScope::Candidates => crate::icloud::watch::conflicted_paths(),
-        };
+        let candidates = conflict_candidates(scope, &ingested_paths);
         run_sweep(
             &sweep_root,
             &skip_paths,
@@ -964,6 +980,26 @@ mod tests {
         // …and the next full sweep prunes it.
         run_sweep(root.path(), &[], &[], false, None).unwrap();
         assert!(ShadowStore::new(root.path()).base("notes/a.md").is_none());
+    }
+
+    #[test]
+    fn ingested_scope_checks_exactly_the_arrivals_and_full_checks_everything() {
+        let arrivals = vec!["notes/a.md".to_string(), "daily/2026-07-04.md".to_string()];
+        assert_eq!(
+            super::conflict_candidates(SweepScope::Ingested, &arrivals),
+            Some(arrivals.iter().cloned().collect::<HashSet<_>>())
+        );
+        assert_eq!(
+            super::conflict_candidates(SweepScope::Full, &arrivals),
+            None
+        );
+        // No metadata watch is installed in a test process (nor ever on
+        // desktop): the candidate scope must degrade to a full check, never
+        // to an empty one.
+        assert_eq!(
+            super::conflict_candidates(SweepScope::Candidates, &arrivals),
+            None
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/icloud/watch.rs
+++ b/apps/desktop/src-tauri/src/icloud/watch.rs
@@ -1,15 +1,29 @@
 //! The iCloud change watcher: an `NSMetadataQuery` over the graph (Plan 21
-//! Phase 2).
+//! Phase 2). **Mobile only.**
 //!
-//! Two jobs, per platform:
+//! On iOS this query is the *sole* external-change source — there is no file
+//! watcher on mobile — so its snapshot diffs become the standard
+//! `index:changed` batches the indexer and open sessions already consume,
+//! and its `HasUnresolvedConflicts` flags are the conflict signal that
+//! triggers a prompt, candidate-scoped sweep.
 //!
-//! - **iOS**: the *sole* external-change source. There is no file watcher on
-//!   mobile — this query's snapshot diffs become the standard `index:changed`
-//!   batches the indexer and open sessions already consume.
-//! - **Both Apple platforms**: the conflict signal. A conflict version
-//!   appearing does not necessarily touch the working file, so the desktop
-//!   `notify` watcher alone would sit silent; the query's
-//!   `HasUnresolvedConflicts` flag is what triggers a sweep promptly.
+//! Desktop deliberately never installs it (issue #1180). The `notify` watcher
+//! already reports every iCloud write there as a plain FS event, and the
+//! query's cost is not confined to the graph: CloudDocs gathers the app's
+//! *entire* ubiquity container whatever the predicate says, building one
+//! observed collection per directory — including the sync-excluded
+//! `.reflect/` and `.git/` trees (`fs::io::mark_dir_local_only`), which carry
+//! no provider identity. Each of those fails with
+//! `NSFileProviderInternalErrorDomain 15`, is retried, and is finally given
+//! up on (`BRItemCollectionGatherer - Repeatedly can't watch item`), and every
+//! retry reloads the whole item tree through `fileproviderd`. macOS 26 bounds
+//! that at a handful of rounds per excluded directory; on macOS 15 the reload
+//! cycle was observed never to settle, pinning `fileproviderd` near 200% CPU
+//! for as long as the app stayed open. Excluding the trees from the
+//! predicate, restricting `searchItems`, or naming them `.nosync` changes
+//! nothing — the gather is scoped by the container, not by the query (see
+//! `docs/icloud-sync.md`). Desktop conflict handling rides the sweeps
+//! instead: arrival-scoped after external writes, full on resume.
 //!
 //! Threading follows the platform contract: the query starts/stops on the
 //! main thread (kept there via `MainThreadBound`), results are delivered on a
@@ -31,17 +45,11 @@
 
 use crate::error::AppResult;
 
-/// Command: watch the graph at `root` for iCloud changes. `emit_file_changes`
-/// turns snapshot diffs into `index:changed` events — pass `true` on mobile
-/// (no watcher there), `false` on desktop (the `notify` watcher already
-/// reports file events; double delivery is harmless but wasteful). Conflict
-/// paths always emit as `icloud:conflicts`.
+/// Command: watch the graph at `root` for iCloud changes — snapshot diffs
+/// emit as `index:changed` batches, conflict paths as `icloud:conflicts`.
+/// Mobile only: the module docs explain why desktop never calls this.
 #[tauri::command]
-pub async fn icloud_watch_start(
-    root: String,
-    emit_file_changes: bool,
-    app: tauri::AppHandle,
-) -> AppResult<()> {
+pub async fn icloud_watch_start(root: String, app: tauri::AppHandle) -> AppResult<()> {
     // Whether the query's scope actually covers this root — it lists the
     // app's own ubiquity container only, so for any other iCloud path (a
     // desktop graph in the user's general iCloud Drive) the gather produces
@@ -57,7 +65,7 @@ pub async fn icloud_watch_start(
             .await
             .unwrap_or(false)
     };
-    platform::start(app, root, emit_file_changes, authoritative)
+    platform::start(app, root, authoritative)
 }
 
 /// See [`icloud_watch_start`]: `root` lives inside the app's own ubiquity
@@ -250,19 +258,12 @@ mod platform {
     /// (dropping observer tokens does not deregister them).
     static EPOCH: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-    pub fn start(
-        app: tauri::AppHandle,
-        root: String,
-        emit_file_changes: bool,
-        authoritative: bool,
-    ) -> AppResult<()> {
+    pub fn start(app: tauri::AppHandle, root: String, authoritative: bool) -> AppResult<()> {
         use std::sync::atomic::Ordering;
         let epoch = EPOCH.fetch_add(1, Ordering::SeqCst) + 1;
         let handle = app.clone();
-        app.run_on_main_thread(move || {
-            install(handle, root, emit_file_changes, authoritative, epoch)
-        })
-        .map_err(|err| AppError::io(format!("failed to reach the main thread: {err}")))
+        app.run_on_main_thread(move || install(handle, root, authoritative, epoch))
+            .map_err(|err| AppError::io(format!("failed to reach the main thread: {err}")))
     }
 
     pub fn stop(app: tauri::AppHandle) -> AppResult<()> {
@@ -320,13 +321,7 @@ mod platform {
     /// aborts when a later `start`/`stop` has superseded this one's epoch —
     /// so rapid graph switches can never leave two queries running or
     /// install a watch after its graph closed.
-    fn install(
-        app: tauri::AppHandle,
-        root: String,
-        emit_file_changes: bool,
-        authoritative: bool,
-        epoch: u64,
-    ) {
+    fn install(app: tauri::AppHandle, root: String, authoritative: bool, epoch: u64) {
         use std::sync::atomic::Ordering;
         let mtm = MainThreadMarker::new().expect("run_on_main_thread is the main thread");
         teardown_active(mtm);
@@ -389,7 +384,7 @@ mod platform {
         let handler_roots = roots.clone();
         let emit_app = app.clone();
         let block = RcBlock::new(move |notification: NonNull<NSNotification>| {
-            handle_notification(&app, &handler_roots, emit_file_changes, epoch, notification);
+            handle_notification(&app, &handler_roots, epoch, notification);
         });
         let center = NSNotificationCenter::defaultCenter();
         let query_object: &AnyObject = &query;
@@ -630,7 +625,6 @@ mod platform {
     fn handle_notification(
         app: &tauri::AppHandle,
         roots: &[String],
-        emit_file_changes: bool,
         epoch: u64,
         notification: NonNull<NSNotification>,
     ) {
@@ -668,11 +662,11 @@ mod platform {
                 let root = std::path::Path::new(root.trim_end_matches('/'));
                 crate::fs::invalidate_file_catalog(&state, root);
             }
-            if emit_file_changes && is_update {
+            if is_update {
                 let _ = app.emit("index:changed", round.changes);
             }
         }
-        if emit_file_changes && !is_update {
+        if !is_update {
             // The gather round diffs against an empty snapshot, so its
             // "changes" are every downloaded note in the graph — not news,
             // just the watch coming up. Emitting them sent an O(graph)
@@ -1225,12 +1219,7 @@ mod platform {
 
     /// No iCloud metadata queries off Apple platforms — honest no-ops so the
     /// command surface never branches.
-    pub fn start(
-        _app: tauri::AppHandle,
-        _root: String,
-        _emit_file_changes: bool,
-        _authoritative: bool,
-    ) -> AppResult<()> {
+    pub fn start(_app: tauri::AppHandle, _root: String, _authoritative: bool) -> AppResult<()> {
         Ok(())
     }
 

--- a/apps/desktop/src-tauri/src/wake.rs
+++ b/apps/desktop/src-tauri/src/wake.rs
@@ -1,9 +1,9 @@
 //! Wake-from-sleep catch-up (macOS).
 //!
 //! On desktop the `notify` FSEvents watcher is the *only* live source of
-//! external content changes: the iCloud metadata watch deliberately does not
-//! emit file events here (`emit_file_changes: false`), and the resume/focus
-//! triggers only run conflict sweeps. A file that iCloud downloads while the
+//! external content changes: the iCloud metadata watch is mobile-only
+//! (`icloud/watch.rs`), and the resume/focus triggers only run conflict
+//! sweeps. A file that iCloud downloads while the
 //! machine sleeps (Power Nap) or during the wake transition can miss FSEvents
 //! delivery entirely — the process is suspended when the write lands — and
 //! with no backstop the note stays stale until the next full reconcile, which

--- a/apps/desktop/src/lib/icloud-controller.test.tsx
+++ b/apps/desktop/src/lib/icloud-controller.test.tsx
@@ -101,11 +101,12 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-function controller(overrides: { emit?: boolean } = {}) {
+/** A desktop controller by default; `watch: true` is the mobile shape. */
+function controller(overrides: { watch?: boolean } = {}) {
   active = createIcloudController({
     graph: GRAPH,
     indexGeneration: 3,
-    emitFileChangesFromWatch: overrides.emit ?? false,
+    metadataWatch: overrides.watch ?? false,
   })
   return active
 }
@@ -151,19 +152,38 @@ describe('isICloudRoot', () => {
 })
 
 describe('createIcloudController', () => {
-  it('starts the watch and runs one baseline sweep', async () => {
-    const icloud = controller({ emit: true })
+  it('mobile starts the watch and runs one baseline sweep', async () => {
+    const icloud = controller({ watch: true })
     await icloud.start()
     await settleScan()
 
     const watchStart = invoked.find(([command]) => command === 'icloud_watch_start')
-    expect(watchStart?.[1]).toMatchObject({ root: GRAPH.root, emitFileChanges: true })
+    expect(watchStart?.[1]).toEqual({ root: GRAPH.root })
     expect(scanCalls).toHaveLength(1)
     expect(scanCalls[0]).toMatchObject({ recordBaseline: true, ingestedPaths: [] })
 
     icloud.dispose()
     active = null
     expect(invoked.some(([command]) => command === 'icloud_watch_stop')).toBe(true)
+  })
+
+  it('desktop never installs the metadata watch (#1180)', async () => {
+    // The container-wide NSMetadataQuery gather is what pinned fileproviderd
+    // on iCloud-backed desktop graphs; the notify watcher already covers
+    // freshness there, so the watch must never start — not on start, not on
+    // resume — and there is nothing to stop on dispose.
+    const icloud = controller()
+    await icloud.start()
+    await settleScan()
+    window.dispatchEvent(new Event('focus'))
+    await settleScan()
+    icloud.dispose()
+    active = null
+
+    const commands = invoked.map(([command]) => command)
+    expect(commands).not.toContain('icloud_watch_start')
+    expect(commands).not.toContain('icloud_watch_stop')
+    expect(scanCalls).toHaveLength(2) // baseline + resume: the sweeps still run
   })
 
   it('external upserts become base ingests; this device’s own writes never do', async () => {
@@ -217,7 +237,7 @@ describe('createIcloudController', () => {
   it('defers mobile baseline, conflict, and ingest scans until foreground', async () => {
     const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
     try {
-      const icloud = controller({ emit: true })
+      const icloud = controller({ watch: true })
       await icloud.start()
       await settleScan()
       expect(scanCalls).toHaveLength(0)
@@ -245,7 +265,7 @@ describe('createIcloudController', () => {
     // A long iOS suspension can kill NSMetadataQuery update delivery, and on
     // mobile the query is the sole external-change source — the resume must
     // reinstall it or remote edits stay invisible until relaunch.
-    const icloud = controller({ emit: true })
+    const icloud = controller({ watch: true })
     await icloud.start()
     await settleScan()
     invoked.length = 0
@@ -258,27 +278,13 @@ describe('createIcloudController', () => {
     const startAt = commands.indexOf('icloud_watch_start')
     expect(stopAt).toBeGreaterThanOrEqual(0)
     expect(startAt).toBeGreaterThan(stopAt)
-    expect(invoked[startAt]?.[1]).toMatchObject({ root: GRAPH.root, emitFileChanges: true })
-  })
-
-  it('a desktop resume sweeps without restarting the watch', async () => {
-    const icloud = controller()
-    await icloud.start()
-    await settleScan()
-    invoked.length = 0
-
-    window.dispatchEvent(new Event('focus'))
-    await settleScan()
-
-    expect(invoked.some(([command]) => command === 'icloud_watch_stop')).toBe(false)
-    expect(invoked.some(([command]) => command === 'icloud_watch_start')).toBe(false)
-    expect(scanCalls).toHaveLength(2) // baseline + the resume sweep itself
+    expect(invoked[startAt]?.[1]).toEqual({ root: GRAPH.root })
   })
 
   it('preserves desktop baseline scanning while the document is hidden', async () => {
     const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
     try {
-      const icloud = controller({ emit: false })
+      const icloud = controller({ watch: false })
       await icloud.start()
       await settleScan()
 
@@ -289,8 +295,8 @@ describe('createIcloudController', () => {
     }
   })
 
-  it('scopes sweeps: full for baseline and resume, candidates for signals and ingests', async () => {
-    const icloud = controller()
+  it('mobile scopes sweeps: full for baseline and resume, candidates for signals and ingests', async () => {
+    const icloud = controller({ watch: true })
     await icloud.start()
     await settleScan()
     expect(scanCalls[0]?.scope).toBe('full') // the adoption baseline is the backstop
@@ -308,8 +314,31 @@ describe('createIcloudController', () => {
     expect(scanCalls[3]?.scope).toBe('full') // resume re-checks everything
   })
 
-  it('a failed candidates sweep retries at full scope', async () => {
+  it('desktop scopes arrival sweeps to the arrivals and never listens for watch signals', async () => {
     const icloud = controller()
+    await icloud.start()
+    await settleScan()
+    expect(scanCalls[0]?.scope).toBe('full') // the adoption baseline is the backstop
+
+    // Without a watch there is no candidate set to trust: the arrivals
+    // themselves are the only notes a just-landed remote edit can have
+    // conflicted, so the sweep checks exactly those — never the whole graph
+    // per batch, and never the (unanswerable) candidates scope.
+    emitFileChanges([{ path: 'notes/external.md', kind: 'upsert', modifiedMs: 2 }])
+    await settleScan(INGEST_SETTLE_MS)
+    expect(scanCalls[1]).toMatchObject({ scope: 'ingested', ingestedPaths: ['notes/external.md'] })
+
+    // No watch runs, so its signals are never subscribed to.
+    expect(listeners.has('icloud:conflicts')).toBe(false)
+    expect(listeners.has('icloud:watch-failed')).toBe(false)
+
+    window.dispatchEvent(new Event('focus'))
+    await settleScan()
+    expect(scanCalls[2]?.scope).toBe('full') // resume re-checks everything
+  })
+
+  it('a failed candidates sweep retries at full scope', async () => {
+    const icloud = controller({ watch: true })
     await icloud.start()
     await settleScan() // baseline (full) out of the way
 
@@ -322,6 +351,24 @@ describe('createIcloudController', () => {
     await settleScan()
     // Whatever failed, the retry must be thorough.
     expect(scanCalls[2]?.scope).toBe('full')
+  })
+
+  it('a failed desktop arrival sweep retries at full scope', async () => {
+    const icloud = controller()
+    await icloud.start()
+    await settleScan() // baseline (full) out of the way
+
+    scanResults.push(new Error('container hiccup'))
+    emitFileChanges([{ path: 'notes/one.md', kind: 'upsert', modifiedMs: 1 }])
+    await settleScan(INGEST_SETTLE_MS)
+    expect(scanCalls[1]?.scope).toBe('ingested')
+
+    emitFileChanges([{ path: 'notes/two.md', kind: 'upsert', modifiedMs: 2 }])
+    await settleScan(INGEST_SETTLE_MS)
+    expect(scanCalls[2]).toMatchObject({
+      scope: 'full',
+      ingestedPaths: expect.arrayContaining(['notes/one.md', 'notes/two.md']),
+    })
   })
 
   it('a failed sweep re-queues its ingests and the adoption baseline', async () => {
@@ -365,7 +412,7 @@ describe('createIcloudController', () => {
 
   it('a conflict signal caught mid-sweep replays on the prompt window', async () => {
     scanResults.push('hang')
-    const icloud = controller()
+    const icloud = controller({ watch: true })
     await icloud.start()
     await settleScan() // the baseline sweep starts — and hangs
     expect(scanCalls).toHaveLength(1)
@@ -388,7 +435,7 @@ describe('createIcloudController', () => {
 
   it('a mid-sweep resume keeps its full scope through the replay', async () => {
     scanResults.push('hang')
-    const icloud = controller()
+    const icloud = controller({ watch: true })
     await icloud.start()
     await settleScan() // the baseline sweep starts — and hangs
     expect(scanCalls).toHaveLength(1)
@@ -417,11 +464,11 @@ describe('createIcloudController', () => {
 
     await settleScan(INGEST_SETTLE_MS)
     expect(scanCalls).toHaveLength(2)
-    expect(scanCalls[1]?.ingestedPaths).toEqual(['notes/late.md'])
+    expect(scanCalls[1]).toMatchObject({ scope: 'ingested', ingestedPaths: ['notes/late.md'] })
   })
 
   it('conflict signals and resume events schedule deduped sweeps', async () => {
-    const icloud = controller()
+    const icloud = controller({ watch: true })
     await icloud.start()
     await settleScan() // baseline
 

--- a/apps/desktop/src/lib/icloud-controller.ts
+++ b/apps/desktop/src/lib/icloud-controller.ts
@@ -58,11 +58,13 @@ export interface IcloudControllerOptions {
   /** The open index session; sweep results reindex under it. */
   indexGeneration: number | null
   /**
-   * Emit `index:changed` from the metadata query's snapshot diffs — true on
-   * mobile (the query is the only external-change source there), false on
-   * desktop (the `notify` watcher already reports file events).
+   * Install the native metadata-query watch — true on mobile, where the
+   * query is the only external-change source and the conflict signal; false
+   * on desktop, where the `notify` watcher already reports every iCloud
+   * write and the query's container-wide gather is what pinned
+   * `fileproviderd` (issue #1180; see `icloud/watch.rs`).
    */
-  emitFileChangesFromWatch: boolean
+  metadataWatch: boolean
 }
 
 export interface IcloudController {
@@ -76,24 +78,25 @@ export interface IcloudController {
  * iCloud moves the files itself, so all that's left to own is *conflict*
  * handling and shadow-base bookkeeping.
  *
- * - Starts/stops the native metadata-query watch.
- * - Debounces `icloud:conflicts` signals and external file-change batches
- *   into conflict sweeps (`icloud_conflicts_scan`).
+ * - Debounces external file-change batches into conflict sweeps
+ *   (`icloud_conflicts_scan`), scoped to the arrivals themselves.
  * - Classifies external arrivals (not this device's own writes — tracked via
  *   the own-write echo — and not the sweep's own output) as clean ingests,
  *   which advance the notes' shadow merge bases.
  * - Fans a sweep's rewrites to every file-change subscriber and reindexes
  *   them directly, exactly like the backup controller's pull path.
- * - Sweeps again on resume/focus: the metadata query only covers the app's
- *   own container, so graphs the user placed in the general iCloud Drive
- *   folder get no conflict signal — and a conflict version can appear
- *   without the working file changing, which the `notify` watcher can't see
- *   either. The resume sweep is the backstop for both.
- * - On mobile, restarts the watch on every foreground resume: a long iOS
- *   suspension can sever the query's link to `fileproviderd` and update
- *   delivery never recovers, and the query is the *sole* external-change
- *   source there — a silently dead watch means a Mac edit synced while
- *   backgrounded stays invisible until the app is relaunched.
+ * - Sweeps everything again on resume/focus: a conflict version can appear
+ *   without the working file changing, which no file watcher can see. The
+ *   resume sweep is the backstop for that — on desktop the only one, and
+ *   the same one graphs kept outside the app's container always relied on.
+ * - On mobile only ({@link IcloudControllerOptions.metadataWatch}): starts
+ *   and stops the native metadata-query watch, sweeps promptly on its
+ *   `icloud:conflicts` signal (scoped to the watch's candidate set), and
+ *   restarts the watch on every foreground resume — a long iOS suspension
+ *   can sever the query's link to `fileproviderd` and update delivery never
+ *   recovers, and the query is the *sole* external-change source there, so
+ *   a silently dead watch means a Mac edit synced while backgrounded stays
+ *   invisible until the app is relaunched.
  *
  * Dirty open sessions are deferred (their paths ride `skipPaths`) as a
  * courtesy, not a safety net — even without it, a sweep write lands on disk
@@ -101,7 +104,7 @@ export interface IcloudController {
  * conflict, the same as any external edit.
  */
 export function createIcloudController(options: IcloudControllerOptions): IcloudController {
-  const { graph, indexGeneration, emitFileChangesFromWatch } = options
+  const { graph, indexGeneration, metadataWatch } = options
   let disposed = false
   let baselinePending = true
   const disposers: Array<() => void> = []
@@ -137,9 +140,16 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
    * sweep re-arms `'full'` so the retry is thorough.
    */
   let nextScanScope: IcloudSweepScope = 'full'
+  /**
+   * The narrow scope for arrival-driven sweeps: the watch's candidate set
+   * where a watch runs, else the arrivals themselves. Everything that is
+   * not `'full'` merges to this one value, so a queued replay can never be
+   * narrower than what this surface can actually answer.
+   */
+  const arrivalScope: IcloudSweepScope = metadataWatch ? 'candidates' : 'ingested'
 
   function scanSuspended(): boolean {
-    return emitFileChangesFromWatch && document.visibilityState === 'hidden'
+    return metadataWatch && document.visibilityState === 'hidden'
   }
 
   function scheduleScan(
@@ -156,7 +166,7 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
       const urgency = delayMs <= SCAN_DEBOUNCE_MS ? 'prompt' : 'ingest'
       queuedScan = {
         urgency: urgency === 'prompt' || queuedScan?.urgency === 'prompt' ? 'prompt' : 'ingest',
-        scope: scope === 'full' || queuedScan?.scope === 'full' ? 'full' : 'candidates',
+        scope: scope === 'full' || queuedScan?.scope === 'full' ? 'full' : arrivalScope,
       }
       return
     }
@@ -176,10 +186,10 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
 
   /** Arrival-triggered sweeps: the wide debounce, stretched further to keep
    * {@link INGEST_SCAN_MIN_SPACING_MS} from the previous sweep's end. Scoped
-   * to the watch's conflict candidates — during a bulk sync these fire every
-   * spacing window, and a full per-note version check each time was the
-   * sweep's dominant cost on a large graph. */
-  function scheduleIngestScan(scope: IcloudSweepScope = 'candidates'): void {
+   * to {@link arrivalScope} — during a bulk sync these fire every spacing
+   * window, and a full per-note version check each time was the sweep's
+   * dominant cost on a large graph. */
+  function scheduleIngestScan(scope: IcloudSweepScope = arrivalScope): void {
     const sinceLastScan = Date.now() - lastScanEndedAt
     scheduleScan(
       Math.max(INGEST_SCAN_DEBOUNCE_MS, INGEST_SCAN_MIN_SPACING_MS - sinceLastScan),
@@ -203,7 +213,7 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
     const recordBaseline = baselinePending
     baselinePending = false
     const scope = recordBaseline ? 'full' : nextScanScope
-    nextScanScope = 'candidates' // consumed; the next full trigger re-arms it
+    nextScanScope = arrivalScope // consumed; the next full trigger re-arms it
     try {
       const outcome = await icloudConflictsScan({
         generation: graph.generation,
@@ -270,7 +280,7 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
         indexGeneration,
         undefined,
         undefined,
-        () => !emitFileChangesFromWatch || document.visibilityState !== 'hidden',
+        () => !metadataWatch || document.visibilityState !== 'hidden',
       ).then((mutations) => {
         if (mutations > 0) {
           throttledInvalidateIndexQueries()
@@ -310,7 +320,7 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
       return // closed mid-restart: never leave a watch running for a dead graph
     }
     try {
-      await icloudWatchStart(graph.root, emitFileChangesFromWatch)
+      await icloudWatchStart(graph.root)
     } catch (err) {
       // Same degradation contract as a failed initial start: freshness
       // rides file-change batches and resume sweeps (this resume already
@@ -325,11 +335,13 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
     if (disposed) {
       return
     }
-    try {
-      await icloudWatchStart(graph.root, emitFileChangesFromWatch)
-    } catch (err) {
-      console.error('iCloud watch failed to start:', err)
-      // Sweeps still run off file-change batches; carry on.
+    if (metadataWatch) {
+      try {
+        await icloudWatchStart(graph.root)
+      } catch (err) {
+        console.error('iCloud watch failed to start:', err)
+        // Sweeps still run off file-change batches; carry on.
+      }
     }
     disposers.push(
       subscribeOwnWrites((path) => {
@@ -365,38 +377,37 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
           scheduleIngestScan()
         }),
       )
-      disposers.push(
-        await subscribeIcloudConflicts(() => {
-          if (!disposed) {
-            // The signal and the candidate set come from the same
-            // notification round, so the flagged paths are already in the
-            // watch's view — the prompt sweep needn't re-check every note.
-            scheduleScan(SCAN_DEBOUNCE_MS, 'candidates')
-          }
-        }),
-      )
-      disposers.push(
-        await subscribeIcloudWatchFailed(() => {
-          if (disposed) {
-            return
-          }
-          // The live watch never started (fire-and-forget install failed
-          // after the command returned). Freshness now rides file-change
-          // batches and the resume sweeps — say so loudly for debugging
-          // stale-state reports, and sweep once right away.
-          console.error('iCloud watch failed to start; relying on resume-triggered sweeps')
-          scheduleScan()
-        }),
-      )
+      if (metadataWatch) {
+        disposers.push(
+          await subscribeIcloudConflicts(() => {
+            if (!disposed) {
+              // The signal and the candidate set come from the same
+              // notification round, so the flagged paths are already in the
+              // watch's view — the prompt sweep needn't re-check every note.
+              scheduleScan(SCAN_DEBOUNCE_MS, 'candidates')
+            }
+          }),
+        )
+        disposers.push(
+          await subscribeIcloudWatchFailed(() => {
+            if (disposed) {
+              return
+            }
+            // The live watch never started (fire-and-forget install failed
+            // after the command returned). Freshness now rides file-change
+            // batches and the resume sweeps — say so loudly for debugging
+            // stale-state reports, and sweep once right away.
+            console.error('iCloud watch failed to start; relying on resume-triggered sweeps')
+            scheduleScan()
+          }),
+        )
+      }
     } catch (err) {
       console.error('iCloud change subscriptions failed to start:', err)
     }
     disposers.push(
       ...attachResumeListeners(() => {
-        if (emitFileChangesFromWatch) {
-          // Mobile only: desktop's query survives sleep well enough for its
-          // conflict-signal role, and desktop content freshness rides the
-          // `notify` watcher plus the wake-time reconcile, not this query.
+        if (metadataWatch) {
           void restartWatch()
         }
         scheduleScan()
@@ -415,9 +426,11 @@ export function createIcloudController(options: IcloudControllerOptions): Icloud
     for (const disposeOne of disposers.splice(0)) {
       disposeOne()
     }
-    void icloudWatchStop().catch(() => {
-      // Shutdown/switch race — the next start replaces the watch anyway.
-    })
+    if (metadataWatch) {
+      void icloudWatchStop().catch(() => {
+        // Shutdown/switch race — the next start replaces the watch anyway.
+      })
+    }
   }
 
   return { start, dispose }

--- a/apps/desktop/src/providers/sync-provider.tsx
+++ b/apps/desktop/src/providers/sync-provider.tsx
@@ -73,9 +73,10 @@ export function SyncProvider({ graph, children }: SyncProviderProps): ReactEleme
   }, [graph, indexGeneration])
 
   // iCloud-hosted graphs additionally get the conflict lifecycle (Plan 21):
-  // the metadata-query watch, debounced conflict sweeps, and shadow-base
-  // bookkeeping. Same per-(graph, index session) shape as the backup
-  // controller; a graph outside iCloud mounts nothing.
+  // debounced conflict sweeps and shadow-base bookkeeping, plus — on mobile
+  // only — the metadata-query watch that stands in for the file watcher.
+  // Same per-(graph, index session) shape as the backup controller; a graph
+  // outside iCloud mounts nothing.
   const bridgeReady = useBridgeReady()
   useMainWindowEffect(() => {
     if (!bridgeReady || !isICloudRoot(graph.root)) {
@@ -84,7 +85,7 @@ export function SyncProvider({ graph, children }: SyncProviderProps): ReactEleme
     const icloud = createIcloudController({
       graph,
       indexGeneration,
-      emitFileChangesFromWatch: isMobileSurface(),
+      metadataWatch: isMobileSurface(),
     })
     void icloud.start()
     return () => {

--- a/docs/icloud-sync.md
+++ b/docs/icloud-sync.md
@@ -74,34 +74,59 @@ Everything below the platform calls — the resolution ladder, the shadow
 merge-base store, the conflict sweep — is plain Rust with unit tests
 (`cargo test -p reflect-open --lib -- conflict icloud`) and runs identically
 in CI. What *needs a real container* (and the two-device manual matrix in
-the plan doc) is the `NSMetadataQuery` watch, `NSFileVersion` conflict
+the plan doc) is the mobile `NSMetadataQuery` watch, `NSFileVersion` conflict
 delivery, and download/eviction behavior.
 
-## Known log noise: `BRItemCollectionGatherer - Repeatedly can't watch item`
+## Sync-excluded directories and the metadata query
 
-With a graph open, the app process logs CloudDocs errors — a burst while the
-`NSMetadataQuery` watch gathers, then one round per graph write:
+`.reflect/` and `.git/` live inside the synced graph but are marked local-only
+(`mark_dir_local_only` in `fs/io.rs`): the `com.apple.fileprovider.ignore#P`
+xattr plus the `NSURLUbiquitousItemIsExcludedFromSyncKey` resource key (which
+sets the same xattr). That keeps the live SQLite index and the backup repo
+off iCloud, but it also means those directories carry no identity in the
+provider database — and CloudDocs' `NSMetadataQuery` machinery trips over
+exactly that.
 
-```text
-[ERROR] … NSError: NSFileProviderInternalErrorDomain 15 … while gathering
-[CRIT] UNREACHABLE: … BRItemCollectionGatherer - Repeatedly can't watch item …
-```
+Measured on macOS 26.5 with an entitled probe app over the real container
+(the shape `icloud/watch.rs` builds — ubiquitous documents scope, path-prefix
+predicate, serial delivery queue):
 
-This is Apple's query machinery tripping over the directories Reflect
-deliberately excludes from sync (`.reflect`, and `.git` on desktop — see
-`mark_dir_local_only` in `fs/io.rs`): they exist on disk inside the watched
-root, but carry no identity in the provider database, so the gatherer's
-per-item watch fails, retries, and gives up with the `UNREACHABLE` fault.
-Any FS event under an excluded tree re-attempts once — on desktop that means
-every note save, because the local Git history engine commits into `.git`.
+- The gatherer (`BRItemCollectionGatherer`) enumerates the app's **entire**
+  container and builds one observed collection per directory, whatever the
+  predicate says. Restricting the predicate (`NOT (path BEGINSWITH …/.reflect/)`),
+  setting `searchItems`, or pointing the scope at note directories changed
+  nothing (URL scopes route the query to Spotlight, which has no ubiquitous
+  attributes at all). Every excluded directory in the container — in *any*
+  graph it holds — fails identically, and so does a `.nosync` directory.
+- Each excluded directory's collection fails with
+  `NSFileProviderInternalErrorDomain 15 while gathering`, is retried with a
+  10 → 50 ms linear backoff, and is given up on after six rounds
+  (`[CRIT] UNREACHABLE: … BRItemCollectionGatherer - Repeatedly can't watch
+  item`). Every retry reloads the whole item tree through `fileproviderd`: a
+  three-graph container of ~13k items re-gathered six times in one start.
+  Churn inside an excluded tree re-triggers the failure (a freshly created
+  one produced 35 give-ups in a single run).
+- Once gathered, the query is silent at idle on macOS 26.
 
-Verified benign (2026-08-02): touching a file inside `.git` reproduces the
-error within milliseconds, the failing watches are exactly the items sync
-must ignore, and the query demonstrably keeps delivering update rounds (and
-the conflict view keeps functioning) after the faults. Don't chase this
-signature; a real watcher failure looks different — `startQuery` returning
-false (logged as `iCloud metadata query failed to start`, surfaced via the
-`icloud:watch-failed` event) or update rounds ceasing entirely.
+On macOS 15.6 that reload cycle was observed never to settle
+([#1180](https://github.com/team-reflect/reflect-open/issues/1180)): opening
+an iCloud graph held `fileproviderd` around 200% CPU (`com.apple.fssync.fstree`
+walks and xattr reads) and Reflect around 40% (File Provider XPC replies)
+until the app quit. Since nothing scopes the gather below the container and
+no exclusion mechanism escapes it, the desktop app **does not run the
+metadata query at all**: the `notify` watcher already reports every iCloud
+write there as a plain FS event, arrival-triggered conflict sweeps check the
+arrived notes (`'ingested'` scope), and the resume/focus sweep checks
+everything — the same backstop graphs kept outside the app's container always
+relied on. Mobile keeps the query: it is the sole external-change source
+there and iOS has no file watcher to fall back on.
+
+So with a graph open on the Mac, the app's process logs **no**
+`BRItemCollectionGatherer` errors. On iOS the burst still appears at each
+watch start and is benign; a real watcher failure looks different —
+`startQuery` returning false (logged as `iCloud metadata query failed to
+start`, surfaced via the `icloud:watch-failed` event) or update rounds ceasing
+entirely.
 
 ## Deliberately not here (yet)
 

--- a/packages/core/src/ipc/commands.ts
+++ b/packages/core/src/ipc/commands.ts
@@ -185,10 +185,12 @@ export type IcloudSweepOutcome = z.infer<typeof icloudSweepOutcomeSchema>
  * How much of the graph a sweep checks for unresolved versions. `'full'`
  * checks every note and runs store housekeeping — the backstop (resume,
  * adoption baseline). `'candidates'` restricts the per-note version checks
- * to the paths the live metadata watch flags as conflicted; Rust degrades it
- * to a full check whenever the watch cannot answer completely.
+ * to the paths the live metadata watch flags as conflicted (mobile); Rust
+ * degrades it to a full check whenever the watch cannot answer completely.
+ * `'ingested'` restricts them to the sweep's own `ingestedPaths` — desktop's
+ * arrival sweeps, where no metadata watch runs.
  */
-export type IcloudSweepScope = 'full' | 'candidates'
+export type IcloudSweepScope = 'full' | 'candidates' | 'ingested'
 
 /** Options for {@link icloudConflictsScan}. */
 export interface IcloudScanOptions {
@@ -228,13 +230,14 @@ export async function icloudConflictsScan(options: IcloudScanOptions): Promise<I
 const voidResponseSchema = z.null()
 
 /**
- * Start the iCloud metadata-query watch over `root` (Plan 21 Phase 2).
- * `emitFileChanges` turns its snapshot diffs into `index:changed` events —
- * pass true on mobile (no file watcher there), false on desktop. Conflict
- * paths always emit as `icloud:conflicts`.
+ * Start the iCloud metadata-query watch over `root` (Plan 21 Phase 2): its
+ * snapshot diffs emit as `index:changed` batches and conflict paths as
+ * `icloud:conflicts`. Mobile only — desktop's `notify` watcher already
+ * reports iCloud writes, and the query's container-wide gather is what
+ * pinned `fileproviderd` there (issue #1180).
  */
-export async function icloudWatchStart(root: string, emitFileChanges: boolean): Promise<void> {
-  await call('icloud_watch_start', { root, emitFileChanges }, voidResponseSchema)
+export async function icloudWatchStart(root: string): Promise<void> {
+  await call('icloud_watch_start', { root }, voidResponseSchema)
 }
 
 /** Stop the active iCloud watch (graph switch). Idempotent. */


### PR DESCRIPTION
Fixes #1180.

## Problem

Opening an iCloud-backed graph on macOS 15.6 held `fileproviderd` around 185–205% CPU and Reflect around 40% for as long as the app stayed open, with a 54-note graph and no edits. Quitting Reflect dropped `fileproviderd` back to idle; relaunching brought the load straight back.

## Root cause

The desktop app installed the same `NSMetadataQuery` watch mobile uses, as a conflict signal. That query's cost is not confined to the graph. Measured on macOS 26.5 with a small entitled probe app over the real container (the exact shape `icloud/watch.rs` builds — ubiquitous documents scope, path-prefix predicate, serial delivery queue), with CloudDocs debug logging on:

- CloudDocs' `BRItemCollectionGatherer` enumerates the app's **entire** ubiquity container and builds one observed collection per directory, whatever the predicate says.
- Every sync-excluded directory in the container — `.reflect/` and `.git/` in *every* graph it holds — carries no provider identity, so its collection fails with `NSFileProviderInternalErrorDomain 15 while gathering`, is retried with a 10→50 ms backoff, and is given up on after six rounds (`[CRIT] UNREACHABLE: … BRItemCollectionGatherer - Repeatedly can't watch item`). Every retry reloads the whole item tree through `fileproviderd`: a three-graph container of ~13k items was re-gathered six times per query start. Churn inside an excluded tree re-triggers the failure (a freshly created one produced 35 give-ups in a single run).
- Nothing scopes the gather below the container. `NOT (path BEGINSWITH …/.reflect/)` predicates: identical failure counts. `searchItems`: ignored. URL search scopes: routed to Spotlight, zero results, no ubiquitous attributes. Marking the directory via the `NSURLUbiquitousItemIsExcludedFromSyncKey` resource key (which sets the same `com.apple.fileprovider.ignore#P` xattr) or naming it `.nosync`: still one failing collection each.

macOS 26 bounds the retry cycle at those six rounds and the query then goes silent; the reporter's sample (`com.apple.fssync.fstree` walks and xattr reads in `fileproviderd`, File Provider XPC replies in Reflect) is that same reload cycle never settling on macOS 15.6. The "benign log noise" note in `docs/icloud-sync.md` was describing this fault from the wrong side.

## Fix

Desktop never needed the query for freshness — the `notify` watcher already reports every iCloud write as a plain FS event — only for the conflict signal and sweep scoping. So the watch becomes mobile-only, where it is the sole external-change source and iOS has no file watcher to fall back on.

- `createIcloudController` takes `metadataWatch` (true on mobile). Desktop no longer installs, restarts, or subscribes to the watch; it mounts the sweeps alone.
- Desktop arrival sweeps get a new `'ingested'` scope (`SweepScope::Ingested`): the `NSFileVersion` checks cover the notes that just arrived, instead of degrading to the full per-note pass that the `'candidates'` scope falls back to without a watch. A remote edit that became the working file is by definition among the arrivals. A conflict version that never touches the working file waits for the resume/focus full sweep — the same backstop graphs kept outside the app's container always relied on.
- `icloud_watch_start` drops its `emit_file_changes` flag; the watch always emits now.
- `docs/icloud-sync.md` records the measured mechanism.

## Testing

- `pnpm check` (typecheck, oxfmt, oxlint, eslint) clean; `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `pnpm test --run apps/desktop/src/lib/icloud-controller.test.tsx`: 19 pass, including new regression tests — desktop never invokes `icloud_watch_start`/`icloud_watch_stop` (start, resume, dispose) and never subscribes to the watch's events; desktop arrival sweeps carry `scope: 'ingested'` with the arrived paths; a failed desktop arrival sweep retries at full scope; the mobile shape keeps its watch lifecycle and candidate scoping.
- `cargo test -p reflect-open --lib -- icloud`: 42 pass, including the new `conflict_candidates` test (`Ingested` → exactly the arrivals, `Full` → everything, `Candidates` without a watch → degrades to everything, never to an empty set).
- Probe measurements above (macOS 26.5.1, Apple Silicon, the real `iCloud.app.reflect` container with three graphs).
- App-level run of a signed build of this branch against a graph in the real container: zero `NSMetadataQuery`/gatherer activity from Reflect's process, `fileproviderd` at 0.0% throughout, baseline sweep at `Full` and both arrival sweeps at `Ingested` — full numbers in the first comment below.

## Not covered

- The mechanism itself could only be measured on macOS 26; a macOS 15.6 machine is needed to confirm the reload cycle now ends there, which the fix guarantees by construction (no query, no gatherer in Reflect's process).
- iOS keeps the watch, so an iPhone still pays the bounded gather cost per watch start; if an iOS-side CPU report ever comes in, the answer is structural (`.reflect` outside the container, or an `NSFilePresenter`-based conflict signal), not a predicate.
- Desktop promptness for a conflict version that never touches the working file now depends on the next refocus rather than the query's update round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
