### PR TITLE
fix: make list hover feedback instant

### DIFF
--- a/apps/desktop/src/components/all-notes/all-notes-row.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-row.tsx
@@ -50,7 +50,7 @@ export const AllNotesRow = memo(function AllNotesRow({
       }}
       onDoubleClick={(event) => onOpen(note.path, event)}
       className={cn(
-        'group/row relative h-12 cursor-default select-none transition-colors duration-100',
+        'group/row relative h-12 cursor-default select-none',
         ALL_NOTES_GRID,
         selected
           ? 'border-y border-accent/20 bg-accent-soft text-text dark:border-accent/10 dark:text-text'

--- a/apps/desktop/src/components/context-sidebar/daily-events-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/daily-events-section.tsx
@@ -39,7 +39,7 @@ export function DailyEventsSection({ date }: DailyEventsSectionProps): ReactElem
               type="button"
               onClick={() => setPendingEvent(event)}
               title="Add to daily note"
-              className="group flex w-full items-center gap-2 rounded-md px-3 py-1 leading-5 text-text-secondary transition-colors duration-100 hover:bg-surface-hover hover:text-text"
+              className="group flex w-full items-center gap-2 rounded-md px-3 py-1 leading-5 text-text-secondary hover:bg-surface-hover hover:text-text"
             >
               <span className="min-w-0 flex-1 truncate text-left text-xs font-medium">
                 {event.title}

--- a/apps/desktop/src/components/context-sidebar/note-gist-action.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-gist-action.tsx
@@ -90,9 +90,9 @@ export function NoteGistAction({
             type="button"
             onClick={() => void (published ? onUnpublish() : onPublish())}
             disabled={isBusy}
-            className="group relative flex w-full items-center space-x-2 rounded-lg px-3 py-2 text-start transition-colors duration-100 hover:bg-surface-hover disabled:opacity-50"
+            className="group relative flex w-full items-center space-x-2 rounded-lg px-3 py-2 text-start hover:bg-surface-hover disabled:opacity-50"
           >
-            <span className="flex h-5 w-5 flex-none items-center justify-center text-text-muted transition-colors duration-100 group-hover:text-text">
+            <span className="flex h-5 w-5 flex-none items-center justify-center text-text-muted group-hover:text-text">
               <Icon size={14} aria-hidden />
             </span>
             <span className="min-w-0 flex-1 truncate text-xs font-medium">{label}</span>

--- a/apps/desktop/src/components/context-sidebar/note-toggle-action.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-toggle-action.tsx
@@ -59,11 +59,11 @@ export function NoteToggleAction({
       type="button"
       onClick={() => void toggleActive()}
       disabled={isToggling}
-      className="group relative flex w-full items-center space-x-2 rounded-lg px-3 py-2 text-start transition-colors duration-100 hover:bg-surface-hover disabled:opacity-50"
+      className="group relative flex w-full items-center space-x-2 rounded-lg px-3 py-2 text-start hover:bg-surface-hover disabled:opacity-50"
     >
       <span
         className={cn(
-          'flex h-5 w-5 flex-none items-center justify-center transition-colors duration-100',
+          'flex h-5 w-5 flex-none items-center justify-center',
           isActive ? 'text-accent' : 'text-text-muted group-hover:text-text',
         )}
       >

--- a/apps/desktop/src/components/context-sidebar/note-trash-action.tsx
+++ b/apps/desktop/src/components/context-sidebar/note-trash-action.tsx
@@ -63,12 +63,12 @@ export function NoteTrashAction({ path }: NoteTrashActionProps): ReactElement | 
       <button
         type="button"
         onClick={() => setConfirmingTrash(true)}
-        className="group relative flex w-full items-center space-x-2 rounded-lg px-3 py-2 text-start transition-colors duration-100 hover:bg-surface-hover"
+        className="group relative flex w-full items-center space-x-2 rounded-lg px-3 py-2 text-start hover:bg-surface-hover"
       >
-        <span className="flex h-5 w-5 flex-none items-center justify-center text-text-muted transition-colors duration-100 group-hover:text-destructive">
+        <span className="flex h-5 w-5 flex-none items-center justify-center text-text-muted group-hover:text-destructive">
           <Trash2 size={14} aria-hidden />
         </span>
-        <span className="min-w-0 flex-1 truncate text-xs font-medium transition-colors duration-100 group-hover:text-destructive">
+        <span className="min-w-0 flex-1 truncate text-xs font-medium group-hover:text-destructive">
           Trash note
         </span>
       </button>

--- a/apps/desktop/src/components/context-sidebar/similar-notes-section.tsx
+++ b/apps/desktop/src/components/context-sidebar/similar-notes-section.tsx
@@ -44,7 +44,7 @@ export function SimilarNotesSection({ path }: SimilarNotesSectionProps): ReactEl
                   openInNewWindow: isModEvent(event),
                 })
               }
-              className="flex w-full items-center space-x-1 rounded-md px-3 py-1 leading-5 text-text-secondary transition-colors duration-100 hover:bg-surface-hover hover:text-text"
+              className="flex w-full items-center space-x-1 rounded-md px-3 py-1 leading-5 text-text-secondary hover:bg-surface-hover hover:text-text"
             >
               <span className="min-w-0 flex-1 truncate text-left text-xs font-medium">
                 {displayNoteTitle(hit.title)}

--- a/apps/desktop/src/components/graph-chooser.tsx
+++ b/apps/desktop/src/components/graph-chooser.tsx
@@ -91,7 +91,7 @@ export function GraphChooser(): ReactElement {
               return (
                 <li
                   key={recent.root}
-                  className="group flex items-center justify-between gap-2 rounded-md px-2 py-1.5 transition-colors duration-100 hover:bg-surface-hover"
+                  className="group flex items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-surface-hover"
                 >
                   <button
                     type="button"

--- a/apps/desktop/src/components/settings/option-card.tsx
+++ b/apps/desktop/src/components/settings/option-card.tsx
@@ -24,7 +24,7 @@ export function SettingsOptionCard({
   return (
     <label
       className={cn(
-        'flex cursor-pointer rounded-lg border transition-colors duration-100',
+        'flex cursor-pointer rounded-lg border',
         'has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-focus-ring',
         selected ? 'border-accent bg-accent-soft' : 'border-border hover:bg-surface-hover',
         className,

--- a/apps/desktop/src/components/sidebar/sidebar-item.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar-item.tsx
@@ -32,7 +32,6 @@ export function SidebarItem({
       aria-current={active ? 'page' : undefined}
       className={cn(
         'group flex w-full items-center space-x-3 rounded-md px-2.5 py-1.5 text-sm font-medium',
-        'transition-colors duration-100',
         active
           ? 'bg-surface-hover text-text dark:bg-transparent dark:text-accent'
           : 'text-text hover:bg-surface-hover',

--- a/apps/desktop/src/components/sidebar/sidebar-pinned-row-preview.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar-pinned-row-preview.tsx
@@ -25,7 +25,7 @@ export function SidebarPinnedRowPreview({
   return (
     <span
       className={cn(
-        'group flex w-full touch-none items-center rounded-md leading-5 transition-colors duration-[50ms]',
+        'group flex w-full touch-none items-center rounded-md leading-5',
         stateClass,
         overlay && 'shadow-sm',
       )}

--- a/apps/desktop/src/components/tasks/task-row.tsx
+++ b/apps/desktop/src/components/tasks/task-row.tsx
@@ -123,7 +123,7 @@ export function TaskRow({
       data-task-key={taskKey(task)}
       onClick={selectFromRow}
       className={cn(
-        'group/task flex min-h-10 items-start gap-3 border-b border-border bg-surface px-4 py-2 transition-colors duration-100 lg:px-12',
+        'group/task flex min-h-10 items-start gap-3 border-b border-border bg-surface px-4 py-2 lg:px-12',
         !editing && 'cursor-pointer',
         selected
           ? 'bg-accent-soft ring-1 ring-inset ring-accent/20 dark:ring-accent/10'


### PR DESCRIPTION
## Problem

List rows animate their background and related text colors for 50–100 ms. When scanning Tasks, All Notes, or sidebar lists quickly, the outgoing and incoming hover states overlap and make the UI feel sluggish.

## Before -> After

| Before | After |
| --- | --- |
| List hover and selection colors fade over 50–100 ms | List hover and selection colors update immediately |
| Related icon/text feedback in context-sidebar action rows fades separately | The entire row responds as one instantaneous state |

## Changes

1. Remove color-transition utilities from the Tasks and All Notes rows.
2. Apply the same instantaneous list-row convention to sidebar navigation and pinned-note previews, recent graphs, context-sidebar event/note/action rows, and settings option cards.
3. Preserve the existing hover, active, selected, focus, disabled, and destructive colors. Standalone control animations remain unchanged.

## Tests

The existing component suites cover task selection/editing, note-list behavior, sidebar navigation, graph selection, daily events, note actions, gist actions, and similar-note navigation.

## Verification

- `pnpm check` — passed
- `pnpm test --run apps/desktop/src/components/tasks/tasks-screen.test.tsx apps/desktop/src/components/all-notes/all-notes-screen.test.tsx apps/desktop/src/components/sidebar/sidebar.test.tsx apps/desktop/src/components/graph-chooser.test.tsx apps/desktop/src/components/context-sidebar/daily-events-section.test.tsx apps/desktop/src/components/context-sidebar/note-actions-section.test.tsx apps/desktop/src/components/context-sidebar/note-gist-action.test.tsx apps/desktop/src/components/context-sidebar/similar-notes-section.test.tsx` — 157 tests passed

## Risk / Rollout

Low-risk styling-only change. No component state, event handling, data flow, or persisted data changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed brief color-transition animations from note, task, sidebar, settings, graph, and context-menu interactions.
  * Existing hover, selection, focus, layout, and disabled-state styling remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->