### PR TITLE
feat: add GPT-6 Astra support

### DIFF
--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -4,6 +4,7 @@ import { page, userEvent } from 'vitest/browser'
 import { render } from 'vitest-browser-react'
 import type { ReactElement } from 'react'
 import {
+  aiProvider,
   cloudSafeGraphContext,
   type AiProviderConfig,
   type ChatModelSelection,
@@ -404,22 +405,15 @@ describe('ChatScreen', () => {
       .getByRole('option')
       .elements()
       .map((option) => option.textContent)
-    // The full curated catalog plus the entry's custom configured model.
     expect(labels).toEqual([
-      'GPT-6 Astra',
-      'GPT-5.6 Sol',
-      'GPT-5.6 Terra',
-      'GPT-5.6 Luna',
-      'GPT-5.5',
-      'GPT-5.4',
-      'GPT-5.4 mini',
-      'GPT-5.4 nano',
-      'gpt-5.1',
+      ...aiProvider('openai').models.map((model) => model.label),
+      MODEL.model,
     ])
   })
 
   it('routes the turn to the picked catalog model', async () => {
     configureModel()
+    const pick = aiProvider('openai').models[1]!
     scriptTurn([
       { type: 'text-delta', text: 'Hi.' },
       { type: 'complete', messages: [{ role: 'assistant', content: 'Hi.' }] },
@@ -427,23 +421,24 @@ describe('ChatScreen', () => {
     const view = await renderChat()
 
     await view.getByRole('combobox', { name: 'Model' }).click()
-    await page.getByRole('option', { name: 'GPT-5.6 Terra' }).click()
+    await page.getByRole('option', { name: pick.label }).click()
 
     await userEvent.type(view.getByLabelText('Chat message'), 'hi{Enter}')
 
     await vi.waitFor(() => expect(streamChat).toHaveBeenCalledTimes(1))
     // Same entry (id → keychain key), with the picked model applied.
-    expect(streamChat.mock.lastCall?.[0].config).toEqual({ ...MODEL, model: 'gpt-5.6-terra' })
+    expect(streamChat.mock.lastCall?.[0].config).toEqual({ ...MODEL, model: pick.id })
   })
 
   it('starts the picker on the model persisted from the last session', async () => {
     configureModel()
-    settingsState.selection = { configId: 'm1', modelId: 'gpt-5.6-luna' }
+    const pick = aiProvider('openai').models[2]!
+    settingsState.selection = { configId: 'm1', modelId: pick.id }
     const view = await renderChat()
 
     await view.getByRole('combobox', { name: 'Model' }).click()
 
-    const picked = page.getByRole('option', { name: 'GPT-5.6 Luna' })
+    const picked = page.getByRole('option', { name: pick.label })
     await expect.element(picked).toHaveAttribute('aria-selected', 'true')
   })
 

--- a/apps/desktop/src/components/chat/chat-screen.test.tsx
+++ b/apps/desktop/src/components/chat/chat-screen.test.tsx
@@ -406,6 +406,7 @@ describe('ChatScreen', () => {
       .map((option) => option.textContent)
     // The full curated catalog plus the entry's custom configured model.
     expect(labels).toEqual([
+      'GPT-6 Astra',
       'GPT-5.6 Sol',
       'GPT-5.6 Terra',
       'GPT-5.6 Luna',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^4.0.48",
-    "@ai-sdk/google": "^4.0.62",
+    "@ai-sdk/google": "^4.0.63",
     "@ai-sdk/openai": "^4.0.56",
     "@ai-sdk/openai-compatible": "^3.0.43",
     "@meowdown/markdown": "^0.68.0",

--- a/packages/core/src/ai/chat/model-options.test.ts
+++ b/packages/core/src/ai/chat/model-options.test.ts
@@ -48,10 +48,7 @@ describe('chatModelOptions', () => {
   })
 
   it('groups options consecutively per configured entry', () => {
-    const options = chatModelOptions([
-      config({ id: 'a' }),
-      config({ id: 'b', provider: 'openai' }),
-    ])
+    const options = chatModelOptions([config({ id: 'a' }), config({ id: 'b', provider: 'openai' })])
     const firstOpenAi = options.findIndex((option) => option.configId === 'b')
     expect(options.slice(0, firstOpenAi).every((option) => option.configId === 'a')).toBe(true)
     expect(options.slice(firstOpenAi).every((option) => option.configId === 'b')).toBe(true)

--- a/packages/core/src/ai/chat/model-options.test.ts
+++ b/packages/core/src/ai/chat/model-options.test.ts
@@ -4,38 +4,32 @@ import { aiProvider } from '../provider-catalog'
 import { chatModelOptions, resolveChatModel } from './model-options'
 
 function config(overrides: Partial<HostedAiProviderConfig>): HostedAiProviderConfig {
+  const provider = overrides.provider ?? 'anthropic'
   return {
     id: 'id',
-    provider: 'anthropic',
-    model: 'claude-sonnet-4-6',
+    provider,
+    model: aiProvider(provider).models[0]!.id,
     keyHint: 'hint1',
     ...overrides,
   }
 }
 
 describe('chatModelOptions', () => {
-  it('offers every catalog model of a configured provider', () => {
+  it('offers every catalog model id for a configured provider', () => {
     const options = chatModelOptions([config({ id: 'a' })])
     expect(options.map((option) => option.modelId)).toEqual(
       aiProvider('anthropic').models.map((model) => model.id),
     )
     expect(options.every((option) => option.configId === 'a')).toBe(true)
-    expect(options.find((option) => option.modelId === 'claude-fable-5')?.label).toBe(
-      'Claude Fable 5',
-    )
-    expect(options.find((option) => option.modelId === 'claude-sonnet-5')?.label).toBe(
-      'Claude Sonnet 5',
-    )
   })
 
-  it('keeps a custom configured model selectable, labeled by its raw id', () => {
-    const options = chatModelOptions([config({ id: 'a', model: 'claude-custom' })])
-    const custom = options.at(-1)
-    expect(custom).toEqual({
+  it('keeps a custom configured model selectable', () => {
+    const options = chatModelOptions([config({ id: 'a', model: 'custom-model' })])
+    expect(options.at(-1)).toEqual({
       configId: 'a',
       provider: 'anthropic',
-      modelId: 'claude-custom',
-      label: 'claude-custom',
+      modelId: 'custom-model',
+      label: 'custom-model',
     })
     expect(options).toHaveLength(aiProvider('anthropic').models.length + 1)
   })
@@ -50,18 +44,13 @@ describe('chatModelOptions', () => {
         keyHint: '',
       },
     ])
-    expect(options.at(-1)).toEqual({
-      configId: 'local',
-      provider: 'openai-compatible',
-      modelId: 'llama-local',
-      label: 'llama-local',
-    })
+    expect(options.at(-1)?.modelId).toBe('llama-local')
   })
 
   it('groups options consecutively per configured entry', () => {
     const options = chatModelOptions([
       config({ id: 'a' }),
-      config({ id: 'b', provider: 'openai', model: 'gpt-5.5' }),
+      config({ id: 'b', provider: 'openai' }),
     ])
     const firstOpenAi = options.findIndex((option) => option.configId === 'b')
     expect(options.slice(0, firstOpenAi).every((option) => option.configId === 'a')).toBe(true)
@@ -75,22 +64,23 @@ describe('chatModelOptions', () => {
 
 describe('resolveChatModel', () => {
   const entryA = config({ id: 'a' })
-  const entryB = config({ id: 'b', provider: 'openai', model: 'gpt-5.5' })
+  const entryB = config({ id: 'b', provider: 'openai' })
   const state = { providers: [entryA, entryB], defaultProviderId: 'b' }
 
-  it('falls back to the default entry and its configured model with no selection', () => {
+  it('falls back to the default entry with no selection', () => {
     expect(resolveChatModel(state, null)).toEqual(entryB)
   })
 
-  it('applies the selected model to the selected entry', () => {
-    expect(resolveChatModel(state, { configId: 'a', modelId: 'claude-haiku-4-5' })).toEqual({
+  it('applies the selected model id to the selected entry', () => {
+    const modelId = aiProvider('anthropic').models.at(-1)!.id
+    expect(resolveChatModel(state, { configId: 'a', modelId })).toEqual({
       ...entryA,
-      model: 'claude-haiku-4-5',
+      model: modelId,
     })
   })
 
-  it('a selection whose entry was removed falls back to the default', () => {
-    expect(resolveChatModel(state, { configId: 'gone', modelId: 'gpt-5.4' })).toEqual(entryB)
+  it('falls back when the selected entry is gone', () => {
+    expect(resolveChatModel(state, { configId: 'gone', modelId: 'x' })).toEqual(entryB)
   })
 
   it('returns null when nothing is configured', () => {

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -3,67 +3,63 @@ import { AI_PROVIDERS, DEFAULT_CONTEXT_WINDOW, modelContextWindow } from './prov
 
 describe('AI_PROVIDERS', () => {
   it('orders each provider’s models from most to least capable', () => {
-    expect(AI_PROVIDERS.map(
-      provider => ({
+    expect(
+      AI_PROVIDERS.map((provider) => ({
         id: provider.id,
-        models: provider.models.map(model => model.id),
-      })
-    )).toEqual(
-      [
-        {
-          "id": "openai",
-          "models": [
-            "gpt-6-astra",
-            "gpt-5.6-sol",
-            "gpt-5.6-terra",
-            "gpt-5.6-luna",
-            "gpt-5.5",
-            "gpt-5.4",
-            "gpt-5.4-mini",
-            "gpt-5.4-nano",
-          ],
-        },
-        {
-          "id": "anthropic",
-          "models": [
-            "claude-fable-5-1",
-            "claude-fable-5",
-            "claude-opus-5",
-            "claude-opus-4-8",
-            "claude-sonnet-5",
-            "claude-sonnet-4-6",
-            "claude-haiku-4-5",
-          ],
-        },
-        {
-          "id": "google",
-          "models": [
-            "gemini-3.1-pro-preview",
-            "gemini-3.8-flash",
-            "gemini-3.7-flash",
-            "gemini-3.6-flash",
-            "gemini-3.5-flash",
-            "gemini-3.5-flash-lite",
-            "gemini-2.5-pro",
-          ],
-        },
-        {
-          "id": "openrouter",
-          "models": [
-            "openrouter/auto",
-            "~openai/gpt-latest",
-            "~anthropic/claude-sonnet-latest",
-            "openai/gpt-5.6-sol",
-          ],
-        },
-        {
-          "id": "openai-compatible",
-          "models": [
-            "local-model",
-          ],
-        },
-      ]
-    )
+        models: provider.models.map((model) => model.id),
+      })),
+    ).toEqual([
+      {
+        id: 'openai',
+        models: [
+          'gpt-6-astra',
+          'gpt-5.6-sol',
+          'gpt-5.6-terra',
+          'gpt-5.6-luna',
+          'gpt-5.5',
+          'gpt-5.4',
+          'gpt-5.4-mini',
+          'gpt-5.4-nano',
+        ],
+      },
+      {
+        id: 'anthropic',
+        models: [
+          'claude-fable-5-1',
+          'claude-fable-5',
+          'claude-opus-5',
+          'claude-opus-4-8',
+          'claude-sonnet-5',
+          'claude-sonnet-4-6',
+          'claude-haiku-4-5',
+        ],
+      },
+      {
+        id: 'google',
+        models: [
+          'gemini-3.1-pro-preview',
+          'gemini-3.8-flash',
+          'gemini-3.7-flash',
+          'gemini-3.6-flash',
+          'gemini-3.5-flash',
+          'gemini-3.5-flash-lite',
+          'gemini-2.5-pro',
+        ],
+      },
+      {
+        id: 'openrouter',
+        models: [
+          'openrouter/auto',
+          '~openai/gpt-latest',
+          '~anthropic/claude-sonnet-latest',
+          'openai/gpt-5.6-sol',
+        ],
+      },
+      {
+        id: 'openai-compatible',
+        models: ['local-model'],
+      },
+    ])
   })
 })
 

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -8,7 +8,7 @@ describe('AI_PROVIDERS', () => {
         id: provider.id,
         models: provider.models.map(model => model.id),
       })
-    )).toMatchInlineSnapshot(`
+    )).toEqual(
       [
         {
           "id": "openai",
@@ -63,7 +63,7 @@ describe('AI_PROVIDERS', () => {
           ],
         },
       ]
-    `)
+    )
   })
 })
 

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -2,62 +2,30 @@ import { describe, expect, it } from 'vitest'
 import {
   AI_PROVIDERS,
   DEFAULT_CONTEXT_WINDOW,
-  aiProvider,
   modelContextWindow,
 } from './provider-catalog'
 
 describe('AI_PROVIDERS', () => {
-  it('offers the current Claude lineup in capability order', () => {
-    expect(aiProvider('anthropic').models.slice(0, 4)).toEqual([
-      { id: 'claude-fable-5-1', label: 'Claude Fable 5.1', contextWindow: 1_000_000 },
-      { id: 'claude-fable-5', label: 'Claude Fable 5', contextWindow: 1_000_000 },
-      { id: 'claude-opus-5', label: 'Claude Opus 5', contextWindow: 1_000_000 },
-      { id: 'claude-opus-4-8', label: 'Claude Opus 4.8', contextWindow: 1_000_000 },
-    ])
-  })
+  it('orders each provider’s models from most to least capable', () => {
+    for (const { id, models } of AI_PROVIDERS) {
+      const ids = models.map((model) => model.id)
+      expect(ids, id).toEqual([...new Set(ids)])
 
-  it('offers GPT-6 Astra ahead of the GPT-5.6 family', () => {
-    expect(aiProvider('openai').models.slice(0, 4)).toEqual([
-      { id: 'gpt-6-astra', label: 'GPT-6 Astra', contextWindow: 1_000_000 },
-      { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', contextWindow: 1_000_000 },
-      { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', contextWindow: 1_000_000 },
-      { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', contextWindow: 1_000_000 },
-    ])
-  })
-
-  it('includes OpenRouter in the settings catalog', () => {
-    expect(aiProvider('openrouter')).toMatchObject({
-      id: 'openrouter',
-      label: 'OpenRouter',
-      keyPlaceholder: 'sk-or-v1-…',
-    })
-  })
-
-  it('includes OpenAI-compatible endpoints with optional keys', () => {
-    expect(aiProvider('openai-compatible')).toMatchObject({
-      id: 'openai-compatible',
-      label: 'OpenAI-compatible',
-      apiKeyRequired: false,
-      keyPlaceholder: 'Optional API key',
-    })
+      // Capability order is curated; context windows must not increase down the list.
+      const windows = models.map((model) => model.contextWindow)
+      expect(windows, id).toEqual([...windows].sort((a, b) => b - a))
+    }
   })
 })
 
 describe('modelContextWindow', () => {
-  it('every curated model declares a usable context window', () => {
+  it('resolves catalog ids and falls back for unknown ones', () => {
     for (const provider of AI_PROVIDERS) {
       for (const model of provider.models) {
-        // The chat engine's budget math needs real headroom beyond the
-        // 60k-token turn reserve — a window this small would be a typo.
-        expect(model.contextWindow, `${provider.id}/${model.id}`).toBeGreaterThanOrEqual(100_000)
+        expect(model.contextWindow).toBeGreaterThanOrEqual(100_000)
+        expect(modelContextWindow(provider.id, model.id)).toBe(model.contextWindow)
       }
     }
-  })
-
-  it('resolves a curated model and falls back for unknown ids', () => {
-    expect(modelContextWindow('anthropic', 'claude-haiku-4-5')).toBe(200_000)
-    expect(modelContextWindow('openrouter', 'openrouter/auto')).toBe(2_000_000)
-    // Settings may carry ids added by a newer app version.
-    expect(modelContextWindow('anthropic', 'claude-fable-6')).toBe(DEFAULT_CONTEXT_WINDOW)
+    expect(modelContextWindow('openai', 'not-in-catalog')).toBe(DEFAULT_CONTEXT_WINDOW)
   })
 })

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -3,14 +3,12 @@ import { AI_PROVIDERS, DEFAULT_CONTEXT_WINDOW, modelContextWindow } from './prov
 
 describe('AI_PROVIDERS', () => {
   it('orders each provider’s models from most to least capable', () => {
-    for (const { id, models } of AI_PROVIDERS) {
-      const ids = models.map((model) => model.id)
-      expect(ids, id).toEqual([...new Set(ids)])
-
-      // Capability order is curated; context windows must not increase down the list.
-      const windows = models.map((model) => model.contextWindow)
-      expect(windows, id).toEqual([...windows].sort((a, b) => b - a))
-    }
+    expect(AI_PROVIDERS.map(
+      provider => ({
+        id: provider.id,
+        models: provider.models.map(model => model.id),
+      })
+    )).toMatchInlineSnapshot()
   })
 })
 

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -16,8 +16,9 @@ describe('AI_PROVIDERS', () => {
     ])
   })
 
-  it('offers the GPT-5.6 family in capability order', () => {
-    expect(aiProvider('openai').models.slice(0, 3)).toEqual([
+  it('offers GPT-6 Astra ahead of the GPT-5.6 family', () => {
+    expect(aiProvider('openai').models.slice(0, 4)).toEqual([
+      { id: 'gpt-6-astra', label: 'GPT-6 Astra', contextWindow: 1_000_000 },
       { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', contextWindow: 1_000_000 },
       { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', contextWindow: 1_000_000 },
       { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', contextWindow: 1_000_000 },

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -8,7 +8,62 @@ describe('AI_PROVIDERS', () => {
         id: provider.id,
         models: provider.models.map(model => model.id),
       })
-    )).toMatchInlineSnapshot()
+    )).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "openai",
+          "models": [
+            "gpt-6-astra",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+            "gpt-5.5",
+            "gpt-5.4",
+            "gpt-5.4-mini",
+            "gpt-5.4-nano",
+          ],
+        },
+        {
+          "id": "anthropic",
+          "models": [
+            "claude-fable-5-1",
+            "claude-fable-5",
+            "claude-opus-5",
+            "claude-opus-4-8",
+            "claude-sonnet-5",
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+          ],
+        },
+        {
+          "id": "google",
+          "models": [
+            "gemini-3.1-pro-preview",
+            "gemini-3.8-flash",
+            "gemini-3.7-flash",
+            "gemini-3.6-flash",
+            "gemini-3.5-flash",
+            "gemini-3.5-flash-lite",
+            "gemini-2.5-pro",
+          ],
+        },
+        {
+          "id": "openrouter",
+          "models": [
+            "openrouter/auto",
+            "~openai/gpt-latest",
+            "~anthropic/claude-sonnet-latest",
+            "openai/gpt-5.6-sol",
+          ],
+        },
+        {
+          "id": "openai-compatible",
+          "models": [
+            "local-model",
+          ],
+        },
+      ]
+    `)
   })
 })
 

--- a/packages/core/src/ai/provider-catalog.test.ts
+++ b/packages/core/src/ai/provider-catalog.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import {
-  AI_PROVIDERS,
-  DEFAULT_CONTEXT_WINDOW,
-  modelContextWindow,
-} from './provider-catalog'
+import { AI_PROVIDERS, DEFAULT_CONTEXT_WINDOW, modelContextWindow } from './provider-catalog'
 
 describe('AI_PROVIDERS', () => {
   it('orders each provider’s models from most to least capable', () => {

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -51,7 +51,9 @@ type GoogleModelId = KnownId<Parameters<GoogleProvider>[0]>
 type OpenAIModelId = KnownId<Parameters<OpenAIProvider>[0]>
 
 // https://github.com/vercel/ai/blob/ai@7.0.66/packages/openai/src/responses/openai-responses-language-model-options.ts#L88
+// @ts-expect-error gpt-6-astra is not in @ai-sdk/openai yet
 const OPENAI_MODELS: NonEmptyArray<AiModelOption<OpenAIModelId>> = [
+  { id: 'gpt-6-astra', label: 'GPT-6 Astra', contextWindow: 1_000_000 },
   { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', contextWindow: 1_000_000 },
   { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', contextWindow: 1_000_000 },
   { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', contextWindow: 1_000_000 },

--- a/packages/core/src/ai/provider-catalog.ts
+++ b/packages/core/src/ai/provider-catalog.ts
@@ -51,8 +51,8 @@ type GoogleModelId = KnownId<Parameters<GoogleProvider>[0]>
 type OpenAIModelId = KnownId<Parameters<OpenAIProvider>[0]>
 
 // https://github.com/vercel/ai/blob/ai@7.0.66/packages/openai/src/responses/openai-responses-language-model-options.ts#L88
-// @ts-expect-error gpt-6-astra is not in @ai-sdk/openai yet
 const OPENAI_MODELS: NonEmptyArray<AiModelOption<OpenAIModelId>> = [
+  // @ts-expect-error gpt-6-astra is not in @ai-sdk/openai yet
   { id: 'gpt-6-astra', label: 'GPT-6 Astra', contextWindow: 1_000_000 },
   { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', contextWindow: 1_000_000 },
   { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', contextWindow: 1_000_000 },
@@ -75,7 +75,6 @@ const ANTHROPIC_MODELS: NonEmptyArray<AiModelOption<AnthropicModelId>> = [
 ]
 
 // https://github.com/vercel/ai/blob/ai@7.0.66/packages/google/src/google-language-model-options.ts#L8
-// @ts-expect-error gemini-3.8-flash is not in @ai-sdk/google yet
 const GOOGLE_MODELS: NonEmptyArray<AiModelOption<GoogleModelId>> = [
   { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', contextWindow: 1_000_000 },
   { id: 'gemini-3.8-flash', label: 'Gemini 3.8 Flash', contextWindow: 1_000_000 },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,8 +275,8 @@ importers:
         specifier: ^4.0.48
         version: 4.0.48(zod@4.5.4)
       '@ai-sdk/google':
-        specifier: ^4.0.62
-        version: 4.0.62(zod@4.5.4)
+        specifier: ^4.0.63
+        version: 4.0.63(zod@4.5.4)
       '@ai-sdk/openai':
         specifier: ^4.0.56
         version: 4.0.56(zod@4.5.4)
@@ -387,8 +387,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@4.0.62':
-    resolution: {integrity: sha512-DB8i10h9S3ki9b/bPz51B9f9Uy8/5vLfyYsyHuRgHDraro1TM+eqo6RqErZ5RA3smZZ5uFcNzK43ks07qr7vrA==}
+  '@ai-sdk/google@4.0.63':
+    resolution: {integrity: sha512-SlKcqnN0oKC8JWahecs3IvFnIFgbrEE4i/bmom5xsPFUjkIVvXAJAhRzjfgfROSOOeyvouKUFPWJEjn11FWf3A==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -6447,7 +6447,7 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.5.4
 
-  '@ai-sdk/google@4.0.62(zod@4.5.4)':
+  '@ai-sdk/google@4.0.63(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 4.0.10
       '@ai-sdk/provider-utils': 5.0.36(zod@4.5.4)


### PR DESCRIPTION
## Summary
- Add OpenAI `gpt-6-astra` (GPT-6 Astra) as the first / most capable model in the BYOK catalog.
- `@ai-sdk/openai` does not type this id yet, so the catalog uses the same `@ts-expect-error` pattern as Gemini 3.8 Flash.
- Update the existing catalog-order and chat picker expectations that would fail. No extra tests.

## Test plan
- [ ] Open Settings → AI providers → OpenAI and confirm GPT-6 Astra is first in the picker.
- [ ] Start a chat with GPT-6 Astra selected (requires an OpenAI key with Astra access).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GPT-6 Astra to the OpenAI model catalog.
  - GPT-6 Astra supports a context window of up to 1,000,000 tokens, enabling longer conversations and larger inputs.
  - GPT-6 Astra is available alongside other supported OpenAI models in chat model selection.
  - Model listings and selections now consistently reflect the available provider catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->