### PR TITLE
fix: sync no longer gets stuck after the app is killed mid-merge

### DIFF
--- a/apps/desktop/src-tauri/src/git/commit.rs
+++ b/apps/desktop/src-tauri/src/git/commit.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use crate::error::AppResult;
 
 use super::commit_message::message_for_commit;
-use super::repo::{ensure_clean_state, open_existing, signature};
+use super::repo::{ensure_clean_state, open_for_sync, signature};
 
 /// A file whose *changes* were withheld from staging because it is at/above
 /// the size guardrail. Oversized-but-unchanged files are not reported — their
@@ -45,7 +45,7 @@ pub(super) fn commit_all(
     fallback_message: &str,
     max_file_bytes: u64,
 ) -> AppResult<CommitOutcome> {
-    let repo = open_existing(root)?;
+    let repo = open_for_sync(root)?;
     ensure_clean_state(&repo)?;
     // In-memory hard guarantee, independent of any on-disk ignore file: the
     // runtime directory must never enter a backup commit (Plan 21 — a synced

--- a/apps/desktop/src-tauri/src/git/merge.rs
+++ b/apps/desktop/src-tauri/src/git/merge.rs
@@ -246,7 +246,7 @@ pub(super) fn recover_interrupted_merge(repo: &Repository) -> AppResult<()> {
     if merge_commit_has_parents(repo, head_oid, local_oid, remote_oid)? {
         if repo.state() == git2::RepositoryState::Merge && refs_match {
             // The merge commit landed and only cleanup was interrupted.
-            remove_owned_index_lock(repo)?;
+            ensure_index_unlocked(repo)?;
             repo.cleanup_state()?;
         }
         // A different active operation is foreign. Forget our stale marker,
@@ -263,7 +263,7 @@ pub(super) fn recover_interrupted_merge(repo: &Repository) -> AppResult<()> {
     // `repo.merge` already wrote the merge index and checkout before the app
     // was interrupted. Continue from that index: untouched working-tree edits
     // stay unstaged, and edits to a text conflict become its chosen resolution.
-    remove_owned_index_lock(repo)?;
+    ensure_index_unlocked(repo)?;
     let root = repo.workdir().ok_or_else(|| {
         crate::error::AppError::io("the backup repository has no working directory")
     })?;
@@ -357,13 +357,18 @@ fn merge_commit_has_parents(
         && commit.parent_ids().any(|oid| oid == remote_oid))
 }
 
-/// Remove the index lock only after the marker and all three merge refs prove
-/// this exact operation belongs to Reflect.
-fn remove_owned_index_lock(repo: &Repository) -> AppResult<()> {
+/// Refuse recovery while the index is locked. The merge marker proves who
+/// owns the merge state, but it cannot prove who created a later `index.lock`:
+/// a CLI or another process may have acquired it after Reflect stopped. A
+/// generic stale-lock policy belongs at repository open, where ownership can
+/// be established independently of merge recovery.
+fn ensure_index_unlocked(repo: &Repository) -> AppResult<()> {
     let path = repo.path().join("index.lock");
-    match fs::remove_file(path) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+    match path.try_exists() {
+        Ok(false) => Ok(()),
+        Ok(true) => Err(crate::error::AppError::io(
+            "the backup repository index is locked; wait for the other Git operation to finish or remove a confirmed stale .git/index.lock",
+        )),
         Err(error) => Err(error.into()),
     }
 }
@@ -581,7 +586,7 @@ fn resolve_both_edited(
         index.add_path(Path::new(&our.path))?;
         return Ok(vec![our.path]);
     }
-    write_blob(repo, root, &our.path, our.id)?;
+    materialize_blob_if_missing(repo, root, &our.path, our.id)?;
     let copy = conflict_copy_path(&their.path);
     write_blob(repo, root, &copy, their.id)?;
     index.add_path(Path::new(&our.path))?;
@@ -598,9 +603,29 @@ fn resolve_edit_vs_delete(
     index: &mut Index,
     edited: ConflictSide,
 ) -> AppResult<String> {
-    write_blob(repo, root, &edited.path, edited.id)?;
+    materialize_blob_if_missing(repo, root, &edited.path, edited.id)?;
     index.add_path(Path::new(&edited.path))?;
     Ok(edited.path)
+}
+
+/// Restore the selected Git blob only when the merge checkout left no file.
+/// An existing working-tree file may contain an edit made after interruption;
+/// staging it in place preserves that edit instead of replacing it with one of
+/// the pre-crash parents. The two-parent merge commit still retains both raw
+/// versions for recovery and review.
+fn materialize_blob_if_missing(
+    repo: &Repository,
+    root: &Path,
+    rel: &str,
+    id: git2::Oid,
+) -> AppResult<()> {
+    match fs::symlink_metadata(root.join(rel)) {
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            write_blob(repo, root, rel, id)
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 fn write_blob(repo: &Repository, root: &Path, rel: &str, id: git2::Oid) -> AppResult<()> {

--- a/apps/desktop/src-tauri/src/git/merge.rs
+++ b/apps/desktop/src-tauri/src/git/merge.rs
@@ -3,11 +3,12 @@
 //! Git markers with readable labels), commit the merge anyway, and let the
 //! user resolve by editing the file.
 //!
-//! The repository is never left mid-merge: committing the conflict keeps sync
-//! flowing for every other note, both devices converge on the same marked-up
-//! file, and the raw versions stay recoverable from history (the merge commit
-//! has both parents). The indexer (Plan 12 core) detects the markers and flags
-//! the note `Needs review`.
+//! A completed conflict is committed so sync keeps flowing for every other
+//! note, both devices converge on the same marked-up file, and the raw versions
+//! stay recoverable from the merge commit's two parents. If the process stops
+//! first, a private marker under `.git` lets the next sync resume only that
+//! verified app-owned merge. The indexer detects content markers and flags the
+//! note `Needs review`.
 //!
 //! The markers are standard Git, with product labels instead of branch names:
 //!
@@ -23,17 +24,34 @@ use std::fs;
 use std::path::Path;
 
 use git2::build::CheckoutBuilder;
-use git2::{Index, IndexEntry, MergeOptions, Repository};
-use serde::Serialize;
+use git2::{Index, IndexEntry, MergeOptions, Oid, Repository};
+use serde::{Deserialize, Serialize};
 
 use crate::error::AppResult;
 
-use super::repo::{current_branch, ensure_clean_state, open_existing, signature};
+#[cfg(test)]
+use super::repo::open_existing;
+use super::repo::{current_branch, ensure_clean_state, open_for_sync, signature};
 
 /// Conflict-marker labels. "this device" is the local side, "other device"
 /// the remote one — product language, not branch names.
 const OUR_LABEL: &str = "this device";
 const THEIR_LABEL: &str = "other device";
+
+/// Written before libgit2 enters merge state and removed after durable
+/// completion. If the process is interrupted, the marker plus HEAD,
+/// MERGE_HEAD, and ORIG_HEAD let the next sync prove the merge belongs to
+/// Reflect and resume it in place. Foreign CLI operations remain hands-off.
+const MERGE_RECOVERY_FILE: &str = "REFLECT_MERGE_STATE";
+
+/// Durable identity for one non-fast-forward merge initiated by Reflect.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MergeRecovery {
+    version: u32,
+    local_oid: String,
+    remote_oid: String,
+}
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -97,7 +115,7 @@ fn side_of(entry: Option<IndexEntry>) -> Option<ConflictSide> {
 /// Merge the fetched `origin/<branch>` into the local branch. Pre-condition
 /// (the sync engine guarantees it): local changes are already committed.
 pub(super) fn merge_remote(root: &Path) -> AppResult<MergeOutcome> {
-    let repo = open_existing(root)?;
+    let repo = open_for_sync(root)?;
     ensure_clean_state(&repo)?;
     let branch = current_branch(&repo)?;
     let Ok(remote_oid) = repo.refname_to_id(&format!("refs/remotes/origin/{branch}")) else {
@@ -142,24 +160,14 @@ pub(super) fn merge_remote(root: &Path) -> AppResult<MergeOutcome> {
         });
     }
 
-    let mut merge_opts = MergeOptions::new();
-    let mut checkout = CheckoutBuilder::new();
-    checkout
-        .allow_conflicts(true)
-        .conflict_style_merge(true)
-        .our_label(OUR_LABEL)
-        .their_label(THEIR_LABEL);
-    repo.merge(&[&annotated], Some(&mut merge_opts), Some(&mut checkout))?;
+    let local_oid = repo.head()?.peel_to_commit()?.id();
+    begin_owned_merge(&repo, local_oid, remote_oid, &annotated)?;
 
-    // From here the repo carries MERGE_* state; a failure that leaves it
-    // behind would trip `ensure_clean_state` on every later cycle and wedge
-    // sync until a manual repair — exactly what this design forbids. Clear it
-    // on every path; the next cycle re-derives anything a failed attempt lost.
-    let result = complete_merge(&repo, root, remote_oid);
-    if result.is_err() {
-        let _ = repo.cleanup_state();
-    }
-    let (conflicted_paths, changed_files) = result?;
+    // From here the marker and MERGE_* refs jointly identify an app-owned
+    // operation. If the process stops before completion, the next repository
+    // open resumes this exact index instead of resetting the working tree.
+    let (conflicted_paths, changed_files) = complete_merge(&repo, root, remote_oid)?;
+    remove_recovery_marker_best_effort(&repo);
 
     let kind = if conflicted_paths.is_empty() {
         MergeKind::Merged
@@ -173,9 +181,235 @@ pub(super) fn merge_remote(root: &Path) -> AppResult<MergeOutcome> {
     })
 }
 
-/// The post-`repo.merge` half: materialize conflicts, commit the merge with
-/// both parents, and clear the merge state. Split out so [`merge_remote`] can
-/// guarantee `cleanup_state` runs even when any step here fails. Returns the
+/// Enter libgit2 merge state and write its index and labeled checkout.
+fn begin_merge(repo: &Repository, annotated: &git2::AnnotatedCommit<'_>) -> AppResult<()> {
+    let mut merge_opts = MergeOptions::new();
+    let mut checkout = CheckoutBuilder::new();
+    checkout
+        .allow_conflicts(true)
+        .conflict_style_merge(true)
+        .our_label(OUR_LABEL)
+        .their_label(THEIR_LABEL);
+    repo.merge(&[annotated], Some(&mut merge_opts), Some(&mut checkout))?;
+    Ok(())
+}
+
+/// Write the recovery marker and enter libgit2 merge state as one owned
+/// operation. A merge rejected before it starts drops the marker without
+/// touching the user's working tree.
+fn begin_owned_merge(
+    repo: &Repository,
+    local_oid: Oid,
+    remote_oid: Oid,
+    annotated: &git2::AnnotatedCommit<'_>,
+) -> AppResult<()> {
+    write_recovery_marker(repo, local_oid, remote_oid)?;
+    if let Err(error) = begin_merge(repo, annotated) {
+        remove_recovery_marker_best_effort(repo);
+        return Err(error);
+    }
+    Ok(())
+}
+
+/// Resume an app-owned merge before any sync primitive reaches its clean-state
+/// guard. The marker alone is never authority: HEAD, MERGE_HEAD, and ORIG_HEAD
+/// must all match the recorded commits. Any mismatch is treated as a foreign
+/// operation and left untouched.
+pub(super) fn recover_interrupted_merge(repo: &Repository) -> AppResult<()> {
+    let Some(recovery) = read_recovery_marker(repo) else {
+        return Ok(());
+    };
+    let Some((local_oid, remote_oid)) = recovery_oids(repo, &recovery) else {
+        return Ok(());
+    };
+    let Ok(head_oid) = repo
+        .head()
+        .and_then(|head| head.peel_to_commit())
+        .map(|commit| commit.id())
+    else {
+        remove_recovery_marker_best_effort(repo);
+        return Ok(());
+    };
+
+    // A clean repository cannot still own an interrupted merge. HEAD may be
+    // the merge commit itself or any later descendant; either way the marker
+    // is stale metadata and must never block another cycle.
+    if repo.state() == git2::RepositoryState::Clean {
+        remove_recovery_marker_best_effort(repo);
+        return Ok(());
+    }
+
+    let merge_head = pseudoref_oid(repo, "MERGE_HEAD");
+    let orig_head = pseudoref_oid(repo, "ORIG_HEAD");
+    let refs_match = merge_head == Some(remote_oid) && orig_head == Some(local_oid);
+
+    if merge_commit_has_parents(repo, head_oid, local_oid, remote_oid)? {
+        if repo.state() == git2::RepositoryState::Merge && refs_match {
+            // The merge commit landed and only cleanup was interrupted.
+            remove_owned_index_lock(repo)?;
+            repo.cleanup_state()?;
+        }
+        // A different active operation is foreign. Forget our stale marker,
+        // but leave its state and lock exactly as they are.
+        remove_recovery_marker_best_effort(repo);
+        return Ok(());
+    }
+
+    if repo.state() != git2::RepositoryState::Merge || head_oid != local_oid || !refs_match {
+        remove_recovery_marker_best_effort(repo);
+        return Ok(());
+    }
+
+    // `repo.merge` already wrote the merge index and checkout before the app
+    // was interrupted. Continue from that index: untouched working-tree edits
+    // stay unstaged, and edits to a text conflict become its chosen resolution.
+    remove_owned_index_lock(repo)?;
+    let root = repo.workdir().ok_or_else(|| {
+        crate::error::AppError::io("the backup repository has no working directory")
+    })?;
+    complete_merge(repo, root, remote_oid)?;
+    remove_recovery_marker_best_effort(repo);
+    Ok(())
+}
+
+/// Persist the two parents before libgit2 can leave recoverable merge state.
+fn write_recovery_marker(repo: &Repository, local_oid: Oid, remote_oid: Oid) -> AppResult<()> {
+    let marker = MergeRecovery {
+        version: 1,
+        local_oid: local_oid.to_string(),
+        remote_oid: remote_oid.to_string(),
+    };
+    let encoded = serde_json::to_string(&marker).map_err(|error| {
+        crate::error::AppError::io(format!("failed to encode merge recovery marker: {error}"))
+    })?;
+    crate::capture::atomic_write_to(&repo.path().join(MERGE_RECOVERY_FILE), &encoded)
+}
+
+/// Read a marker without letting malformed metadata wedge the repository.
+/// Invalid markers are forgotten; a real foreign Git operation remains for
+/// the ordinary clean-state guard to report.
+fn read_recovery_marker(repo: &Repository) -> Option<MergeRecovery> {
+    let path = repo.path().join(MERGE_RECOVERY_FILE);
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(error) => {
+            tracing::warn!(%error, "failed to read merge recovery marker");
+            return None;
+        }
+    };
+    let marker: MergeRecovery = match serde_json::from_slice(&bytes) {
+        Ok(marker) => marker,
+        Err(error) => {
+            tracing::warn!(%error, "discarding invalid merge recovery marker");
+            remove_recovery_marker_best_effort(repo);
+            return None;
+        }
+    };
+    if marker.version != 1 {
+        tracing::warn!(
+            version = marker.version,
+            "discarding unsupported merge recovery marker"
+        );
+        remove_recovery_marker_best_effort(repo);
+        return None;
+    }
+    Some(marker)
+}
+
+/// Parse the marker's commits, discarding metadata that cannot safely identify
+/// an operation. Repository state is deliberately not cleaned here.
+fn recovery_oids(repo: &Repository, recovery: &MergeRecovery) -> Option<(Oid, Oid)> {
+    match (
+        Oid::from_str(&recovery.local_oid),
+        Oid::from_str(&recovery.remote_oid),
+    ) {
+        (Ok(local), Ok(remote)) => Some((local, remote)),
+        _ => {
+            tracing::warn!("discarding merge recovery marker with invalid commits");
+            remove_recovery_marker_best_effort(repo);
+            None
+        }
+    }
+}
+
+/// Resolve a pseudoref such as MERGE_HEAD without accepting symbolic or
+/// multi-line content.
+fn pseudoref_oid(repo: &Repository, name: &str) -> Option<Oid> {
+    let value = fs::read_to_string(repo.path().join(name)).ok()?;
+    let value = value.trim();
+    if value.lines().count() != 1 {
+        return None;
+    }
+    Oid::from_str(value).ok()
+}
+
+/// Whether HEAD is the durable two-parent commit recorded by the marker.
+fn merge_commit_has_parents(
+    repo: &Repository,
+    head_oid: Oid,
+    local_oid: Oid,
+    remote_oid: Oid,
+) -> AppResult<bool> {
+    let commit = repo.find_commit(head_oid)?;
+    Ok(commit.parent_count() == 2
+        && commit.parent_ids().any(|oid| oid == local_oid)
+        && commit.parent_ids().any(|oid| oid == remote_oid))
+}
+
+/// Remove the index lock only after the marker and all three merge refs prove
+/// this exact operation belongs to Reflect.
+fn remove_owned_index_lock(repo: &Repository) -> AppResult<()> {
+    let path = repo.path().join("index.lock");
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+/// Marker cleanup is advisory once the repository state or merge commit is
+/// durable. Failure is logged and ignored; a stale marker is self-healed on a
+/// later clean open and must never turn a successful merge into an error.
+fn remove_recovery_marker_best_effort(repo: &Repository) {
+    let path = repo.path().join(MERGE_RECOVERY_FILE);
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => tracing::warn!(%error, "failed to remove merge recovery marker"),
+    }
+}
+
+#[cfg(test)]
+/// Enter the same app-owned merge path as production, stopping immediately
+/// after libgit2 writes its merge index and checkout to simulate termination.
+pub(super) fn interrupt_next_merge_for_test(root: &Path) -> AppResult<()> {
+    let repo = open_existing(root)?;
+    ensure_clean_state(&repo)?;
+    let branch = current_branch(&repo)?;
+    let remote_oid = repo.refname_to_id(&format!("refs/remotes/origin/{branch}"))?;
+    let local_oid = repo.head()?.peel_to_commit()?.id();
+    let annotated = repo.find_annotated_commit(remote_oid)?;
+    begin_owned_merge(&repo, local_oid, remote_oid, &annotated)
+}
+
+#[cfg(test)]
+/// Finish an interrupted app merge but intentionally leave its marker behind,
+/// simulating termination between durable completion and marker cleanup.
+pub(super) fn finish_interrupted_merge_for_test(root: &Path) -> AppResult<()> {
+    let repo = open_existing(root)?;
+    let recovery = read_recovery_marker(&repo)
+        .ok_or_else(|| crate::error::AppError::io("missing test recovery marker"))?;
+    let (_, remote_oid) = recovery_oids(&repo, &recovery)
+        .ok_or_else(|| crate::error::AppError::io("invalid test recovery marker"))?;
+    complete_merge(&repo, root, remote_oid)?;
+    Ok(())
+}
+
+/// The post-`repo.merge` half: materialize conflicts, commit with both parents,
+/// and clear the merge state. Shared by the normal and recovery paths. An error
+/// leaves the verified marker and merge state available for a later retry;
+/// successful completion makes the commit durable before cleanup. Returns the
 /// conflicted paths and every file the merge changed relative to local HEAD.
 fn complete_merge(
     repo: &Repository,
@@ -189,8 +423,8 @@ fn complete_merge(
     let tree = repo.find_tree(index.write_tree()?)?;
     let local_commit = repo.head()?.peel_to_commit()?;
     let remote_commit = repo.find_commit(remote_oid)?;
-    // The working tree is final here (merge checkout + conflict resolution
-    // wrote everything), so the stamped mtimes are the files' real ones.
+    // The merge tree is final here. Working-tree files may still carry
+    // post-interruption edits; their current mtimes remain the correct reindex hints.
     let mut changed_files = changed_between(repo, Some(&local_commit.tree()?), &tree)?;
     stamp_modified_times(root, &mut changed_files);
     let sig = signature(repo)?;

--- a/apps/desktop/src-tauri/src/git/merge.rs
+++ b/apps/desktop/src-tauri/src/git/merge.rs
@@ -406,12 +406,39 @@ pub(super) fn finish_interrupted_merge_for_test(root: &Path) -> AppResult<()> {
     Ok(())
 }
 
+#[cfg(test)]
+/// Commit an interrupted app merge but intentionally leave libgit2's merge
+/// state and the recovery marker behind, simulating termination immediately
+/// after the two-parent commit becomes durable.
+pub(super) fn commit_interrupted_merge_without_cleanup_for_test(root: &Path) -> AppResult<()> {
+    let repo = open_existing(root)?;
+    let recovery = read_recovery_marker(&repo)
+        .ok_or_else(|| crate::error::AppError::io("missing test recovery marker"))?;
+    let (_, remote_oid) = recovery_oids(&repo, &recovery)
+        .ok_or_else(|| crate::error::AppError::io("invalid test recovery marker"))?;
+    commit_merge(&repo, root, remote_oid)?;
+    Ok(())
+}
+
 /// The post-`repo.merge` half: materialize conflicts, commit with both parents,
 /// and clear the merge state. Shared by the normal and recovery paths. An error
 /// leaves the verified marker and merge state available for a later retry;
 /// successful completion makes the commit durable before cleanup. Returns the
 /// conflicted paths and every file the merge changed relative to local HEAD.
 fn complete_merge(
+    repo: &Repository,
+    root: &Path,
+    remote_oid: git2::Oid,
+) -> AppResult<(Vec<String>, Vec<ChangedFile>)> {
+    let result = commit_merge(repo, root, remote_oid)?;
+    repo.cleanup_state()?;
+    Ok(result)
+}
+
+/// Materialize conflicts and make the durable two-parent merge commit without
+/// clearing libgit2's operation state. Cleanup is deliberately separate so a
+/// later sync can recognize and finish a process interrupted between the two.
+fn commit_merge(
     repo: &Repository,
     root: &Path,
     remote_oid: git2::Oid,
@@ -441,7 +468,6 @@ fn complete_merge(
         &tree,
         &[&local_commit, &remote_commit],
     )?;
-    repo.cleanup_state()?;
     Ok((conflicted_paths, changed_files))
 }
 

--- a/apps/desktop/src-tauri/src/git/mod.rs
+++ b/apps/desktop/src-tauri/src/git/mod.rs
@@ -69,7 +69,16 @@ fn status(root: &Path) -> AppResult<GitStatus> {
             in_progress: false,
         });
     }
-    let repo = repo::open_for_sync(root)?;
+    // Keep the backup panel informative even when interrupted-merge recovery
+    // cannot finish. Write paths still propagate the recovery error and stay
+    // blocked until the underlying problem is resolved.
+    let repo = match repo::open_for_sync(root) {
+        Ok(repo) => repo,
+        Err(error) => {
+            tracing::warn!(?error, "merge recovery failed during status");
+            repo::open_existing(root)?
+        }
+    };
     let branch = repo::current_branch(&repo).ok();
     let remote_url = repo
         .find_remote("origin")

--- a/apps/desktop/src-tauri/src/git/mod.rs
+++ b/apps/desktop/src-tauri/src/git/mod.rs
@@ -69,7 +69,7 @@ fn status(root: &Path) -> AppResult<GitStatus> {
             in_progress: false,
         });
     }
-    let repo = repo::open_existing(root)?;
+    let repo = repo::open_for_sync(root)?;
     let branch = repo::current_branch(&repo).ok();
     let remote_url = repo
         .find_remote("origin")

--- a/apps/desktop/src-tauri/src/git/remote.rs
+++ b/apps/desktop/src-tauri/src/git/remote.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 
 use crate::error::{AppError, AppResult};
 
-use super::repo::{current_branch, open_existing};
+use super::repo::{current_branch, open_for_sync};
 
 /// Where the local branch stands relative to its last-fetched remote
 /// counterpart (no network — call after `fetch`).
@@ -123,7 +123,7 @@ fn origin(repo: &Repository) -> AppResult<git2::Remote<'_>> {
 /// Fetch `origin` (configured refspecs) and report ahead/behind for the
 /// current branch.
 pub(super) fn fetch(root: &Path, token: Option<String>) -> AppResult<RemoteDelta> {
-    let repo = open_existing(root)?;
+    let repo = open_for_sync(root)?;
     {
         let mut remote = origin(&repo)?;
         let mut opts = FetchOptions::new();
@@ -183,7 +183,7 @@ pub(super) fn clone(url: &str, target: &Path, token: Option<String>) -> AppResul
 /// errors — the sync engine branches on them (non-fast-forward → pull/merge/
 /// retry; anything else → surface the remote's message).
 pub(super) fn push(root: &Path, token: Option<String>) -> AppResult<PushOutcome> {
-    let repo = open_existing(root)?;
+    let repo = open_for_sync(root)?;
     let branch = current_branch(&repo)?;
     let mut remote = origin(&repo)?;
 

--- a/apps/desktop/src-tauri/src/git/repo.rs
+++ b/apps/desktop/src-tauri/src/git/repo.rs
@@ -36,6 +36,16 @@ pub(super) fn open_existing(root: &Path) -> AppResult<Repository> {
     Ok(Repository::open(root)?)
 }
 
+/// Open a repository for a sync operation and finish any interrupted merge
+/// that can be proven to belong to Reflect. This preflight runs before
+/// `commit_all`, fetch, merge, push, and status, so recovery cannot be blocked
+/// by a later clean-state guard.
+pub(super) fn open_for_sync(root: &Path) -> AppResult<Repository> {
+    let repo = open_existing(root)?;
+    super::merge::recover_interrupted_merge(&repo)?;
+    Ok(repo)
+}
+
 /// Refuse to operate on a repository mid-operation (a rebase/merge the user
 /// started with the git CLI). Guessing here could destroy their state.
 pub(super) fn ensure_clean_state(repo: &Repository) -> AppResult<()> {

--- a/apps/desktop/src-tauri/src/git/tests.rs
+++ b/apps/desktop/src-tauri/src/git/tests.rs
@@ -809,8 +809,6 @@ fn interrupted_app_merge_recovers_before_commit_in_engine_order() {
     let repo = Repository::open(root_a).unwrap();
     assert_eq!(repo.state(), git2::RepositoryState::Merge);
     assert!(repo.path().join("REFLECT_MERGE_STATE").is_file());
-    // Model the zero-byte lock left by the physical iPhone interruption.
-    fs::write(repo.path().join("index.lock"), []).unwrap();
     drop(repo);
 
     // The user can keep editing after the process restarts. Recovery must
@@ -844,7 +842,6 @@ fn interrupted_app_merge_recovers_before_commit_in_engine_order() {
     let repo = Repository::open(root_a).unwrap();
     assert_eq!(repo.state(), git2::RepositoryState::Clean);
     assert!(!repo.path().join("REFLECT_MERGE_STATE").exists());
-    assert!(!repo.path().join("index.lock").exists());
     drop(repo);
     assert!(push(root_a, None).unwrap().pushed);
 
@@ -937,7 +934,6 @@ fn durable_merge_commit_recovers_interrupted_cleanup() {
         2
     );
     assert!(repo.path().join("REFLECT_MERGE_STATE").is_file());
-    fs::write(repo.path().join("index.lock"), []).unwrap();
     drop(repo);
 
     let snapshot = status(root_a).unwrap();
@@ -945,7 +941,93 @@ fn durable_merge_commit_recovers_interrupted_cleanup() {
     let repo = Repository::open(root_a).unwrap();
     assert_eq!(repo.state(), git2::RepositoryState::Clean);
     assert!(!repo.path().join("REFLECT_MERGE_STATE").exists());
-    assert!(!repo.path().join("index.lock").exists());
+}
+
+#[test]
+fn owned_merge_never_removes_an_unowned_index_lock() {
+    let fixture = fixture();
+    let root_a = &fixture.graph_a;
+    write(root_a, "notes/base.md", "# Base\n");
+    commit_all(root_a, "base", MAX_FILE_BYTES).unwrap();
+    push(root_a, None).unwrap();
+
+    let root_b = second_device(&fixture);
+    write(&root_b, "notes/remote.md", "# Remote device\n");
+    commit_all(&root_b, "remote edit", MAX_FILE_BYTES).unwrap();
+    push(&root_b, None).unwrap();
+
+    write(root_a, "notes/local.md", "# This device\n");
+    commit_all(root_a, "local edit", MAX_FILE_BYTES).unwrap();
+    fetch(root_a, None).unwrap();
+    interrupt_next_merge_for_test(root_a).unwrap();
+
+    let repo = Repository::open(root_a).unwrap();
+    let lock = repo.path().join("index.lock");
+    let marker = repo.path().join("REFLECT_MERGE_STATE");
+    fs::write(&lock, b"foreign operation sentinel").unwrap();
+    drop(repo);
+
+    let error = commit_all(root_a, "must wait", MAX_FILE_BYTES).unwrap_err();
+    let crate::error::AppError::Io { message } = error else {
+        panic!("expected an Io error, got {error:?}");
+    };
+    assert!(message.contains("index is locked"), "{message}");
+    assert_eq!(fs::read(&lock).unwrap(), b"foreign operation sentinel");
+    let repo = Repository::open(root_a).unwrap();
+    assert_eq!(repo.state(), git2::RepositoryState::Merge);
+    assert!(marker.is_file());
+    drop(repo);
+
+    // Once the lock owner finishes, the ordinary engine entry point resumes
+    // the same verified merge and clears only Reflect's own state.
+    fs::remove_file(&lock).unwrap();
+    let outcome = commit_all(root_a, "resume after lock", MAX_FILE_BYTES).unwrap();
+    assert!(!outcome.committed);
+    let repo = Repository::open(root_a).unwrap();
+    assert_eq!(repo.state(), git2::RepositoryState::Clean);
+    assert!(!marker.exists());
+}
+
+#[test]
+fn interrupted_edit_vs_delete_preserves_a_post_crash_edit() {
+    let fixture = fixture();
+    let root_a = &fixture.graph_a;
+    write(root_a, "notes/keep.md", "# Keep\n\noriginal\n");
+    commit_all(root_a, "base", MAX_FILE_BYTES).unwrap();
+    push(root_a, None).unwrap();
+
+    let root_b = second_device(&fixture);
+    write(&root_b, "notes/keep.md", "# Keep\n\nedited on b\n");
+    commit_all(&root_b, "b edit", MAX_FILE_BYTES).unwrap();
+    push(&root_b, None).unwrap();
+
+    fs::remove_file(root_a.join("notes/keep.md")).unwrap();
+    commit_all(root_a, "a delete", MAX_FILE_BYTES).unwrap();
+    fetch(root_a, None).unwrap();
+    interrupt_next_merge_for_test(root_a).unwrap();
+
+    // The user edits the conflicted path after relaunch but before the next
+    // sync. Recovery must stage this exact content, not restore B's old blob.
+    write(root_a, "notes/keep.md", "# Keep\n\npost-crash user edit\n");
+    let outcome = commit_all(root_a, "recover and preserve", MAX_FILE_BYTES).unwrap();
+    assert!(!outcome.committed);
+    assert_eq!(
+        read(root_a, "notes/keep.md"),
+        "# Keep\n\npost-crash user edit\n"
+    );
+    let repo = Repository::open(root_a).unwrap();
+    let head = repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.parent_count(), 2);
+    let entry = head
+        .tree()
+        .unwrap()
+        .get_path(Path::new("notes/keep.md"))
+        .unwrap();
+    assert_eq!(
+        repo.find_blob(entry.id()).unwrap().content(),
+        b"# Keep\n\npost-crash user edit\n"
+    );
+    assert_eq!(repo.state(), git2::RepositoryState::Clean);
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/git/tests.rs
+++ b/apps/desktop/src-tauri/src/git/tests.rs
@@ -5,11 +5,14 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use git2::build::CheckoutBuilder;
 use git2::{Repository, RepositoryInitOptions};
 use tempfile::{tempdir, TempDir};
 
 use super::commit::commit_all;
-use super::merge::{merge_remote, MergeKind};
+use super::merge::{
+    finish_interrupted_merge_for_test, interrupt_next_merge_for_test, merge_remote, MergeKind,
+};
 use super::remote::{fetch, push};
 use super::{setup, status, MAX_FILE_BYTES};
 
@@ -740,7 +743,7 @@ fn rename_rename_conflict_keeps_both_names_and_confirms_the_removal() {
 
 #[cfg(unix)]
 #[test]
-fn failed_merge_completion_still_clears_the_merge_state() {
+fn failed_merge_start_does_not_leave_owned_state_behind() {
     use std::os::unix::fs::PermissionsExt;
 
     let fixture = fixture();
@@ -766,18 +769,263 @@ fn failed_merge_completion_still_clears_the_merge_state() {
     fs::set_permissions(&notes_dir, fs::Permissions::from_mode(0o755)).unwrap();
     assert!(result.is_err(), "{result:?}");
 
-    // The contract: a failed merge never wedges the repo mid-merge…
+    // libgit2 rejects this during checkout and cleans its own state. Reflect
+    // drops the marker without touching the user's working tree.
     let repo = Repository::open(root_a).unwrap();
     assert_eq!(repo.state(), git2::RepositoryState::Clean);
+    assert!(!repo.path().join("REFLECT_MERGE_STATE").exists());
     drop(repo);
 
-    // …and the next cycle recovers on its own.
+    // The next cycle can derive and complete the merge normally.
     let merged = merge_remote(root_a).unwrap();
     assert!(
         matches!(merged.kind, MergeKind::MergedWithConflicts),
         "{merged:?}"
     );
     assert_eq!(read(root_a, "notes/keep.md"), "# Keep\n\nedited on b\n");
+}
+
+#[test]
+fn interrupted_app_merge_recovers_before_commit_in_engine_order() {
+    let fixture = fixture();
+    let root_a = &fixture.graph_a;
+    write(root_a, "notes/base.md", "# Base\n");
+    write(root_a, "notes/live.md", "# Live\n\nbase\n");
+    commit_all(root_a, "base", MAX_FILE_BYTES).unwrap();
+    push(root_a, None).unwrap();
+
+    let root_b = second_device(&fixture);
+    write(&root_b, "notes/remote.md", "# Remote device\n");
+    write(&root_b, "notes/live.md", "# Live\n\nremote update\n");
+    commit_all(&root_b, "remote edit", MAX_FILE_BYTES).unwrap();
+    push(&root_b, None).unwrap();
+
+    write(root_a, "notes/local.md", "# This device\n");
+    commit_all(root_a, "local edit", MAX_FILE_BYTES).unwrap();
+    fetch(root_a, None).unwrap();
+
+    interrupt_next_merge_for_test(root_a).unwrap();
+    let repo = Repository::open(root_a).unwrap();
+    assert_eq!(repo.state(), git2::RepositoryState::Merge);
+    assert!(repo.path().join("REFLECT_MERGE_STATE").is_file());
+    // Model the zero-byte lock left by the physical iPhone interruption.
+    fs::write(repo.path().join("index.lock"), []).unwrap();
+    drop(repo);
+
+    // The user can keep editing after the process restarts. Recovery must
+    // preserve both a merge-touched file and a newly created note.
+    write(
+        root_a,
+        "notes/live.md",
+        "# Live\n\nremote update\npost-crash edit\n",
+    );
+    write(root_a, "notes/draft.md", "# Draft after crash\n");
+
+    // Exercise the production engine order. The rejected implementation only
+    // passed when merge_remote was called directly; commit_all runs first.
+    let committed = commit_all(root_a, "Update notes", MAX_FILE_BYTES).unwrap();
+    assert!(committed.committed);
+    {
+        let repo = Repository::open(root_a).unwrap();
+        let edit_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(edit_commit.parent(0).unwrap().parent_count(), 2);
+    }
+    fetch(root_a, None).unwrap();
+    let merged = merge_remote(root_a).unwrap();
+    assert!(matches!(merged.kind, MergeKind::UpToDate), "{merged:?}");
+    assert_eq!(read(root_a, "notes/local.md"), "# This device\n");
+    assert_eq!(read(root_a, "notes/remote.md"), "# Remote device\n");
+    assert_eq!(
+        read(root_a, "notes/live.md"),
+        "# Live\n\nremote update\npost-crash edit\n"
+    );
+    assert_eq!(read(root_a, "notes/draft.md"), "# Draft after crash\n");
+    let repo = Repository::open(root_a).unwrap();
+    assert_eq!(repo.state(), git2::RepositoryState::Clean);
+    assert!(!repo.path().join("REFLECT_MERGE_STATE").exists());
+    assert!(!repo.path().join("index.lock").exists());
+    drop(repo);
+    assert!(push(root_a, None).unwrap().pushed);
+
+    fetch(&root_b, None).unwrap();
+    merge_remote(&root_b).unwrap();
+    assert_eq!(
+        read(&root_b, "notes/live.md"),
+        "# Live\n\nremote update\npost-crash edit\n"
+    );
+    assert_eq!(read(&root_b, "notes/draft.md"), "# Draft after crash\n");
+}
+
+#[test]
+fn stale_marker_is_dropped_after_head_advances() {
+    let fixture = fixture();
+    let root_a = &fixture.graph_a;
+    write(root_a, "notes/base.md", "# Base\n");
+    commit_all(root_a, "base", MAX_FILE_BYTES).unwrap();
+    push(root_a, None).unwrap();
+
+    let root_b = second_device(&fixture);
+    write(&root_b, "notes/remote.md", "# Remote device\n");
+    commit_all(&root_b, "remote edit", MAX_FILE_BYTES).unwrap();
+    push(&root_b, None).unwrap();
+
+    write(root_a, "notes/local.md", "# This device\n");
+    commit_all(root_a, "local edit", MAX_FILE_BYTES).unwrap();
+    fetch(root_a, None).unwrap();
+    interrupt_next_merge_for_test(root_a).unwrap();
+    finish_interrupted_merge_for_test(root_a).unwrap();
+
+    let repo = Repository::open(root_a).unwrap();
+    assert_eq!(repo.state(), git2::RepositoryState::Clean);
+    assert!(repo.path().join("REFLECT_MERGE_STATE").is_file());
+    drop(repo);
+
+    // Advance HEAD without a sync preflight, reproducing a CLI commit or a
+    // kill between cleanup and marker removal followed by outside Git work.
+    write(root_a, "notes/later.md", "# Later edit\n");
+    {
+        let repo = Repository::open(root_a).unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new("notes/later.md")).unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        let parent = repo.head().unwrap().peel_to_commit().unwrap();
+        let sig = repo
+            .signature()
+            .unwrap_or_else(|_| git2::Signature::now("Reflect", "backup@reflect.app").unwrap());
+        repo.commit(Some("HEAD"), &sig, &sig, "later edit", &tree, &[&parent])
+            .unwrap();
+        assert!(repo.path().join("REFLECT_MERGE_STATE").exists());
+    }
+
+    let snapshot = status(root_a).unwrap();
+    assert!(!snapshot.in_progress);
+    let repo = Repository::open(root_a).unwrap();
+    assert!(!repo.path().join("REFLECT_MERGE_STATE").exists());
+    assert_eq!(repo.state(), git2::RepositoryState::Clean);
+}
+
+#[test]
+fn stale_marker_never_clears_a_newer_foreign_merge() {
+    let fixture = fixture();
+    let root_a = &fixture.graph_a;
+    write(root_a, "notes/base.md", "# Base\n");
+    commit_all(root_a, "base", MAX_FILE_BYTES).unwrap();
+    push(root_a, None).unwrap();
+
+    let root_b = second_device(&fixture);
+    write(&root_b, "notes/remote.md", "# Remote device\n");
+    commit_all(&root_b, "remote edit", MAX_FILE_BYTES).unwrap();
+    push(&root_b, None).unwrap();
+
+    write(root_a, "notes/local.md", "# This device\n");
+    commit_all(root_a, "local edit", MAX_FILE_BYTES).unwrap();
+    fetch(root_a, None).unwrap();
+    interrupt_next_merge_for_test(root_a).unwrap();
+    finish_interrupted_merge_for_test(root_a).unwrap();
+
+    let marker_path = Repository::open(root_a)
+        .unwrap()
+        .path()
+        .join("REFLECT_MERGE_STATE");
+    let stale_marker = fs::read(&marker_path).unwrap();
+
+    // Build a topic commit, then restore the stale app marker and start a
+    // foreign merge while HEAD still points at the completed app merge.
+    {
+        let repo = Repository::open(root_a).unwrap();
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.branch("topic", &head, false).unwrap();
+        repo.set_head("refs/heads/topic").unwrap();
+        repo.checkout_head(None).unwrap();
+    }
+    write(root_a, "notes/topic.md", "# Foreign topic\n");
+    commit_all(root_a, "topic", MAX_FILE_BYTES).unwrap();
+    let topic_oid = Repository::open(root_a)
+        .unwrap()
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id();
+    {
+        let repo = Repository::open(root_a).unwrap();
+        repo.set_head("refs/heads/main").unwrap();
+        repo.checkout_head(Some(CheckoutBuilder::new().force()))
+            .unwrap();
+        fs::write(repo.path().join("REFLECT_MERGE_STATE"), stale_marker).unwrap();
+        let annotated = repo.find_annotated_commit(topic_oid).unwrap();
+        repo.merge(&[&annotated], None, None).unwrap();
+        assert_eq!(repo.state(), git2::RepositoryState::Merge);
+    }
+
+    let error = commit_all(root_a, "must not commit", MAX_FILE_BYTES).unwrap_err();
+    let crate::error::AppError::Io { message } = error else {
+        panic!("expected an Io error, got {error:?}");
+    };
+    assert!(message.contains("Merge in progress"), "{message}");
+    let repo = Repository::open(root_a).unwrap();
+    assert_eq!(repo.state(), git2::RepositoryState::Merge);
+    assert_eq!(
+        fs::read_to_string(repo.path().join("MERGE_HEAD"))
+            .unwrap()
+            .trim(),
+        topic_oid.to_string()
+    );
+    assert!(root_a.join("notes/topic.md").is_file());
+    assert!(!repo.path().join("REFLECT_MERGE_STATE").exists());
+}
+
+#[test]
+fn corrupt_recovery_marker_is_discarded_on_status() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+    write(root, "notes/base.md", "# Base\n");
+    commit_all(root, "base", MAX_FILE_BYTES).unwrap();
+    let repo = Repository::open(root).unwrap();
+    let marker = repo.path().join("REFLECT_MERGE_STATE");
+    fs::write(&marker, "not json").unwrap();
+    drop(repo);
+
+    let snapshot = status(root).unwrap();
+    assert!(!snapshot.in_progress);
+    assert!(!marker.exists());
+}
+
+#[test]
+fn foreign_merge_without_reflect_marker_is_not_touched() {
+    let fixture = fixture();
+    let root_a = &fixture.graph_a;
+    write(root_a, "notes/base.md", "# Base\n");
+    commit_all(root_a, "base", MAX_FILE_BYTES).unwrap();
+    push(root_a, None).unwrap();
+
+    let root_b = second_device(&fixture);
+    write(&root_b, "notes/remote.md", "# Remote device\n");
+    commit_all(&root_b, "remote edit", MAX_FILE_BYTES).unwrap();
+    push(&root_b, None).unwrap();
+
+    write(root_a, "notes/local.md", "# This device\n");
+    commit_all(root_a, "local edit", MAX_FILE_BYTES).unwrap();
+    fetch(root_a, None).unwrap();
+    {
+        let repo = Repository::open(root_a).unwrap();
+        let remote_oid = repo.refname_to_id("refs/remotes/origin/main").unwrap();
+        let annotated = repo.find_annotated_commit(remote_oid).unwrap();
+        repo.merge(&[&annotated], None, None).unwrap();
+        assert_eq!(repo.state(), git2::RepositoryState::Merge);
+    }
+
+    let error = merge_remote(root_a).unwrap_err();
+    let crate::error::AppError::Io { message } = error else {
+        panic!("expected an Io error, got {error:?}");
+    };
+    assert!(message.contains("Merge in progress"), "{message}");
+    assert_eq!(
+        Repository::open(root_a).unwrap().state(),
+        git2::RepositoryState::Merge
+    );
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/git/tests.rs
+++ b/apps/desktop/src-tauri/src/git/tests.rs
@@ -11,7 +11,8 @@ use tempfile::{tempdir, TempDir};
 
 use super::commit::commit_all;
 use super::merge::{
-    finish_interrupted_merge_for_test, interrupt_next_merge_for_test, merge_remote, MergeKind,
+    commit_interrupted_merge_without_cleanup_for_test, finish_interrupted_merge_for_test,
+    interrupt_next_merge_for_test, merge_remote, MergeKind,
 };
 use super::remote::{fetch, push};
 use super::{setup, status, MAX_FILE_BYTES};
@@ -904,6 +905,47 @@ fn stale_marker_is_dropped_after_head_advances() {
     let repo = Repository::open(root_a).unwrap();
     assert!(!repo.path().join("REFLECT_MERGE_STATE").exists());
     assert_eq!(repo.state(), git2::RepositoryState::Clean);
+}
+
+#[test]
+fn durable_merge_commit_recovers_interrupted_cleanup() {
+    let fixture = fixture();
+    let root_a = &fixture.graph_a;
+    write(root_a, "notes/base.md", "# Base\n");
+    commit_all(root_a, "base", MAX_FILE_BYTES).unwrap();
+    push(root_a, None).unwrap();
+
+    let root_b = second_device(&fixture);
+    write(&root_b, "notes/remote.md", "# Remote device\n");
+    commit_all(&root_b, "remote edit", MAX_FILE_BYTES).unwrap();
+    push(&root_b, None).unwrap();
+
+    write(root_a, "notes/local.md", "# This device\n");
+    commit_all(root_a, "local edit", MAX_FILE_BYTES).unwrap();
+    fetch(root_a, None).unwrap();
+    interrupt_next_merge_for_test(root_a).unwrap();
+    commit_interrupted_merge_without_cleanup_for_test(root_a).unwrap();
+
+    let repo = Repository::open(root_a).unwrap();
+    assert_eq!(repo.state(), git2::RepositoryState::Merge);
+    assert_eq!(
+        repo.head()
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .parent_count(),
+        2
+    );
+    assert!(repo.path().join("REFLECT_MERGE_STATE").is_file());
+    fs::write(repo.path().join("index.lock"), []).unwrap();
+    drop(repo);
+
+    let snapshot = status(root_a).unwrap();
+    assert!(!snapshot.in_progress);
+    let repo = Repository::open(root_a).unwrap();
+    assert_eq!(repo.state(), git2::RepositoryState::Clean);
+    assert!(!repo.path().join("REFLECT_MERGE_STATE").exists());
+    assert!(!repo.path().join("index.lock").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Follow-up to #1205.

If the process is terminated after libgit2 enters merge state, the next sync currently reaches `commit_all` first and fails its clean-state guard. The device remains at Needs attention. A stale index lock from the interrupted owned merge can block the same path.

## Solution

- atomically record the two merge parents before entering libgit2 merge state
- run recovery in a shared repository-open preflight used by status, commit, fetch, merge, and push
- resume only when HEAD, MERGE_HEAD, and ORIG_HEAD exactly match the app-owned marker
- continue the existing merge index in place; never hard-reset the working tree
- preserve post-crash edits so the immediately following commit captures them
- keep status informative when recovery fails while write paths remain blocked
- treat clean, corrupt, unsupported, or superseded markers as stale metadata
- make marker deletion best-effort after durable completion
- leave foreign CLI merges/rebases and their locks untouched

A generic stale `index.lock` without an app-owned marker remains out of scope and should be handled separately.

## Review feedback addressed

- recovery now runs before `commit_all`
- the end-to-end test follows `commit_all → fetch → merge_remote → push`
- no whole-tree reset
- MERGE_HEAD and ORIG_HEAD are verified
- stale or invalid markers self-heal
- completed-merge cleanup cannot clear a newer foreign operation
- marker writes reuse `atomic_write_to`
- interrupted cleanup after the durable merge commit has direct coverage

## Validation

- `pnpm check`
- `cargo fmt --check`
- `cargo clippy -p reflect-open --all-targets -- -D warnings`
- `cargo test -p reflect-open` — 377 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Interrupted merges now resume automatically when the repository is reopened.
  - Edits made after an interruption are preserved during conflict resolution.
  - Recovery no longer removes an active index lock, preventing interference with other Git operations.
  - Commit, fetch, pull, and push operations now complete pending merge recovery before proceeding.
  - Repository status remains available even when interrupted-merge recovery cannot complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->