### PR TITLE
fix: preserve local edits during Git sync

### DIFF
--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -473,6 +473,8 @@ fn downscale_jpeg(bytes: &[u8], max_dim: u32) -> AppResult<Vec<u8>> {
 }
 
 fn persist_asset(root: &Path, asset_path: &str, bytes: &[u8]) -> AppResult<()> {
+    let gate = crate::fs::mutation::gate(root)?;
+    let _writer = crate::fs::mutation::writer(&gate)?;
     let target = crate::fs::resolve_in_graph(root, asset_path)?;
     let parent = target
         .parent()

--- a/apps/desktop/src-tauri/src/fs/io.rs
+++ b/apps/desktop/src-tauri/src/fs/io.rs
@@ -288,6 +288,8 @@ pub(super) fn atomic_create(
     target: &Path,
     contents: &str,
 ) -> AppResult<AtomicCreateOutcome> {
+    let gate = super::mutation::gate(root)?;
+    let _writer = super::mutation::writer(&gate)?;
     // An evicted iCloud note occupies its logical path through the placeholder
     // alone. `persist_noclobber(target)` cannot see that sibling stub, so keep
     // the shared occupancy check in front of the atomic real-file claim.
@@ -322,6 +324,8 @@ pub(crate) fn atomic_write_bytes(
     target: &Path,
     contents: &[u8],
 ) -> AppResult<Option<u64>> {
+    let gate = super::mutation::gate(root)?;
+    let _writer = super::mutation::writer(&gate)?;
     let tmp = stage_bytes(root, target, contents)?;
     let file = tmp
         .persist(target)

--- a/apps/desktop/src-tauri/src/fs/io.rs
+++ b/apps/desktop/src-tauri/src/fs/io.rs
@@ -268,8 +268,30 @@ fn set_local_only_xattrs(dir: &Path) -> Vec<String> {
 
 /// Atomically write `contents` to `target` inside the graph at `root`.
 /// Returns the persisted file's mtime (see [`atomic_write_bytes`]).
+#[cfg(test)]
 pub(super) fn atomic_write(root: &Path, target: &Path, contents: &str) -> AppResult<Option<u64>> {
     atomic_write_bytes(root, target, contents.as_bytes())
+}
+
+/// Run on the blocking pool: saves wait for local checkout, then revalidate the
+/// graph session before writing. This keeps quit-time flushes from losing a
+/// dirty buffer merely because a merge held the gate.
+pub(super) fn write_note(
+    root: &Path,
+    path: &str,
+    contents: &str,
+    validate: impl FnOnce() -> AppResult<()>,
+) -> AppResult<Option<u64>> {
+    let gate = super::mutation::gate(root)?;
+    let _writer = gate
+        .read()
+        .map_err(|_| AppError::io("graph mutation gate poisoned"))?;
+    validate()?;
+    persist_bytes(
+        root,
+        &super::resolve::resolve(root, path)?,
+        contents.as_bytes(),
+    )
 }
 
 /// Result of an atomic create-if-absent attempt.
@@ -326,6 +348,10 @@ pub(crate) fn atomic_write_bytes(
 ) -> AppResult<Option<u64>> {
     let gate = super::mutation::gate(root)?;
     let _writer = super::mutation::writer(&gate)?;
+    persist_bytes(root, target, contents)
+}
+
+fn persist_bytes(root: &Path, target: &Path, contents: &[u8]) -> AppResult<Option<u64>> {
     let tmp = stage_bytes(root, target, contents)?;
     let file = tmp
         .persist(target)

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -11,6 +11,7 @@ pub mod assets;
 mod import;
 mod import_assets;
 mod io;
+pub(crate) mod mutation;
 mod resolve;
 
 use std::fs;
@@ -482,6 +483,8 @@ pub fn audio_memo_delete(path: String, generation: u64, state: State<GraphState>
         )));
     }
     let root = root_for_generation(&state, generation)?;
+    let gate = mutation::gate(&root)?;
+    let _writer = mutation::writer(&gate)?;
     let abs = resolve(&root, &path)?;
     // An iCloud-evicted segment exists only as its `.name.icloud` stub —
     // mirror `note_delete` so a cancelled session's evicted parts still
@@ -710,6 +713,8 @@ pub fn note_exists(path: String, state: State<GraphState>) -> AppResult<bool> {
 /// reports failed. One rule, no adoption heuristics; the filename drifts
 /// until the next settled rename retries.
 pub(crate) fn move_note_file(root: &Path, from: &str, to: &str) -> AppResult<()> {
+    let gate = mutation::gate(root)?;
+    let _writer = mutation::writer(&gate)?;
     let from_abs = resolve(root, from)?;
     let to_abs = resolve(root, to)?;
     // Occupied includes an evicted iCloud note (placeholder only on disk):
@@ -736,6 +741,8 @@ pub(crate) fn move_note_file(root: &Path, from: &str, to: &str) -> AppResult<()>
 #[tauri::command]
 pub fn note_delete(path: String, generation: u64, state: State<GraphState>) -> AppResult<()> {
     let root = root_for_generation(&state, generation)?;
+    let gate = mutation::gate(&root)?;
+    let _writer = mutation::writer(&gate)?;
     let abs = resolve(&root, &path)?;
     // An iCloud-evicted note exists only as its `.name.md.icloud` stub —
     // trashing the logical path would fail and the note would be
@@ -771,6 +778,9 @@ pub fn note_delete(path: String, generation: u64, state: State<GraphState>) -> A
 pub fn graph_delete(generation: u64, state: State<GraphState>) -> AppResult<()> {
     #[cfg(desktop)]
     {
+        let root = root_for_generation(&state, generation)?;
+        let gate = mutation::gate(&root)?;
+        let _writer = mutation::writer(&gate)?;
         // Check-and-invalidate under one lock hold — `root_for_generation`
         // followed by a separate invalidation would leave a window where a
         // pinned write still resolves the doomed root.

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -24,9 +24,7 @@ use tauri_plugin_opener::OpenerExt;
 
 use crate::error::{AppError, AppResult};
 
-use self::io::{
-    atomic_create, atomic_write, bootstrap, collect_files, initialize_runtime, AtomicCreateOutcome,
-};
+use self::io::{atomic_create, bootstrap, collect_files, initialize_runtime, AtomicCreateOutcome};
 use self::resolve::resolve;
 
 /// Cancellation flag for the running Reflect V1 import, managed as Tauri
@@ -417,16 +415,22 @@ pub async fn note_read_local(
 /// with the value a later `list_files` will report — a `Date.now()` stamp
 /// never matches and costs a re-read on every reconcile.
 #[tauri::command]
-pub fn note_write(
+pub async fn note_write(
     path: String,
     contents: String,
     generation: u64,
-    state: State<GraphState>,
+    app: tauri::AppHandle,
 ) -> AppResult<Option<u64>> {
-    let root = root_for_generation(&state, generation)?;
-    let modified_ms = atomic_write(&root, &resolve(&root, &path)?, &contents)?;
-    invalidate_file_catalog(&state, &root);
-    Ok(modified_ms)
+    crate::blocking::run_blocking(move || {
+        let state = app.state::<GraphState>();
+        let root = root_for_generation(&state, generation)?;
+        let modified_ms = io::write_note(&root, &path, &contents, || {
+            root_for_generation(&state, generation).map(|_| ())
+        })?;
+        invalidate_file_catalog(&state, &root);
+        Ok(modified_ms)
+    })
+    .await
 }
 
 /// Atomically create a note only when `path` is still free. Unlike

--- a/apps/desktop/src-tauri/src/fs/mutation.rs
+++ b/apps/desktop/src-tauri/src/fs/mutation.rs
@@ -7,8 +7,8 @@ use crate::error::{AppError, AppResult};
 type Locks = HashMap<PathBuf, Weak<RwLock<()>>>;
 
 /// One gate per canonical graph, shared by all windows and native writers.
-/// Network operations never acquire this gate. Writers fail promptly during
-/// a checkout instead of blocking the UI; their caller retains the unsaved edit.
+/// Network operations never acquire this gate. Synchronous writers refuse
+/// promptly; note saves wait on the blocking pool and revalidate their session.
 pub(crate) fn gate(root: &Path) -> AppResult<Arc<RwLock<()>>> {
     static LOCKS: OnceLock<Mutex<Locks>> = OnceLock::new();
     let root = root.canonicalize()?;
@@ -37,6 +37,63 @@ pub(crate) fn writer(gate: &RwLock<()>) -> AppResult<RwLockReadGuard<'_, ()>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn note_save_waits_for_checkout_then_writes_the_complete_buffer() {
+        let graph = tempfile::tempdir().unwrap();
+        let gate = gate(graph.path()).unwrap();
+        let checkout = gate.write().unwrap();
+        let root = graph.path().to_path_buf();
+        let (started, waiting) = std::sync::mpsc::channel();
+        let (finished, result) = std::sync::mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            started.send(()).unwrap();
+            finished
+                .send(crate::fs::io::write_note(
+                    &root,
+                    "note.md",
+                    "queued saved edit",
+                    || Ok(()),
+                ))
+                .unwrap();
+        });
+        waiting.recv().unwrap();
+        assert!(result.try_recv().is_err());
+        std::fs::write(graph.path().join("note.md"), "incoming checkout").unwrap();
+        drop(checkout);
+        result.recv().unwrap().unwrap();
+        writer.join().unwrap();
+        assert_eq!(
+            std::fs::read(graph.path().join("note.md")).unwrap(),
+            b"queued saved edit"
+        );
+    }
+
+    #[test]
+    fn queued_note_save_revalidates_its_generation_after_checkout() {
+        let graph = tempfile::tempdir().unwrap();
+        let gate = gate(graph.path()).unwrap();
+        let checkout = gate.write().unwrap();
+        let current = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let validation = current.clone();
+        let root = graph.path().to_path_buf();
+        let (started, waiting) = std::sync::mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            started.send(()).unwrap();
+            crate::fs::io::write_note(&root, "note.md", "stale edit", || {
+                if validation.load(std::sync::atomic::Ordering::SeqCst) {
+                    Ok(())
+                } else {
+                    Err(AppError::io("graph switched"))
+                }
+            })
+        });
+        waiting.recv().unwrap();
+        current.store(false, std::sync::atomic::Ordering::SeqCst);
+        drop(checkout);
+        assert!(writer.join().unwrap().is_err());
+        assert!(!graph.path().join("note.md").exists());
+    }
 
     #[test]
     fn checkout_refuses_writes_promptly_across_handles_but_not_other_graphs() {

--- a/apps/desktop/src-tauri/src/fs/mutation.rs
+++ b/apps/desktop/src-tauri/src/fs/mutation.rs
@@ -1,0 +1,65 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock, RwLock, RwLockReadGuard, Weak};
+
+use crate::error::{AppError, AppResult};
+
+type Locks = HashMap<PathBuf, Weak<RwLock<()>>>;
+
+/// One gate per canonical graph, shared by all windows and native writers.
+/// Network operations never acquire this gate. Writers fail promptly during
+/// a checkout instead of blocking the UI; their caller retains the unsaved edit.
+pub(crate) fn gate(root: &Path) -> AppResult<Arc<RwLock<()>>> {
+    static LOCKS: OnceLock<Mutex<Locks>> = OnceLock::new();
+    let root = root.canonicalize()?;
+    let mut locks = LOCKS
+        .get_or_init(Mutex::default)
+        .lock()
+        .map_err(|_| AppError::io("graph mutation registry poisoned"))?;
+    locks.retain(|_, lock| lock.strong_count() > 0);
+    if let Some(lock) = locks.get(&root).and_then(Weak::upgrade) {
+        return Ok(lock);
+    }
+    let lock = Arc::new(RwLock::new(()));
+    locks.insert(root, Arc::downgrade(&lock));
+    Ok(lock)
+}
+
+/// Admit a short filesystem mutation without waiting on a sync checkout.
+pub(crate) fn writer(gate: &RwLock<()>) -> AppResult<RwLockReadGuard<'_, ()>> {
+    gate.try_read().map_err(|_| {
+        AppError::io(
+            "Git sync is updating this graph; the edit has not been written, retry saving shortly",
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checkout_refuses_writes_promptly_across_handles_but_not_other_graphs() {
+        let graph = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let first = gate(graph.path()).unwrap();
+        let second = gate(&graph.path().join(".")).unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+        let checkout = first.write().unwrap();
+        assert!(crate::fs::atomic_write_bytes(
+            graph.path(),
+            &graph.path().join("note.md"),
+            b"edit"
+        )
+        .is_err());
+        crate::fs::atomic_write_bytes(other.path(), &other.path().join("note.md"), b"other")
+            .unwrap();
+        drop(checkout);
+        crate::fs::atomic_write_bytes(graph.path(), &graph.path().join("note.md"), b"edit")
+            .unwrap();
+        assert_eq!(
+            std::fs::read(graph.path().join("note.md")).unwrap(),
+            b"edit"
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/git/checkout.rs
+++ b/apps/desktop/src-tauri/src/git/checkout.rs
@@ -125,6 +125,7 @@ pub(super) fn install(
     Ok(())
 }
 
+/// Preflight the complete diff so predictable failures happen before any move.
 fn plan(
     repo: &Repository,
     root: &Path,
@@ -178,6 +179,7 @@ fn plan(
     Ok(changes)
 }
 
+/// Keep displaced inodes alive and atomically claim replacements, never truncate.
 fn apply(
     repo: &Repository,
     root: &Path,
@@ -235,6 +237,7 @@ fn apply(
     Ok(())
 }
 
+/// Roll back in reverse order while retaining any file another writer installed.
 fn restore(root: &Path, recovery: &Path, changes: &[Change]) -> AppResult<()> {
     for change in changes.iter().rev() {
         let target = checked_path(root, &change.path)?;
@@ -258,10 +261,12 @@ fn restore(root: &Path, recovery: &Path, changes: &[Change]) -> AppResult<()> {
     Ok(())
 }
 
+/// Compare bytes, not stat-cache hints, before risking a working-tree replacement.
 fn verify(repo: &Repository, path: &Path, expected: Option<Oid>) -> AppResult<()> {
     let matches = match (fs::symlink_metadata(path), expected) {
         (Ok(metadata), Some(expected)) if metadata.is_file() => {
-            fs::read(path)? == repo.find_blob(expected)?.content()
+            let blob = repo.find_blob(expected)?;
+            metadata.len() == blob.size() as u64 && fs::read(path)? == blob.content()
         }
         (Err(error), None) if error.kind() == std::io::ErrorKind::NotFound => true,
         (Err(error), _) if error.kind() != std::io::ErrorKind::NotFound => return Err(error.into()),
@@ -276,6 +281,7 @@ fn verify(repo: &Repository, path: &Path, expected: Option<Oid>) -> AppResult<()
     Ok(())
 }
 
+/// Refuse paths that could redirect an installation into metadata or symlinks.
 fn checked_path(root: &Path, path: &str) -> AppResult<PathBuf> {
     if path.contains('\\') || path.contains(':') {
         return Err(AppError::io(format!(
@@ -302,6 +308,7 @@ fn checked_path(root: &Path, path: &str) -> AppResult<PathBuf> {
     Ok(target)
 }
 
+/// Establish recovery evidence before starting any destructive rename.
 fn write_synced(path: &Path, bytes: &[u8]) -> AppResult<()> {
     let mut file = File::options().create_new(true).write(true).open(path)?;
     file.write_all(bytes)?;
@@ -310,6 +317,7 @@ fn write_synced(path: &Path, bytes: &[u8]) -> AppResult<()> {
     Ok(())
 }
 
+/// Persist directory-entry updates where directory fsync is supported.
 fn sync_parent(path: &Path) -> AppResult<()> {
     #[cfg(unix)]
     File::open(
@@ -322,6 +330,7 @@ fn sync_parent(path: &Path) -> AppResult<()> {
     Ok(())
 }
 
+/// Replace an index as a complete file while the caller holds index.lock.
 fn replace_file(path: &Path, bytes: &[u8]) -> AppResult<()> {
     let mut staged = tempfile::NamedTempFile::new_in(
         path.parent()

--- a/apps/desktop/src-tauri/src/git/checkout.rs
+++ b/apps/desktop/src-tauri/src/git/checkout.rs
@@ -1,0 +1,526 @@
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use git2::{Oid, Repository, Tree};
+
+use crate::error::{AppError, AppResult};
+
+use super::repo::{current_branch, is_runtime, signature};
+
+struct Change {
+    path: String,
+    before: Option<Oid>,
+    after: Option<Oid>,
+    executable: bool,
+    moved: bool,
+    installed: bool,
+}
+
+/// Install a prepared tree without ever truncating an existing worktree file.
+/// Originals are moved to a persistent recovery directory before a no-clobber
+/// claim. This also preserves writes through an external writer's open file
+/// descriptor. HEAD moves last; failures restore the index and worktree without
+/// overwriting a racing writer. A crash marker prevents committing a partial pull.
+pub(super) fn install(
+    repo: &Repository,
+    root: &Path,
+    branch: &str,
+    expected: Option<Oid>,
+    target: Oid,
+    old: Option<&Tree<'_>>,
+    new: &Tree<'_>,
+) -> AppResult<()> {
+    let mut changes = plan(repo, root, old, new)?;
+    let refname = format!("refs/heads/{branch}");
+    let mut transaction = repo.transaction()?;
+    transaction.lock_ref("HEAD")?;
+    transaction.lock_ref(&refname)?;
+    if current_branch(repo)? != branch || repo.refname_to_id(&refname).ok() != expected {
+        return Err(AppError::io("Git HEAD changed during sync; retry"));
+    }
+    let lock_path = repo.path().join("index.lock");
+    let index_lock = File::options()
+        .write(true)
+        .create_new(true)
+        .open(&lock_path)?;
+    let _lock = IndexLock {
+        path: lock_path,
+        _file: index_lock,
+    };
+    let current_index = repo.index()?.write_tree()?;
+    let empty = git2::Index::new()?.write_tree_to(repo)?;
+    if current_index != old.map_or(empty, Tree::id) {
+        return Err(AppError::io("Git index changed during sync; retry"));
+    }
+    let recovery_root = repo.path().join("reflect-sync");
+    fs::create_dir_all(&recovery_root)?;
+    let recovery = tempfile::Builder::new()
+        .prefix("checkout-")
+        .tempdir_in(&recovery_root)?
+        .keep();
+    let pending = recovery_root.join("pending");
+    let index_path = repo.path().join("index");
+    let old_index = match fs::read(&index_path) {
+        Ok(bytes) => Some(bytes),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error.into()),
+    };
+    if let Some(bytes) = &old_index {
+        write_synced(&recovery.join("index-before"), bytes)?;
+    }
+    let manifest = serde_json::json!({
+        "branch": branch,
+        "before": expected.map(|oid| oid.to_string()),
+        "after": target.to_string(),
+        "paths": changes.iter().map(|change| &change.path).collect::<Vec<_>>(),
+    });
+    write_synced(
+        &recovery.join("manifest.json"),
+        &serde_json::to_vec_pretty(&manifest).map_err(|error| AppError::io(error.to_string()))?,
+    )?;
+    write_synced(&pending, recovery.to_string_lossy().as_bytes())?;
+
+    let mut index_written = false;
+    let result: AppResult<()> = (|| {
+        apply(repo, root, &recovery, &mut changes, |_, _| Ok(()))?;
+        let mut prepared_index = git2::Index::open(&recovery.join("index-after"))?;
+        prepared_index.read_tree(new)?;
+        prepared_index.write()?;
+        replace_file(&index_path, &fs::read(recovery.join("index-after"))?)?;
+        index_written = true;
+        let sig = signature(repo)?;
+        transaction.set_target(&refname, target, Some(&sig), "reflect sync")?;
+        transaction.commit()?;
+        Ok(())
+    })();
+
+    if let Err(error) = result {
+        if index_written && repo.refname_to_id(&refname).ok() == Some(target) {
+            fs::remove_file(pending)?;
+            return Ok(());
+        }
+        let rollback = (|| {
+            if index_written {
+                match old_index {
+                    Some(bytes) => replace_file(&index_path, &bytes)?,
+                    None => fs::remove_file(&index_path)?,
+                }
+            }
+            restore(root, &recovery, &changes)?;
+            fs::remove_file(&pending)?;
+            Ok::<_, AppError>(())
+        })();
+        return Err(AppError::io(format!(
+            "Git sync failed: {error:?}. Recovery files: {}. {}",
+            recovery.display(),
+            if rollback.is_ok() {
+                "HEAD and index are unchanged; retry after checking local files".to_string()
+            } else {
+                format!("Recovery needs attention: {rollback:?}; do not reset --hard")
+            }
+        )));
+    }
+    fs::remove_file(pending)?;
+    Ok(())
+}
+
+fn plan(
+    repo: &Repository,
+    root: &Path,
+    old: Option<&Tree<'_>>,
+    new: &Tree<'_>,
+) -> AppResult<Vec<Change>> {
+    let diff = repo.diff_tree_to_tree(old, Some(new), None)?;
+    let mut changes = Vec::new();
+    for delta in diff.deltas() {
+        let file = if delta.status() == git2::Delta::Deleted {
+            delta.old_file()
+        } else {
+            delta.new_file()
+        };
+        let path = file
+            .path()
+            .and_then(Path::to_str)
+            .ok_or_else(|| AppError::io("unsupported Git path"))?;
+        if is_runtime(path.as_bytes()) {
+            continue;
+        }
+        checked_path(root, path)?;
+        for side in [delta.old_file(), delta.new_file()] {
+            if !side.id().is_zero()
+                && !matches!(
+                    side.mode(),
+                    git2::FileMode::Blob | git2::FileMode::BlobExecutable
+                )
+            {
+                return Err(AppError::io(format!(
+                    "Git sync refuses non-regular file: {path}"
+                )));
+            }
+        }
+        let mut before = (!delta.old_file().id().is_zero()).then(|| delta.old_file().id());
+        let after = (!delta.new_file().id().is_zero()).then(|| delta.new_file().id());
+        if before.is_none() && after.is_some() && fs::symlink_metadata(root.join(path)).is_ok() {
+            verify(repo, &root.join(path), after)?;
+            before = after;
+        }
+        verify(repo, &root.join(path), before)?;
+        changes.push(Change {
+            path: path.to_owned(),
+            before,
+            after,
+            executable: delta.new_file().mode() == git2::FileMode::BlobExecutable,
+            moved: false,
+            installed: false,
+        });
+    }
+    Ok(changes)
+}
+
+fn apply(
+    repo: &Repository,
+    root: &Path,
+    recovery: &Path,
+    changes: &mut [Change],
+    mut boundary: impl FnMut(&str, &str) -> AppResult<()>,
+) -> AppResult<()> {
+    for change in changes {
+        boundary(&change.path, "before")?;
+        let target = checked_path(root, &change.path)?;
+        verify(repo, &target, change.before)?;
+        if change.before.is_some() {
+            let original = recovery.join("original").join(&change.path);
+            fs::create_dir_all(
+                original
+                    .parent()
+                    .ok_or_else(|| AppError::io("missing recovery parent"))?,
+            )?;
+            fs::rename(&target, &original)?;
+            change.moved = true;
+            sync_parent(&original)?;
+            sync_parent(&target)?;
+            boundary(&change.path, "moved")?;
+            verify(repo, &original, change.before)?;
+        }
+        if let Some(after) = change.after {
+            fs::create_dir_all(
+                target
+                    .parent()
+                    .ok_or_else(|| AppError::io("missing checkout parent"))?,
+            )?;
+            let mut staged = tempfile::NamedTempFile::new_in(recovery)?;
+            staged.write_all(repo.find_blob(after)?.content())?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                staged
+                    .as_file()
+                    .set_permissions(fs::Permissions::from_mode(if change.executable {
+                        0o755
+                    } else {
+                        0o644
+                    }))?;
+            }
+            staged.as_file().sync_all()?;
+            staged.persist_noclobber(&target).map_err(|error| {
+                AppError::io(format!("checkout refused {}: {}", change.path, error.error))
+            })?;
+            change.installed = true;
+            sync_parent(&target)?;
+        }
+        boundary(&change.path, "installed")?;
+    }
+    Ok(())
+}
+
+fn restore(root: &Path, recovery: &Path, changes: &[Change]) -> AppResult<()> {
+    for change in changes.iter().rev() {
+        let target = checked_path(root, &change.path)?;
+        if change.installed && fs::symlink_metadata(&target).is_ok() {
+            let displaced = recovery.join("displaced").join(&change.path);
+            fs::create_dir_all(
+                displaced
+                    .parent()
+                    .ok_or_else(|| AppError::io("missing recovery parent"))?,
+            )?;
+            fs::rename(&target, displaced)?;
+        }
+        if change.moved {
+            match fs::hard_link(recovery.join("original").join(&change.path), &target) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn verify(repo: &Repository, path: &Path, expected: Option<Oid>) -> AppResult<()> {
+    let matches = match (fs::symlink_metadata(path), expected) {
+        (Ok(metadata), Some(expected)) if metadata.is_file() => {
+            fs::read(path)? == repo.find_blob(expected)?.content()
+        }
+        (Err(error), None) if error.kind() == std::io::ErrorKind::NotFound => true,
+        (Err(error), _) if error.kind() != std::io::ErrorKind::NotFound => return Err(error.into()),
+        _ => false,
+    };
+    if !matches {
+        return Err(AppError::io(format!(
+            "file changed during Git sync; preserved locally: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn checked_path(root: &Path, path: &str) -> AppResult<PathBuf> {
+    if path.contains('\\') || path.contains(':') {
+        return Err(AppError::io(format!(
+            "Git sync refuses non-portable path: {path}"
+        )));
+    }
+    let relative = crate::fs::ensure_relative(path)?;
+    let mut target = root.to_path_buf();
+    for component in relative.components() {
+        let name = component.as_os_str().to_string_lossy();
+        if name
+            .trim_end_matches([' ', '.'])
+            .eq_ignore_ascii_case(".git")
+        {
+            return Err(AppError::io(format!(
+                "Git sync refuses repository metadata: {path}"
+            )));
+        }
+        target.push(component);
+        if fs::symlink_metadata(&target).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+            return Err(AppError::io(format!("Git sync refuses symlink: {path}")));
+        }
+    }
+    Ok(target)
+}
+
+fn write_synced(path: &Path, bytes: &[u8]) -> AppResult<()> {
+    let mut file = File::options().create_new(true).write(true).open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    sync_parent(path)?;
+    Ok(())
+}
+
+fn sync_parent(path: &Path) -> AppResult<()> {
+    #[cfg(unix)]
+    File::open(
+        path.parent()
+            .ok_or_else(|| AppError::io("missing parent directory"))?,
+    )?
+    .sync_all()?;
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+fn replace_file(path: &Path, bytes: &[u8]) -> AppResult<()> {
+    let mut staged = tempfile::NamedTempFile::new_in(
+        path.parent()
+            .ok_or_else(|| AppError::io("missing index parent"))?,
+    )?;
+    staged.write_all(bytes)?;
+    staged.as_file().sync_all()?;
+    staged
+        .persist(path)
+        .map_err(|error| AppError::io(error.error.to_string()))?;
+    Ok(())
+}
+
+struct IndexLock {
+    path: PathBuf,
+    _file: File,
+}
+
+impl Drop for IndexLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn trees(root: &Path) -> (Repository, Oid, Oid) {
+        Repository::init(root).unwrap();
+        fs::write(root.join("a.md"), b"old a").unwrap();
+        fs::write(root.join("b.md"), b"old b").unwrap();
+        super::super::commit::commit_all(root, "before", u64::MAX).unwrap();
+        let repo = Repository::open(root).unwrap();
+        let before = repo.head().unwrap().target().unwrap();
+        fs::write(root.join("a.md"), b"new a").unwrap();
+        fs::write(root.join("b.md"), b"new b").unwrap();
+        super::super::commit::commit_all(root, "after", u64::MAX).unwrap();
+        let after = repo.head().unwrap().target().unwrap();
+        repo.reset(
+            &repo.find_object(before, None).unwrap(),
+            git2::ResetType::Hard,
+            None,
+        )
+        .unwrap();
+        (repo, before, after)
+    }
+
+    #[test]
+    fn a_save_after_preflight_is_refused_without_changing_the_saved_bytes() {
+        let root = tempfile::tempdir().unwrap();
+        let recovery = tempfile::tempdir_in(root.path()).unwrap();
+        let (repo, before, after) = trees(root.path());
+        let old = repo.find_commit(before).unwrap().tree().unwrap();
+        let new = repo.find_commit(after).unwrap().tree().unwrap();
+        let mut changes = plan(&repo, root.path(), Some(&old), &new).unwrap();
+        let result = apply(
+            &repo,
+            root.path(),
+            recovery.path(),
+            &mut changes,
+            |path, boundary| {
+                if path == "a.md" && boundary == "before" {
+                    fs::write(root.path().join(path), b"saved after preflight")?;
+                }
+                Ok(())
+            },
+        );
+        assert!(result.is_err());
+        restore(root.path(), recovery.path(), &changes).unwrap();
+        assert_eq!(
+            fs::read(root.path().join("a.md")).unwrap(),
+            b"saved after preflight"
+        );
+        assert_eq!(repo.head().unwrap().target(), Some(before));
+    }
+
+    #[test]
+    fn an_atomic_save_between_move_and_claim_wins_without_clobbering_either_version() {
+        let root = tempfile::tempdir().unwrap();
+        let recovery = tempfile::tempdir_in(root.path()).unwrap();
+        let (repo, before, after) = trees(root.path());
+        let old = repo.find_commit(before).unwrap().tree().unwrap();
+        let new = repo.find_commit(after).unwrap().tree().unwrap();
+        let mut changes = plan(&repo, root.path(), Some(&old), &new).unwrap();
+        let result = apply(
+            &repo,
+            root.path(),
+            recovery.path(),
+            &mut changes,
+            |path, boundary| {
+                if path == "a.md" && boundary == "moved" {
+                    fs::write(root.path().join(path), b"external atomic save")?;
+                }
+                Ok(())
+            },
+        );
+        assert!(result.is_err());
+        restore(root.path(), recovery.path(), &changes).unwrap();
+        assert_eq!(
+            fs::read(root.path().join("a.md")).unwrap(),
+            b"external atomic save"
+        );
+        assert_eq!(
+            fs::read(recovery.path().join("original/a.md")).unwrap(),
+            b"old a"
+        );
+    }
+
+    #[test]
+    fn partial_install_rollback_retains_a_racing_edit_and_restores_originals() {
+        let root = tempfile::tempdir().unwrap();
+        let recovery = tempfile::tempdir_in(root.path()).unwrap();
+        let (repo, before, after) = trees(root.path());
+        let old = repo.find_commit(before).unwrap().tree().unwrap();
+        let new = repo.find_commit(after).unwrap().tree().unwrap();
+        let mut changes = plan(&repo, root.path(), Some(&old), &new).unwrap();
+        let result = apply(
+            &repo,
+            root.path(),
+            recovery.path(),
+            &mut changes,
+            |path, boundary| {
+                if path == "b.md" && boundary == "before" {
+                    fs::write(root.path().join("a.md"), b"external edit after install")?;
+                    return Err(AppError::io("injected second-file failure"));
+                }
+                Ok(())
+            },
+        );
+        assert!(result.is_err());
+        restore(root.path(), recovery.path(), &changes).unwrap();
+        assert_eq!(fs::read(root.path().join("a.md")).unwrap(), b"old a");
+        assert_eq!(fs::read(root.path().join("b.md")).unwrap(), b"old b");
+        assert_eq!(
+            fs::read(recovery.path().join("displaced/a.md")).unwrap(),
+            b"external edit after install"
+        );
+        assert_eq!(repo.head().unwrap().target(), Some(before));
+        assert_eq!(repo.index().unwrap().write_tree().unwrap(), old.id());
+    }
+
+    #[test]
+    fn writes_through_an_old_descriptor_remain_recoverable_after_success() {
+        let root = tempfile::tempdir().unwrap();
+        let recovery = tempfile::tempdir_in(root.path()).unwrap();
+        let (repo, before, after) = trees(root.path());
+        let old = repo.find_commit(before).unwrap().tree().unwrap();
+        let new = repo.find_commit(after).unwrap().tree().unwrap();
+        let mut changes = plan(&repo, root.path(), Some(&old), &new).unwrap();
+        let mut external = File::options()
+            .write(true)
+            .open(root.path().join("a.md"))
+            .unwrap();
+        apply(&repo, root.path(), recovery.path(), &mut changes, |_, _| {
+            Ok(())
+        })
+        .unwrap();
+        external.write_all(b"late descriptor save").unwrap();
+        assert_eq!(fs::read(root.path().join("a.md")).unwrap(), b"new a");
+        assert_eq!(
+            fs::read(recovery.path().join("original/a.md")).unwrap(),
+            b"late descriptor save"
+        );
+    }
+
+    #[test]
+    fn an_existing_index_lock_refuses_before_touching_head_or_worktree() {
+        let root = tempfile::tempdir().unwrap();
+        let (repo, before, after) = trees(root.path());
+        let old = repo.find_commit(before).unwrap().tree().unwrap();
+        let new = repo.find_commit(after).unwrap().tree().unwrap();
+        fs::write(repo.path().join("index.lock"), b"external git").unwrap();
+        let branch = current_branch(&repo).unwrap();
+        assert!(install(
+            &repo,
+            root.path(),
+            &branch,
+            Some(before),
+            after,
+            Some(&old),
+            &new
+        )
+        .is_err());
+        assert_eq!(fs::read(root.path().join("a.md")).unwrap(), b"old a");
+        assert_eq!(
+            fs::read(repo.path().join("index.lock")).unwrap(),
+            b"external git"
+        );
+        assert_eq!(repo.head().unwrap().target(), Some(before));
+    }
+
+    #[test]
+    fn interrupted_checkout_blocks_future_commits_without_touching_notes() {
+        let root = tempfile::tempdir().unwrap();
+        let (repo, before, _) = trees(root.path());
+        fs::create_dir_all(repo.path().join("reflect-sync")).unwrap();
+        fs::write(repo.path().join("reflect-sync/pending"), b"recovery path").unwrap();
+        assert!(super::super::commit::commit_all(root.path(), "retry", u64::MAX).is_err());
+        assert_eq!(repo.head().unwrap().target(), Some(before));
+        assert_eq!(fs::read(root.path().join("a.md")).unwrap(), b"old a");
+    }
+}

--- a/apps/desktop/src-tauri/src/git/checkout.rs
+++ b/apps/desktop/src-tauri/src/git/checkout.rs
@@ -223,6 +223,7 @@ fn apply(
                     }))?;
             }
             staged.as_file().sync_all()?;
+            boundary(&change.path, "claim")?;
             staged.persist_noclobber(&target).map_err(|error| {
                 AppError::io(format!("checkout refused {}: {}", change.path, error.error))
             })?;
@@ -522,5 +523,97 @@ mod tests {
         assert!(super::super::commit::commit_all(root.path(), "retry", u64::MAX).is_err());
         assert_eq!(repo.head().unwrap().target(), Some(before));
         assert_eq!(fs::read(root.path().join("a.md")).unwrap(), b"old a");
+    }
+
+    #[test]
+    fn a_conflict_copy_arriving_at_the_final_claim_is_not_overwritten() {
+        let root = tempfile::tempdir().unwrap();
+        let recovery = tempfile::tempdir_in(root.path()).unwrap();
+        let (repo, _, _) = trees(root.path());
+        let mut changes = vec![Change {
+            path: "assets/img (conflict).bin".to_owned(),
+            before: None,
+            after: Some(repo.blob(b"remote image\0").unwrap()),
+            executable: false,
+            moved: false,
+            installed: false,
+        }];
+        let result = apply(
+            &repo,
+            root.path(),
+            recovery.path(),
+            &mut changes,
+            |path, boundary| {
+                if boundary == "claim" {
+                    fs::write(root.path().join(path), b"late intentional attachment\0")?;
+                }
+                Ok(())
+            },
+        );
+        assert!(result.is_err());
+        restore(root.path(), recovery.path(), &changes).unwrap();
+        assert_eq!(
+            fs::read(root.path().join(&changes[0].path)).unwrap(),
+            b"late intentional attachment\0"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_multi_file_install_restores_head_index_and_worktree() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let (repo, before, after) = trees(root.path());
+        let old = repo.find_commit(before).unwrap().tree().unwrap();
+        let mut index = git2::Index::new().unwrap();
+        index
+            .read_tree(&repo.find_commit(after).unwrap().tree().unwrap())
+            .unwrap();
+        let mut entry = index.get_path(Path::new("a.md"), 0).unwrap();
+        entry.path = b"z/new.md".to_vec();
+        index.add(&entry).unwrap();
+        let new = repo.find_tree(index.write_tree_to(&repo).unwrap()).unwrap();
+        let sig = signature(&repo).unwrap();
+        let target = repo
+            .commit(
+                None,
+                &sig,
+                &sig,
+                "incoming",
+                &new,
+                &[&repo.find_commit(before).unwrap()],
+            )
+            .unwrap();
+        let index_before = fs::read(repo.path().join("index")).unwrap();
+        fs::create_dir(root.path().join("z")).unwrap();
+        fs::set_permissions(root.path().join("z"), fs::Permissions::from_mode(0o555)).unwrap();
+        let result = install(
+            &repo,
+            root.path(),
+            &current_branch(&repo).unwrap(),
+            Some(before),
+            target,
+            Some(&old),
+            &new,
+        );
+        fs::set_permissions(root.path().join("z"), fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(result.is_err());
+        assert_eq!(repo.head().unwrap().target(), Some(before));
+        assert_eq!(fs::read(repo.path().join("index")).unwrap(), index_before);
+        assert_eq!(fs::read(root.path().join("a.md")).unwrap(), b"old a");
+        assert_eq!(fs::read(root.path().join("b.md")).unwrap(), b"old b");
+        assert!(!repo.path().join("reflect-sync/pending").exists());
+        install(
+            &repo,
+            root.path(),
+            &current_branch(&repo).unwrap(),
+            Some(before),
+            target,
+            Some(&old),
+            &new,
+        )
+        .unwrap();
+        assert_eq!(repo.head().unwrap().target(), Some(target));
     }
 }

--- a/apps/desktop/src-tauri/src/git/commit.rs
+++ b/apps/desktop/src-tauri/src/git/commit.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use crate::error::AppResult;
 
 use super::commit_message::message_for_commit;
-use super::repo::{ensure_clean_state, open_existing, signature};
+use super::repo::{ensure_clean_state, exclude_runtime, is_runtime, open_existing, signature};
 
 /// A file whose *changes* were withheld from staging because it is at/above
 /// the size guardrail. Oversized-but-unchanged files are not reported — their
@@ -45,6 +45,10 @@ pub(super) fn commit_all(
     fallback_message: &str,
     max_file_bytes: u64,
 ) -> AppResult<CommitOutcome> {
+    let gate = crate::fs::mutation::gate(root)?;
+    let _mutation = gate
+        .write()
+        .map_err(|_| crate::error::AppError::io("graph mutation gate poisoned"))?;
     let repo = open_existing(root)?;
     ensure_clean_state(&repo)?;
     // In-memory hard guarantee, independent of any on-disk ignore file: the
@@ -53,6 +57,7 @@ pub(super) fn commit_all(
     repo.add_ignore_rule("/.reflect/")?;
 
     let mut index = repo.index()?;
+    exclude_runtime(&mut index)?;
     let skipped = add_all_with_size_guard(&mut index, root, max_file_bytes)?;
 
     let parent = repo.head().ok().and_then(|head| head.peel_to_commit().ok());
@@ -126,6 +131,9 @@ fn add_all_with_size_guard(
 
     let skipped: RefCell<Vec<SkippedFile>> = RefCell::new(Vec::new());
     let mut size_guard = |path: &Path, _spec: &[u8]| -> i32 {
+        if is_runtime(path.to_string_lossy().as_bytes()) {
+            return 1;
+        }
         let Ok(meta) = root.join(path).metadata() else {
             // Deleted file: let the staging proceed so the removal is recorded.
             return 0;

--- a/apps/desktop/src-tauri/src/git/merge.rs
+++ b/apps/desktop/src-tauri/src/git/merge.rs
@@ -46,6 +46,7 @@ pub struct MergeOutcome {
     pub changed_files: Vec<ChangedFile>,
 }
 
+/// No-write outcomes must never emit speculative file changes to the editor.
 fn unchanged(kind: MergeKind) -> MergeOutcome {
     MergeOutcome {
         kind,
@@ -171,6 +172,7 @@ pub(super) fn merge_remote(root: &Path) -> AppResult<MergeOutcome> {
     })
 }
 
+/// The operation-state check alone says nothing about saves made during fetch.
 fn has_local_changes(repo: &Repository, include_untracked: bool) -> AppResult<bool> {
     let mut options = git2::StatusOptions::new();
     options
@@ -183,6 +185,7 @@ fn has_local_changes(repo: &Repository, include_untracked: bool) -> AppResult<bo
         .any(|entry| !is_runtime(entry.path_bytes()) && entry.status() != git2::Status::CURRENT))
 }
 
+/// Report installed content changes, never runtime exclusions that left disk alone.
 fn changed_between(
     repo: &Repository,
     old: Option<&git2::Tree>,
@@ -217,10 +220,12 @@ fn changed_between(
     Ok(changes)
 }
 
+/// Refuse unrepresentable paths rather than lossy-converting them to other names.
 fn path_of(entry: &IndexEntry) -> AppResult<&str> {
     std::str::from_utf8(&entry.path).map_err(|_| AppError::io("non-UTF-8 conflict path"))
 }
 
+/// Resolve index stages without reading a potentially racing working copy.
 fn stage(index: &mut Index, mut entry: IndexEntry, id: git2::Oid) -> AppResult<()> {
     index.remove_path(Path::new(path_of(&entry)?))?;
     entry.id = id;
@@ -229,6 +234,7 @@ fn stage(index: &mut Index, mut entry: IndexEntry, id: git2::Oid) -> AppResult<(
     Ok(())
 }
 
+/// Preserve both edited versions in blobs before touching the live working tree.
 fn resolve_conflicts(repo: &Repository, root: &Path, index: &mut Index) -> AppResult<Vec<String>> {
     let conflicts = index.conflicts()?.collect::<Result<Vec<_>, _>>()?;
     let mut paths = Vec::new();
@@ -289,6 +295,7 @@ fn resolve_conflicts(repo: &Repository, root: &Path, index: &mut Index) -> AppRe
     Ok(paths)
 }
 
+/// Reserve names in every merge stage; installation supplies the atomic disk claim.
 fn available_copy(root: &Path, index: &Index, path: &str) -> AppResult<String> {
     for number in 1..=10_000 {
         let candidate = conflict_copy_path(path, number);
@@ -302,6 +309,7 @@ fn available_copy(root: &Path, index: &Index, path: &str) -> AppResult<String> {
     Err(AppError::io("too many conflict copies; no free filename"))
 }
 
+/// Suffix only the basename so dotted directories cannot relocate a conflict copy.
 fn conflict_copy_path(rel: &str, number: usize) -> String {
     let path = Path::new(rel);
     let file = path.file_name().unwrap_or_default().to_string_lossy();

--- a/apps/desktop/src-tauri/src/git/merge.rs
+++ b/apps/desktop/src-tauri/src/git/merge.rs
@@ -292,7 +292,7 @@ fn resolve_conflicts(repo: &Repository, root: &Path, index: &mut Index) -> AppRe
 fn available_copy(root: &Path, index: &Index, path: &str) -> AppResult<String> {
     for number in 1..=10_000 {
         let candidate = conflict_copy_path(path, number);
-        if index.get_path(Path::new(&candidate), 0).is_none()
+        if !index.iter().any(|entry| entry.path == candidate.as_bytes())
             && std::fs::symlink_metadata(root.join(&candidate))
                 .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound)
         {

--- a/apps/desktop/src-tauri/src/git/merge.rs
+++ b/apps/desktop/src-tauri/src/git/merge.rs
@@ -1,170 +1,168 @@
-//! Pull-side merge: fast-forward when possible, otherwise merge — and when
-//! the merge conflicts, materialize the conflict **into the note** (standard
-//! Git markers with readable labels), commit the merge anyway, and let the
-//! user resolve by editing the file.
-//!
-//! The repository is never left mid-merge: committing the conflict keeps sync
-//! flowing for every other note, both devices converge on the same marked-up
-//! file, and the raw versions stay recoverable from history (the merge commit
-//! has both parents). The indexer (Plan 12 core) detects the markers and flags
-//! the note `Needs review`.
-//!
-//! The markers are standard Git, with product labels instead of branch names:
-//!
-//! ```text
-//! <<<<<<< this device
-//! the local version
-//! =======
-//! the other device's version
-//! >>>>>>> other device
-//! ```
-
-use std::fs;
 use std::path::Path;
 
-use git2::build::CheckoutBuilder;
-use git2::{Index, IndexEntry, MergeOptions, Repository};
+use git2::{Index, IndexEntry, MergeFileOptions, Repository};
 use serde::Serialize;
 
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 
-use super::repo::{current_branch, ensure_clean_state, open_existing, signature};
-
-/// Conflict-marker labels. "this device" is the local side, "other device"
-/// the remote one — product language, not branch names.
-const OUR_LABEL: &str = "this device";
-const THEIR_LABEL: &str = "other device";
+use super::repo::{
+    current_branch, ensure_clean_state, exclude_runtime, is_runtime, open_existing, signature,
+};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+/// A refused dirty tree has no changed files; the engine can snapshot and retry.
 pub enum MergeKind {
     UpToDate,
     FastForward,
     Merged,
     MergedWithConflicts,
+    WorktreeChanged,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+/// The watcher-compatible mutation kind for direct reindexing.
 pub enum ChangeKind {
     Upsert,
     Remove,
 }
 
-/// One working-tree file a merge/fast-forward rewrote, in the same shape as
-/// the watcher's `FileChange` so the caller can reindex directly.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+/// A successfully installed graph-relative file, with its actual disk mtime.
 pub struct ChangedFile {
-    /// Graph-relative path, forward-slashed.
     pub path: String,
     pub kind: ChangeKind,
-    /// Last-modified time of the written file (epoch ms; upserts only), so
-    /// the reindex stamps the real mtime like the watcher path does.
     pub modified_ms: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+/// Successful checkout changes, or a no-write refusal for pending local edits.
 pub struct MergeOutcome {
     pub kind: MergeKind,
-    /// Graph-relative paths that now carry conflict markers (or a binary
-    /// conflict copy). Informational — the indexer rediscovers them from
-    /// content.
     pub conflicted_paths: Vec<String>,
-    /// Every file this merge changed on disk. The sync layer reindexes these
-    /// directly — pulls must not depend on the file watcher being up (on
-    /// launch it may not be yet) to keep the index in step with the notes.
-    /// Deletions carry `modified_ms: None`; upserts carry the written file's
-    /// real mtime.
     pub changed_files: Vec<ChangedFile>,
 }
 
-/// One side of an index conflict, lifted out of the index so the borrow ends
-/// before we mutate it.
-struct ConflictSide {
-    path: String,
-    id: git2::Oid,
+fn unchanged(kind: MergeKind) -> MergeOutcome {
+    MergeOutcome {
+        kind,
+        conflicted_paths: Vec::new(),
+        changed_files: Vec::new(),
+    }
 }
 
-fn side_of(entry: Option<IndexEntry>) -> Option<ConflictSide> {
-    entry.map(|entry| ConflictSide {
-        path: String::from_utf8_lossy(&entry.path).into_owned(),
-        id: entry.id,
-    })
-}
-
-/// Merge the fetched `origin/<branch>` into the local branch. Pre-condition
-/// (the sync engine guarantees it): local changes are already committed.
+/// Prepare the entire merge in memory, then install it under the graph gate.
+/// A save during fetch is a recoverable refusal, never a checkout precondition
+/// supplied by JavaScript. Neither Git operation state nor the live index is
+/// modified during merge calculation or conflict resolution.
 pub(super) fn merge_remote(root: &Path) -> AppResult<MergeOutcome> {
+    let gate = crate::fs::mutation::gate(root)?;
+    let _mutation = gate
+        .write()
+        .map_err(|_| AppError::io("graph mutation gate poisoned"))?;
     let repo = open_existing(root)?;
     ensure_clean_state(&repo)?;
     let branch = current_branch(&repo)?;
-    let Ok(remote_oid) = repo.refname_to_id(&format!("refs/remotes/origin/{branch}")) else {
-        // A brand-new (empty) backup repo has no remote branch until the
-        // first push creates it. Nothing to merge is success, not an error —
-        // the launch cycle (commit → fetch → merge → push) must fall through
-        // to that push.
-        return Ok(MergeOutcome {
-            kind: MergeKind::UpToDate,
-            conflicted_paths: Vec::new(),
-            changed_files: Vec::new(),
-        });
+    let remote_oid = match repo.refname_to_id(&format!("refs/remotes/origin/{branch}")) {
+        Ok(oid) => oid,
+        Err(error) if error.code() == git2::ErrorCode::NotFound => {
+            return Ok(unchanged(MergeKind::UpToDate))
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let remote_commit = repo.find_commit(remote_oid)?;
+    let local_commit = match repo.head() {
+        Ok(head) => Some(head.peel_to_commit()?),
+        Err(error)
+            if matches!(
+                error.code(),
+                git2::ErrorCode::UnbornBranch | git2::ErrorCode::NotFound
+            ) =>
+        {
+            None
+        }
+        Err(error) => return Err(error.into()),
     };
     let annotated = repo.find_annotated_commit(remote_oid)?;
     let (analysis, _) = repo.merge_analysis(&[&annotated])?;
-
     if analysis.is_up_to_date() {
-        return Ok(MergeOutcome {
-            kind: MergeKind::UpToDate,
-            conflicted_paths: Vec::new(),
-            changed_files: Vec::new(),
-        });
+        return Ok(unchanged(MergeKind::UpToDate));
+    }
+    if has_local_changes(&repo, local_commit.is_some())? {
+        return Ok(unchanged(MergeKind::WorktreeChanged));
     }
 
-    if analysis.is_unborn() || analysis.is_fast_forward() {
-        // Capture the outgoing tree before the ref moves (None on unborn).
-        let old_tree = repo.head().ok().and_then(|head| head.peel_to_tree().ok());
-        let new_tree = repo.find_commit(remote_oid)?.tree()?;
-        let mut changed_files = changed_between(&repo, old_tree.as_ref(), &new_tree)?;
-        let refname = format!("refs/heads/{branch}");
-        repo.reference(&refname, remote_oid, true, "reflect sync: fast-forward")?;
-        repo.set_head(&refname)?;
-        // Force is safe here: the pre-merge invariant is a committed working
-        // tree, so there is nothing uncommitted to clobber.
-        repo.checkout_head(Some(CheckoutBuilder::new().force()))?;
-        // Stamp mtimes only now — the checkout above is what wrote the files.
-        stamp_modified_times(root, &mut changed_files);
-        return Ok(MergeOutcome {
-            kind: MergeKind::FastForward,
-            conflicted_paths: Vec::new(),
-            changed_files,
-        });
-    }
-
-    let mut merge_opts = MergeOptions::new();
-    let mut checkout = CheckoutBuilder::new();
-    checkout
-        .allow_conflicts(true)
-        .conflict_style_merge(true)
-        .our_label(OUR_LABEL)
-        .their_label(THEIR_LABEL);
-    repo.merge(&[&annotated], Some(&mut merge_opts), Some(&mut checkout))?;
-
-    // From here the repo carries MERGE_* state; a failure that leaves it
-    // behind would trip `ensure_clean_state` on every later cycle and wedge
-    // sync until a manual repair — exactly what this design forbids. Clear it
-    // on every path; the next cycle re-derives anything a failed attempt lost.
-    let result = complete_merge(&repo, root, remote_oid);
-    if result.is_err() {
-        let _ = repo.cleanup_state();
-    }
-    let (conflicted_paths, changed_files) = result?;
-
-    let kind = if conflicted_paths.is_empty() {
-        MergeKind::Merged
+    let old_tree = local_commit
+        .as_ref()
+        .map(|commit| commit.tree())
+        .transpose()?;
+    let fast_forward = analysis.is_fast_forward() || analysis.is_unborn();
+    let mut index = if fast_forward {
+        let mut index = Index::new()?;
+        index.read_tree(&remote_commit.tree()?)?;
+        index
     } else {
+        repo.merge_commits(
+            local_commit
+                .as_ref()
+                .ok_or_else(|| AppError::io("missing local commit"))?,
+            &remote_commit,
+            None,
+        )?
+    };
+    exclude_runtime(&mut index)?;
+    let conflicted_paths = resolve_conflicts(&repo, root, &mut index)?;
+    let tree = repo.find_tree(index.write_tree_to(&repo)?)?;
+    let sig = signature(&repo)?;
+    let target = if fast_forward && tree.id() == remote_commit.tree_id() {
+        remote_oid
+    } else {
+        let mut parents = Vec::new();
+        if !fast_forward {
+            parents.extend(local_commit.iter());
+        }
+        parents.push(&remote_commit);
+        repo.commit(
+            None,
+            &sig,
+            &sig,
+            if fast_forward {
+                "Exclude local Reflect runtime from backup"
+            } else if conflicted_paths.is_empty() {
+                "Merge changes from other devices"
+            } else {
+                "Merge changes from other devices (conflicts to review)"
+            },
+            &tree,
+            &parents,
+        )?
+    };
+    let mut changed_files = changed_between(&repo, old_tree.as_ref(), &tree)?;
+    super::checkout::install(
+        &repo,
+        root,
+        &branch,
+        local_commit.as_ref().map(|commit| commit.id()),
+        target,
+        old_tree.as_ref(),
+        &tree,
+    )?;
+    for change in &mut changed_files {
+        if matches!(change.kind, ChangeKind::Upsert) {
+            change.modified_ms = std::fs::metadata(root.join(&change.path))
+                .ok()
+                .and_then(|metadata| crate::fs::modified_ms(&metadata));
+        }
+    }
+    let kind = if !conflicted_paths.is_empty() {
         MergeKind::MergedWithConflicts
+    } else if fast_forward && target == remote_oid {
+        MergeKind::FastForward
+    } else {
+        MergeKind::Merged
     };
     Ok(MergeOutcome {
         kind,
@@ -173,53 +171,25 @@ pub(super) fn merge_remote(root: &Path) -> AppResult<MergeOutcome> {
     })
 }
 
-/// The post-`repo.merge` half: materialize conflicts, commit the merge with
-/// both parents, and clear the merge state. Split out so [`merge_remote`] can
-/// guarantee `cleanup_state` runs even when any step here fails. Returns the
-/// conflicted paths and every file the merge changed relative to local HEAD.
-fn complete_merge(
-    repo: &Repository,
-    root: &Path,
-    remote_oid: git2::Oid,
-) -> AppResult<(Vec<String>, Vec<ChangedFile>)> {
-    let mut index = repo.index()?;
-    let conflicted_paths = resolve_conflicts(repo, root, &mut index)?;
-    index.write()?;
-
-    let tree = repo.find_tree(index.write_tree()?)?;
-    let local_commit = repo.head()?.peel_to_commit()?;
-    let remote_commit = repo.find_commit(remote_oid)?;
-    // The working tree is final here (merge checkout + conflict resolution
-    // wrote everything), so the stamped mtimes are the files' real ones.
-    let mut changed_files = changed_between(repo, Some(&local_commit.tree()?), &tree)?;
-    stamp_modified_times(root, &mut changed_files);
-    let sig = signature(repo)?;
-    let message = if conflicted_paths.is_empty() {
-        "Merge changes from other devices"
-    } else {
-        "Merge changes from other devices (conflicts to review)"
-    };
-    repo.commit(
-        Some("HEAD"),
-        &sig,
-        &sig,
-        message,
-        &tree,
-        &[&local_commit, &remote_commit],
-    )?;
-    repo.cleanup_state()?;
-    Ok((conflicted_paths, changed_files))
+fn has_local_changes(repo: &Repository, include_untracked: bool) -> AppResult<bool> {
+    let mut options = git2::StatusOptions::new();
+    options
+        .include_untracked(include_untracked)
+        .recurse_untracked_dirs(true)
+        .update_index(false);
+    Ok(repo
+        .statuses(Some(&mut options))?
+        .iter()
+        .any(|entry| !is_runtime(entry.path_bytes()) && entry.status() != git2::Status::CURRENT))
 }
 
-/// Diff two trees into the watcher's change shape: what the merge wrote or
-/// removed on disk relative to the previous local HEAD.
 fn changed_between(
     repo: &Repository,
     old: Option<&git2::Tree>,
     new: &git2::Tree,
 ) -> AppResult<Vec<ChangedFile>> {
     let diff = repo.diff_tree_to_tree(old, Some(new), None)?;
-    let mut out = Vec::new();
+    let mut changes = Vec::new();
     for delta in diff.deltas() {
         let removed = delta.status() == git2::Delta::Deleted;
         let file = if removed {
@@ -228,147 +198,125 @@ fn changed_between(
             delta.new_file()
         };
         if let Some(path) = file.path() {
-            out.push(ChangedFile {
-                path: path.to_string_lossy().replace('\\', "/"),
-                kind: if removed {
-                    ChangeKind::Remove
-                } else {
-                    ChangeKind::Upsert
-                },
-                modified_ms: None, // stamped once the working tree is final
-            });
+            let path = path
+                .to_str()
+                .ok_or_else(|| AppError::io("non-UTF-8 Git path"))?;
+            if !is_runtime(path.as_bytes()) {
+                changes.push(ChangedFile {
+                    path: path.to_owned(),
+                    kind: if removed {
+                        ChangeKind::Remove
+                    } else {
+                        ChangeKind::Upsert
+                    },
+                    modified_ms: None,
+                });
+            }
         }
     }
-    Ok(out)
+    Ok(changes)
 }
 
-/// Fill `modified_ms` for upserts from the (now final) working-tree files.
-fn stamp_modified_times(root: &Path, changes: &mut [ChangedFile]) {
-    for change in changes {
-        if matches!(change.kind, ChangeKind::Remove) {
-            continue;
-        }
-        change.modified_ms = root
-            .join(&change.path)
-            .metadata()
-            .ok()
-            .and_then(|meta| meta.modified().ok())
-            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|duration| duration.as_millis() as u64);
-    }
+fn path_of(entry: &IndexEntry) -> AppResult<&str> {
+    std::str::from_utf8(&entry.path).map_err(|_| AppError::io("non-UTF-8 conflict path"))
 }
 
-/// Turn every index conflict into committed working-tree content:
-///
-/// - **text vs text** — the merge checkout already wrote labeled markers into
-///   the file; stage it as-is (the user resolves by editing the note);
-/// - **edit vs delete** — keep the edited version, never silently delete;
-/// - **binary vs binary** — keep ours in place and the other device's copy
-///   alongside (`name (conflict).ext`);
-/// - **deleted on both** — confirm the removal.
+fn stage(index: &mut Index, mut entry: IndexEntry, id: git2::Oid) -> AppResult<()> {
+    index.remove_path(Path::new(path_of(&entry)?))?;
+    entry.id = id;
+    entry.flags &= !0x3000;
+    index.add(&entry)?;
+    Ok(())
+}
+
 fn resolve_conflicts(repo: &Repository, root: &Path, index: &mut Index) -> AppResult<Vec<String>> {
-    if !index.has_conflicts() {
-        return Ok(Vec::new());
-    }
-
-    struct OwnedConflict {
-        our: Option<ConflictSide>,
-        their: Option<ConflictSide>,
-        ancestor: Option<ConflictSide>,
-    }
-    let conflicts: Vec<OwnedConflict> = index
-        .conflicts()?
-        .filter_map(Result::ok)
-        .map(|conflict| OwnedConflict {
-            our: side_of(conflict.our),
-            their: side_of(conflict.their),
-            ancestor: side_of(conflict.ancestor),
-        })
-        .collect();
-
-    let mut conflicted_paths = Vec::new();
+    let conflicts = index.conflicts()?.collect::<Result<Vec<_>, _>>()?;
+    let mut paths = Vec::new();
     for conflict in conflicts {
         match (conflict.our, conflict.their) {
             (Some(our), Some(their)) => {
-                conflicted_paths.extend(resolve_both_edited(repo, root, index, our, their)?);
+                let our_path = path_of(&our)?.to_owned();
+                let their_path = path_of(&their)?.to_owned();
+                if our_path != their_path {
+                    let our_id = our.id;
+                    let their_id = their.id;
+                    stage(index, our, our_id)?;
+                    stage(index, their, their_id)?;
+                    paths.extend([our_path, their_path]);
+                } else if repo.find_blob(our.id)?.is_binary()
+                    || repo.find_blob(their.id)?.is_binary()
+                {
+                    let copy = available_copy(root, index, &their_path)?;
+                    let our_id = our.id;
+                    let their_id = their.id;
+                    stage(index, our, our_id)?;
+                    let mut copy_entry = their;
+                    copy_entry.path = copy.as_bytes().to_vec();
+                    stage(index, copy_entry, their_id)?;
+                    paths.extend([our_path, copy]);
+                } else {
+                    let ancestor = match conflict.ancestor {
+                        Some(ancestor) => ancestor,
+                        None => {
+                            let mut empty = index
+                                .get_path(Path::new(&our_path), 2)
+                                .ok_or_else(|| AppError::io("missing conflict entry"))?;
+                            empty.id = repo.blob(b"")?;
+                            empty
+                        }
+                    };
+                    let mut options = MergeFileOptions::new();
+                    options.our_label("this device").their_label("other device");
+                    let merged =
+                        repo.merge_file_from_index(&ancestor, &our, &their, Some(&mut options))?;
+                    let id = repo.blob(merged.content())?;
+                    stage(index, our, id)?;
+                    paths.push(our_path);
+                }
             }
             (Some(edited), None) | (None, Some(edited)) => {
-                conflicted_paths.push(resolve_edit_vs_delete(repo, root, index, edited)?);
+                paths.push(path_of(&edited)?.to_owned());
+                let id = edited.id;
+                stage(index, edited, id)?;
             }
             (None, None) => {
                 if let Some(ancestor) = conflict.ancestor {
-                    index.remove_path(Path::new(&ancestor.path))?;
+                    index.remove_path(Path::new(path_of(&ancestor)?))?;
                 }
             }
         }
     }
-    Ok(conflicted_paths)
+    Ok(paths)
 }
 
-/// Both sides changed the file. Text: the merge checkout already wrote the
-/// labeled marker file, so staging the working copy clears the conflict
-/// entries. Binary: markers would corrupt the bytes — keep ours in place and
-/// write the other device's version alongside (`name (conflict).ext`).
-fn resolve_both_edited(
-    repo: &Repository,
-    root: &Path,
-    index: &mut Index,
-    our: ConflictSide,
-    their: ConflictSide,
-) -> AppResult<Vec<String>> {
-    let binary = repo.find_blob(our.id)?.is_binary() || repo.find_blob(their.id)?.is_binary();
-    if !binary {
-        index.add_path(Path::new(&our.path))?;
-        return Ok(vec![our.path]);
+fn available_copy(root: &Path, index: &Index, path: &str) -> AppResult<String> {
+    for number in 1..=10_000 {
+        let candidate = conflict_copy_path(path, number);
+        if index.get_path(Path::new(&candidate), 0).is_none()
+            && std::fs::symlink_metadata(root.join(&candidate))
+                .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound)
+        {
+            return Ok(candidate);
+        }
     }
-    write_blob(repo, root, &our.path, our.id)?;
-    let copy = conflict_copy_path(&their.path);
-    write_blob(repo, root, &copy, their.id)?;
-    index.add_path(Path::new(&our.path))?;
-    index.add_path(Path::new(&copy))?;
-    Ok(vec![our.path, copy])
+    Err(AppError::io("too many conflict copies; no free filename"))
 }
 
-/// One side edited what the other deleted (either direction): restore and
-/// stage the edited version — sync must never silently delete a note someone
-/// touched. The user removes it again if the deletion was intentional.
-fn resolve_edit_vs_delete(
-    repo: &Repository,
-    root: &Path,
-    index: &mut Index,
-    edited: ConflictSide,
-) -> AppResult<String> {
-    write_blob(repo, root, &edited.path, edited.id)?;
-    index.add_path(Path::new(&edited.path))?;
-    Ok(edited.path)
-}
-
-fn write_blob(repo: &Repository, root: &Path, rel: &str, id: git2::Oid) -> AppResult<()> {
-    let blob = repo.find_blob(id)?;
-    let target = root.join(rel);
-    if let Some(parent) = target.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    fs::write(target, blob.content())?;
-    Ok(())
-}
-
-/// `assets/img.png` → `assets/img (conflict).png`; no extension → appended.
-/// Splits on the basename only — a dot in a *directory* name (`assets.v1/x`)
-/// must not relocate the copy out of the file's directory.
-fn conflict_copy_path(rel: &str) -> String {
-    let (dir, file) = match rel.rsplit_once('/') {
-        Some((dir, file)) => (Some(dir), file),
-        None => (None, rel),
+fn conflict_copy_path(rel: &str, number: usize) -> String {
+    let path = Path::new(rel);
+    let file = path.file_name().unwrap_or_default().to_string_lossy();
+    let suffix = if number == 1 {
+        " (conflict)".to_string()
+    } else {
+        format!(" (conflict {number})")
     };
     let renamed = match file.rsplit_once('.') {
-        Some((stem, ext)) if !stem.is_empty() => format!("{stem} (conflict).{ext}"),
-        _ => format!("{file} (conflict)"),
+        Some((stem, ext)) if !stem.is_empty() => format!("{stem}{suffix}.{ext}"),
+        _ => format!("{file}{suffix}"),
     };
-    match dir {
-        Some(dir) => format!("{dir}/{renamed}"),
-        None => renamed,
-    }
+    path.with_file_name(renamed)
+        .to_string_lossy()
+        .replace('\\', "/")
 }
 
 #[cfg(test)]
@@ -378,21 +326,15 @@ mod path_tests {
     #[test]
     fn conflict_copies_stay_in_their_directory() {
         assert_eq!(
-            conflict_copy_path("assets/img.png"),
+            conflict_copy_path("assets/img.png", 1),
             "assets/img (conflict).png"
         );
         assert_eq!(
-            conflict_copy_path("assets.v1/img"),
-            "assets.v1/img (conflict)"
+            conflict_copy_path("assets.v1/img", 2),
+            "assets.v1/img (conflict 2)"
         );
         assert_eq!(
-            conflict_copy_path("assets.v1/img.png"),
-            "assets.v1/img (conflict).png"
-        );
-        assert_eq!(conflict_copy_path("topfile.bin"), "topfile (conflict).bin");
-        assert_eq!(conflict_copy_path("noext"), "noext (conflict)");
-        assert_eq!(
-            conflict_copy_path("assets/.hidden"),
+            conflict_copy_path("assets/.hidden", 1),
             "assets/.hidden (conflict)"
         );
     }

--- a/apps/desktop/src-tauri/src/git/mod.rs
+++ b/apps/desktop/src-tauri/src/git/mod.rs
@@ -11,10 +11,12 @@
 //! the `generation` the frontend received when its graph was opened and
 //! resolves the root through `crate::fs::root_for_generation`, which fails
 //! when the active graph's generation has since moved (the user switched
-//! graphs after the command was issued). A stale command errors loudly instead
-//! of acting on the new graph, so commands never interleave across graphs.
+//! graphs after the command was issued). Already-issued work can finish on
+//! its captured root, never on the newly opened graph. Local mutations share
+//! the canonical-root filesystem gate; fetch and push never hold that gate.
 //! The one exception is `git_clone`, which runs before any graph is open.
 
+mod checkout;
 mod commit;
 mod commit_message;
 mod merge;
@@ -93,6 +95,10 @@ fn status(root: &Path) -> AppResult<GitStatus> {
 /// its history stay intact (reconnecting re-adds a remote); the machine-level
 /// GitHub credential is untouched — other graphs keep syncing.
 fn disconnect(root: &Path) -> AppResult<GitStatus> {
+    let gate = crate::fs::mutation::gate(root)?;
+    let _mutation = gate
+        .write()
+        .map_err(|_| crate::error::AppError::io("graph mutation gate poisoned"))?;
     let repo = repo::open_existing(root)?;
     if repo.find_remote("origin").is_ok() {
         repo.remote_delete("origin")?;
@@ -102,7 +108,12 @@ fn disconnect(root: &Path) -> AppResult<GitStatus> {
 }
 
 fn setup(root: &Path, remote_url: Option<String>, branch: Option<String>) -> AppResult<GitStatus> {
+    let gate = crate::fs::mutation::gate(root)?;
+    let _mutation = gate
+        .write()
+        .map_err(|_| crate::error::AppError::io("graph mutation gate poisoned"))?;
     let repo = repo::open_or_init(root)?;
+    repo::ensure_clean_state(&repo)?;
     repo::ensure_gitignore_defaults(root)?;
     if let Some(url) = remote_url {
         if repo.find_remote("origin").is_ok() {
@@ -190,7 +201,8 @@ pub async fn git_fetch(
 }
 
 /// Merge the fetched remote branch; conflicts are committed into the notes as
-/// labeled markers (see [`merge`]). The repo is never left mid-merge.
+/// labeled markers (see [`merge`]). Dirty worktrees are refused without writes;
+/// checkout failures preserve originals and report a recovery location.
 #[tauri::command]
 pub async fn git_merge_remote(
     generation: u64,

--- a/apps/desktop/src-tauri/src/git/remote.rs
+++ b/apps/desktop/src-tauri/src/git/remote.rs
@@ -173,9 +173,41 @@ fn count_commits(repo: &Repository, from: git2::Oid) -> AppResult<usize> {
 pub(super) fn clone(url: &str, target: &Path, token: Option<String>) -> AppResult<()> {
     let mut fetch_options = FetchOptions::new();
     fetch_options.remote_callbacks(callbacks_with_credentials(token));
-    git2::build::RepoBuilder::new()
+    let mut checkout = git2::build::CheckoutBuilder::new();
+    checkout.dry_run();
+    let repo = git2::build::RepoBuilder::new()
         .fetch_options(fetch_options)
+        .with_checkout(checkout)
         .clone(url, target)?;
+    if let Ok(head) = repo.head() {
+        let parent = head.peel_to_commit()?;
+        let mut index = git2::Index::new()?;
+        index.read_tree(&parent.tree()?)?;
+        super::repo::exclude_runtime(&mut index)?;
+        let tree = repo.find_tree(index.write_tree_to(&repo)?)?;
+        let target_oid = if tree.id() == parent.tree_id() {
+            parent.id()
+        } else {
+            let sig = super::repo::signature(&repo)?;
+            repo.commit(
+                None,
+                &sig,
+                &sig,
+                "Exclude local Reflect runtime from backup",
+                &tree,
+                &[&parent],
+            )?
+        };
+        super::checkout::install(
+            &repo,
+            target,
+            &current_branch(&repo)?,
+            Some(parent.id()),
+            target_oid,
+            None,
+            &tree,
+        )?;
+    }
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/git/repo.rs
+++ b/apps/desktop/src-tauri/src/git/repo.rs
@@ -62,9 +62,13 @@ pub(super) fn ensure_clean_state(repo: &Repository) -> AppResult<()> {
 /// Runtime data never participates in history or checkout, even when tracked
 /// by an adopted repository. Case folding also protects case-insensitive disks.
 pub(super) fn is_runtime(path: &[u8]) -> bool {
-    path.split(|byte| *byte == b'/')
-        .next()
-        .is_some_and(|part| part.eq_ignore_ascii_case(b".reflect"))
+    path.split(|byte| *byte == b'/').next().is_some_and(|part| {
+        let end = part
+            .iter()
+            .rposition(|byte| *byte != b'.' && *byte != b' ')
+            .map_or(0, |position| position + 1);
+        part[..end].eq_ignore_ascii_case(b".reflect")
+    })
 }
 
 /// Remove runtime entries from every index stage without touching local files.
@@ -129,4 +133,30 @@ pub(super) fn signature(repo: &Repository) -> AppResult<Signature<'static>> {
 /// bootstrap already writes these, but setup may adopt an existing repository.
 pub(super) fn ensure_gitignore_defaults(root: &Path) -> AppResult<()> {
     graph_gitignore::ensure_defaults(root)
+}
+
+#[cfg(test)]
+mod runtime_tests {
+    use super::is_runtime;
+
+    #[test]
+    fn reserves_case_and_windows_trailing_dot_space_aliases() {
+        for path in [
+            ".reflect/index.sqlite",
+            ".REFLECT/index.sqlite-wal",
+            ".reflect./index.sqlite",
+            ".ReFlEcT . ./chat",
+            ".reflect",
+        ] {
+            assert!(is_runtime(path.as_bytes()), "{path}");
+        }
+        for path in [
+            "notes/.reflect.md",
+            ".reflect-notes/a.md",
+            "notes/a.md",
+            ".../note",
+        ] {
+            assert!(!is_runtime(path.as_bytes()), "{path}");
+        }
+    }
 }

--- a/apps/desktop/src-tauri/src/git/repo.rs
+++ b/apps/desktop/src-tauri/src/git/repo.rs
@@ -39,11 +39,45 @@ pub(super) fn open_existing(root: &Path) -> AppResult<Repository> {
 /// Refuse to operate on a repository mid-operation (a rebase/merge the user
 /// started with the git CLI). Guessing here could destroy their state.
 pub(super) fn ensure_clean_state(repo: &Repository) -> AppResult<()> {
+    if repo.path().join("reflect-sync/pending").exists() {
+        return Err(AppError::io(format!(
+            "an interrupted Git sync needs recovery; original files and index are in {}. Inspect pending before retrying; do not reset --hard",
+            repo.path().join("reflect-sync").display()
+        )));
+    }
     if repo.state() != git2::RepositoryState::Clean {
         return Err(AppError::io(format!(
             "the backup repository has a {:?} in progress; finish or abort it with git first",
             repo.state()
         )));
+    }
+    if repo.index()?.has_conflicts() {
+        return Err(AppError::io(
+            "the Git index has unresolved conflicts; resolve them with git before syncing",
+        ));
+    }
+    Ok(())
+}
+
+/// Runtime data never participates in history or checkout, even when tracked
+/// by an adopted repository. Case folding also protects case-insensitive disks.
+pub(super) fn is_runtime(path: &[u8]) -> bool {
+    path.split(|byte| *byte == b'/')
+        .next()
+        .is_some_and(|part| part.eq_ignore_ascii_case(b".reflect"))
+}
+
+/// Remove runtime entries from every index stage without touching local files.
+pub(super) fn exclude_runtime(index: &mut git2::Index) -> AppResult<()> {
+    let paths: Vec<_> = index
+        .iter()
+        .filter(|entry| is_runtime(&entry.path))
+        .map(|entry| {
+            String::from_utf8(entry.path).map_err(|_| AppError::io("non-UTF-8 runtime path"))
+        })
+        .collect::<AppResult<_>>()?;
+    for path in paths {
+        index.remove_path(Path::new(&path))?;
     }
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/git/tests.rs
+++ b/apps/desktop/src-tauri/src/git/tests.rs
@@ -104,6 +104,215 @@ fn setup_initializes_main_and_origin() {
 }
 
 #[test]
+fn saved_edit_during_fetch_is_refused_then_merged_without_loss() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+    write(root, "notes/shared.md", "base\n");
+    commit_all(root, "base", MAX_FILE_BYTES).unwrap();
+    push(root, None).unwrap();
+    let peer = second_device(&fixture);
+    write(&peer, "notes/shared.md", "remote revision\n");
+    commit_all(&peer, "remote", MAX_FILE_BYTES).unwrap();
+    push(&peer, None).unwrap();
+    commit_all(root, "before fetch", MAX_FILE_BYTES).unwrap();
+    let repo = Repository::open(root).unwrap();
+    let before = repo.head().unwrap().target();
+    let index_before = fs::read(repo.path().join("index")).unwrap();
+    crate::fs::atomic_write_bytes(root, &root.join("notes/shared.md"), b"saved during fetch\n")
+        .unwrap();
+    fetch(root, None).unwrap();
+
+    let result = merge_remote(root).unwrap();
+    assert!(matches!(result.kind, MergeKind::WorktreeChanged));
+    assert_eq!(read(root, "notes/shared.md"), "saved during fetch\n");
+    assert_eq!(repo.head().unwrap().target(), before);
+    assert_eq!(fs::read(repo.path().join("index")).unwrap(), index_before);
+    commit_all(root, "retry", MAX_FILE_BYTES).unwrap();
+    let result = merge_remote(root).unwrap();
+    assert!(matches!(result.kind, MergeKind::MergedWithConflicts));
+    let content = read(root, "notes/shared.md");
+    assert!(content.contains("saved during fetch"));
+    assert!(content.contains("remote revision"));
+    assert!(push(root, None).unwrap().pushed);
+}
+
+#[test]
+fn repeated_binary_conflicts_preserve_existing_copies_and_links() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+    write(root, "assets/img.bin", "base\0");
+    write(
+        root,
+        "assets/img (conflict).bin",
+        "intentional attachment\0",
+    );
+    write(
+        root,
+        "notes/links.md",
+        "[attachment](../assets/img (conflict).bin)",
+    );
+    commit_all(root, "base", MAX_FILE_BYTES).unwrap();
+    push(root, None).unwrap();
+    let peer = second_device(&fixture);
+    for round in 2..=3 {
+        write(&peer, "assets/img.bin", &format!("remote {round}\0"));
+        commit_all(&peer, "peer", MAX_FILE_BYTES).unwrap();
+        push(&peer, None).unwrap();
+        write(root, "assets/img.bin", &format!("local {round}\0"));
+        commit_all(root, "local", MAX_FILE_BYTES).unwrap();
+        fetch(root, None).unwrap();
+        assert!(matches!(
+            merge_remote(root).unwrap().kind,
+            MergeKind::MergedWithConflicts
+        ));
+        assert_eq!(
+            read(root, &format!("assets/img (conflict {round}).bin")),
+            format!("remote {round}\0")
+        );
+        assert!(push(root, None).unwrap().pushed);
+        fetch(&peer, None).unwrap();
+        merge_remote(&peer).unwrap();
+    }
+    assert_eq!(
+        read(root, "assets/img (conflict).bin"),
+        "intentional attachment\0"
+    );
+    assert_eq!(read(root, "assets/img (conflict 2).bin"), "remote 2\0");
+    assert_eq!(
+        read(root, "notes/links.md"),
+        "[attachment](../assets/img (conflict).bin)"
+    );
+}
+
+fn commit_runtime_with_external_git(root: &Path, content: &str) {
+    write(root, ".reflect/index.sqlite", content);
+    let repo = Repository::open(root).unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new(".reflect/index.sqlite")).unwrap();
+    index.write().unwrap();
+    let tree = repo.find_tree(index.write_tree().unwrap()).unwrap();
+    let parent = repo.head().unwrap().peel_to_commit().unwrap();
+    let sig = super::repo::signature(&repo).unwrap();
+    repo.commit(
+        Some("HEAD"),
+        &sig,
+        &sig,
+        "external runtime",
+        &tree,
+        &[&parent],
+    )
+    .unwrap();
+}
+
+#[test]
+fn adopted_runtime_is_untracked_without_touching_local_database() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+    write(root, "notes/a.md", "base");
+    commit_all(root, "base", MAX_FILE_BYTES).unwrap();
+    commit_runtime_with_external_git(root, "old database");
+    write(root, ".reflect/index.sqlite", "private durable chat bytes");
+    write(root, ".reflect/index.sqlite-wal", "local wal");
+    assert!(
+        commit_all(root, "backup", MAX_FILE_BYTES)
+            .unwrap()
+            .committed
+    );
+    assert!(!head_tree_paths(root)
+        .iter()
+        .any(|path| path.starts_with(".reflect/")));
+    assert_eq!(
+        read(root, ".reflect/index.sqlite"),
+        "private durable chat bytes"
+    );
+    assert_eq!(read(root, ".reflect/index.sqlite-wal"), "local wal");
+    assert!(!commit_all(root, "clean", MAX_FILE_BYTES).unwrap().committed);
+}
+
+#[test]
+fn remote_runtime_never_overwrites_an_open_database_or_enters_merge_tree() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+    write(root, "notes/a.md", "base");
+    commit_all(root, "base", MAX_FILE_BYTES).unwrap();
+    push(root, None).unwrap();
+    let peer = second_device(&fixture);
+    fs::remove_file(root.join(".reflect/index.sqlite")).unwrap();
+    let database = rusqlite::Connection::open(root.join(".reflect/index.sqlite")).unwrap();
+    database.execute_batch("PRAGMA journal_mode=WAL; CREATE TABLE chat_messages (body TEXT); INSERT INTO chat_messages VALUES ('durable chat');").unwrap();
+    let database_before = fs::read(root.join(".reflect/index.sqlite")).unwrap();
+    let wal_before = fs::read(root.join(".reflect/index.sqlite-wal")).unwrap();
+    commit_runtime_with_external_git(&peer, "foreign database");
+    push(&peer, None).unwrap();
+    fetch(root, None).unwrap();
+    let result = merge_remote(root).unwrap();
+    assert!(matches!(result.kind, MergeKind::Merged));
+    assert!(!result
+        .changed_files
+        .iter()
+        .any(|file| file.path.starts_with(".reflect/")));
+    assert_eq!(
+        fs::read(root.join(".reflect/index.sqlite")).unwrap(),
+        database_before
+    );
+    assert_eq!(
+        fs::read(root.join(".reflect/index.sqlite-wal")).unwrap(),
+        wal_before
+    );
+    assert_eq!(
+        database
+            .query_row("SELECT body FROM chat_messages", [], |row| row
+                .get::<_, String>(0))
+            .unwrap(),
+        "durable chat"
+    );
+    assert!(!head_tree_paths(root)
+        .iter()
+        .any(|path| path.starts_with(".reflect/")));
+    assert!(push(root, None).unwrap().pushed);
+}
+
+#[test]
+fn restore_never_materializes_remote_runtime() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+    write(root, "notes/a.md", "base");
+    commit_all(root, "base", MAX_FILE_BYTES).unwrap();
+    commit_runtime_with_external_git(root, "foreign database");
+    push(root, None).unwrap();
+    let restored = fixture._dir.path().join("restored");
+    super::remote::clone(&fixture.remote_url, &restored, None).unwrap();
+    assert_eq!(read(&restored, "notes/a.md"), "base");
+    assert!(!restored.join(".reflect").exists());
+    assert!(!head_tree_paths(&restored)
+        .iter()
+        .any(|path| path.starts_with(".reflect/")));
+}
+
+#[test]
+fn divergent_runtime_edit_delete_conflict_keeps_the_local_runtime() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+    write(root, "notes/a.md", "base");
+    commit_all(root, "base", MAX_FILE_BYTES).unwrap();
+    commit_runtime_with_external_git(root, "tracked old runtime");
+    push(root, None).unwrap();
+    let peer = second_device(&fixture);
+    commit_runtime_with_external_git(&peer, "remote changed runtime");
+    push(&peer, None).unwrap();
+    write(root, ".reflect/index.sqlite", "local durable chat");
+    write(root, "notes/local.md", "local note");
+    commit_all(root, "stop tracking runtime", MAX_FILE_BYTES).unwrap();
+    fetch(root, None).unwrap();
+    merge_remote(root).unwrap();
+    assert_eq!(read(root, ".reflect/index.sqlite"), "local durable chat");
+    assert_eq!(read(root, "notes/local.md"), "local note");
+    assert!(!head_tree_paths(root)
+        .iter()
+        .any(|path| path.starts_with(".reflect/")));
+}
+
+#[test]
 fn setup_creates_graph_gitignore_defaults_when_missing() {
     let dir = tempdir().unwrap();
     let root = dir.path().join("graph");

--- a/apps/desktop/src-tauri/src/git/tests.rs
+++ b/apps/desktop/src-tauri/src/git/tests.rs
@@ -184,6 +184,29 @@ fn repeated_binary_conflicts_preserve_existing_copies_and_links() {
     );
 }
 
+#[test]
+fn binary_copy_names_reserve_unresolved_edit_delete_conflicts_too() {
+    let fixture = fixture();
+    let root = &fixture.graph_a;
+    write(root, "assets/img", "base image\0");
+    write(root, "assets/img (conflict)", "base attachment\0");
+    commit_all(root, "base", MAX_FILE_BYTES).unwrap();
+    push(root, None).unwrap();
+    let peer = second_device(&fixture);
+    write(&peer, "assets/img", "remote image\0");
+    write(&peer, "assets/img (conflict)", "remote attachment\0");
+    commit_all(&peer, "peer", MAX_FILE_BYTES).unwrap();
+    push(&peer, None).unwrap();
+    write(root, "assets/img", "local image\0");
+    fs::remove_file(root.join("assets/img (conflict)")).unwrap();
+    commit_all(root, "local", MAX_FILE_BYTES).unwrap();
+    fetch(root, None).unwrap();
+    merge_remote(root).unwrap();
+    assert_eq!(read(root, "assets/img"), "local image\0");
+    assert_eq!(read(root, "assets/img (conflict)"), "remote attachment\0");
+    assert_eq!(read(root, "assets/img (conflict 2)"), "remote image\0");
+}
+
 fn commit_runtime_with_external_git(root: &Path, content: &str) {
     write(root, ".reflect/index.sqlite", content);
     let repo = Repository::open(root).unwrap();

--- a/docs/git-sync-safety.md
+++ b/docs/git-sync-safety.md
@@ -88,3 +88,5 @@ interrupted process. Do not use `git reset --hard` to dismiss the error.
 
 Recovery archives can be removed manually after all writers have stopped and
 their contents have been checked. They are local-only and are not pushed.
+From the graph root, inspect their total size with
+`du -sh "$(git rev-parse --git-dir)/reflect-sync"` before deciding what to retain.

--- a/docs/git-sync-safety.md
+++ b/docs/git-sync-safety.md
@@ -6,8 +6,9 @@ Fetch and push do not hold the graph filesystem gate. Editing remains enabled
 while the network runs. Commits and merge installation take an exclusive gate
 keyed by the canonical graph root, shared across windows. Native note writes,
 creation, renames, deletion, and screenshot writes participate in that gate.
-A save attempted during installation fails promptly rather than blocking the
-UI; the unsaved editor buffer remains available to retry.
+Note saves wait on the blocking pool rather than blocking the UI or failing a
+quit-time flush. The graph generation is revalidated after waiting. Other
+synchronous mutations refuse promptly during installation and can be retried.
 
 The native merge checks for pending local changes after acquiring the gate.
 An edit saved during fetch produces a no-write `worktreeChanged` result.
@@ -56,8 +57,10 @@ An open SQLite database, WAL, and durable chat tables therefore remain local.
 Sanitizing a fetched tree creates a normal descendant commit so the exclusion
 can be pushed without rewriting history.
 
-Previously published runtime bytes still exist in old Git history. This
-change does not rewrite or purge that history.
+Existing commits containing runtime bytes remain in history, including commits
+created before adoption; they can still be included in a normal history push.
+This change excludes future trees, not historical objects. Removing historical
+runtime data requires a separate, explicitly authorized history rewrite.
 
 ## Recovery
 

--- a/docs/git-sync-safety.md
+++ b/docs/git-sync-safety.md
@@ -1,0 +1,87 @@
+# Git sync safety and recovery
+
+## Mutation contract
+
+Fetch and push do not hold the graph filesystem gate. Editing remains enabled
+while the network runs. Commits and merge installation take an exclusive gate
+keyed by the canonical graph root, shared across windows. Native note writes,
+creation, renames, deletion, and screenshot writes participate in that gate.
+A save attempted during installation fails promptly rather than blocking the
+UI; the unsaved editor buffer remains available to retry.
+
+The native merge checks for pending local changes after acquiring the gate.
+An edit saved during fetch produces a no-write `worktreeChanged` result.
+The engine snapshots those edits and retries the already-fetched merge, with
+three attempts maximum. It never forces a dirty worktree to match the remote.
+Stopped engines issue no new command after the current command boundary.
+An already-issued command may finish on its captured old root, never the new
+graph's root.
+
+Merge calculation and conflict resolution use an in-memory index. Installation
+locks HEAD, the branch, and the Git index, checks the expected state, and moves
+HEAD only after the files and index are installed. Existing files are moved
+aside, not truncated. New files use atomic no-clobber claims. Every changed
+path is checked again immediately before installation, and the moved original
+is checked before its replacement is claimed.
+
+Other applications do not honor Reflect's in-process gate. A concurrent atomic
+save either remains at its path or makes installation refuse. Writes through
+an already-open descriptor remain in the moved original, even after installation
+finishes. Recovery copies are deliberately retained, including on success;
+there is no automatic age-based deletion that could erase a delayed writer.
+On a failed multi-file installation, originals are restored without clobbering
+new arrivals; displaced files are retained too.
+
+The installer refuses symlinks, submodules, repository-metadata paths, and
+incompatible file/directory shapes rather than guessing. It installs raw Git
+blob bytes, without invoking external checkout filters. A working copy changed
+by Git filters (for example CRLF conversion) can refuse the byte-level check;
+the original is preserved. Concurrent directory restructuring by other tools
+is not coordinated; pause those tools before retrying a refusal.
+
+## Conflicts and runtime data
+
+Text conflicts commit both versions with `this device` / `other device`
+markers. Edit/delete conflicts retain the edit. Binary conflicts retain the
+local attachment and choose `name (conflict).ext`, then
+`name (conflict 2).ext`, etc. Existing files and names in the merged index
+are reserved; the final no-clobber claim also protects against a late arrival.
+Existing references are not rewritten.
+
+The root `.reflect` directory is excluded from every new commit and merged
+tree, even if an adopted repository previously tracked it. Removing an index
+entry never deletes the local file. Pull installation also excludes runtime
+deletions, and restore skips the remote runtime before opening the graph.
+An open SQLite database, WAL, and durable chat tables therefore remain local.
+Sanitizing a fetched tree creates a normal descendant commit so the exclusion
+can be pushed without rewriting history.
+
+Previously published runtime bytes still exist in old Git history. This
+change does not rewrite or purge that history.
+
+## Recovery
+
+Recovery lives under the repository's actual Git directory:
+`reflect-sync/checkout-*/` (normally `<graph>/.git/reflect-sync/`).
+Each directory contains:
+
+- `manifest.json`: branch, before/after commits, and affected paths.
+- `original/<path>`: original file inodes moved out of the working tree.
+- `displaced/<path>`: files moved aside during failed-install rollback.
+- `index-before` and, when prepared, `index-after`.
+
+An ordinary failure rolls back the index and installed files, leaving HEAD
+unchanged and the repository usable. The error includes the recovery location.
+Check both the working copy and recovery files before retrying.
+
+A process interruption or failed rollback leaves `reflect-sync/pending`.
+Subsequent setup/commit/merge operations refuse rather than commit a partial
+pull as local edits. Close Reflect and stop other writers. Back up the entire
+graph, including its Git directory, then inspect the manifest, current HEAD,
+index, original files, and displaced files. Restore the desired versions
+without overwriting any newer edits. Only after the repository is consistent,
+remove the pending marker and any stale Git lock files belonging to the
+interrupted process. Do not use `git reset --hard` to dismiss the error.
+
+Recovery archives can be removed manually after all writers have stopped and
+their contents have been checked. They are local-only and are not pushed.

--- a/packages/core/src/sync/commands.test.ts
+++ b/packages/core/src/sync/commands.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { changedFileSchema } from './commands'
+
+describe('changedFileSchema', () => {
+  it.each(['upsert', 'remove'])(
+    'keeps %s notifications when native metadata is unavailable',
+    (kind) => {
+      for (const modifiedMs of [null, undefined]) {
+        expect(changedFileSchema.parse({ path: 'notes/a.md', kind, modifiedMs })).toEqual({
+          path: 'notes/a.md',
+          kind,
+          modifiedMs: undefined,
+        })
+      }
+    },
+  )
+
+  it('preserves real timestamps and rejects malformed metadata', () => {
+    expect(
+      changedFileSchema.parse({
+        path: 'notes/a.md',
+        kind: 'upsert',
+        modifiedMs: 1234,
+      }).modifiedMs,
+    ).toBe(1234)
+    expect(
+      changedFileSchema.safeParse({
+        path: 'notes/a.md',
+        kind: 'upsert',
+        modifiedMs: '1234',
+      }).success,
+    ).toBe(false)
+  })
+})

--- a/packages/core/src/sync/commands.ts
+++ b/packages/core/src/sync/commands.ts
@@ -52,7 +52,7 @@ export type RemoteDelta = z.infer<typeof remoteDeltaSchema>
 export const changedFileSchema = z.object({
   path: z.string(),
   kind: z.enum(['upsert', 'remove']),
-  /** Last-modified time (epoch ms; upserts only) — real mtime for the reindex. */
+  /** Real mtime when the native filesystem supplies it; unavailable metadata must not discard a landed merge. */
   modifiedMs: z
     .number()
     .nullish()

--- a/packages/core/src/sync/commands.ts
+++ b/packages/core/src/sync/commands.ts
@@ -53,12 +53,15 @@ export const changedFileSchema = z.object({
   path: z.string(),
   kind: z.enum(['upsert', 'remove']),
   /** Last-modified time (epoch ms; upserts only) — real mtime for the reindex. */
-  modifiedMs: z.number().optional(),
+  modifiedMs: z
+    .number()
+    .nullish()
+    .transform((value) => value ?? undefined),
 })
 export type ChangedFile = z.infer<typeof changedFileSchema>
 
 export const mergeOutcomeSchema = z.object({
-  kind: z.enum(['upToDate', 'fastForward', 'merged', 'mergedWithConflicts']),
+  kind: z.enum(['upToDate', 'fastForward', 'merged', 'mergedWithConflicts', 'worktreeChanged']),
   conflictedPaths: z.array(z.string()),
   /**
    * Every file the merge changed. The caller reindexes these directly —
@@ -129,8 +132,9 @@ export async function gitFetch(token: string | null, generation: number): Promis
 
 /**
  * Merge the fetched remote branch. Conflicts are committed into the notes as
- * labeled markers — the repo is never left mid-merge, and the indexer turns
- * the markers into `Needs review` flags.
+ * labeled markers, and the indexer turns them into `Needs review` flags.
+ * `worktreeChanged` is a no-write refusal: snapshot local edits and retry.
+ * Installation failures preserve originals and report recovery instructions.
  */
 export async function gitMergeRemote(generation: number): Promise<MergeOutcome> {
   return await call('git_merge_remote', { generation }, mergeOutcomeSchema)

--- a/packages/core/src/sync/engine.test.ts
+++ b/packages/core/src/sync/engine.test.ts
@@ -61,6 +61,47 @@ function commandsOf(calls: Call[]): string[] {
 }
 
 describe('createSyncEngine', () => {
+  it.each([
+    { retry: false, stop: true },
+    { retry: true, stop: true },
+    { retry: false, stop: false },
+    { retry: true, stop: false },
+  ])('respects skipped-file callback cancellation: %j', async ({ retry, stop }) => {
+    let commits = 0
+    let allowed = true
+    const calls = fakeGit((command) => {
+      if (command === 'git_commit_all') {
+        commits += 1
+        return retry && commits === 1
+          ? CLEAN_COMMIT
+          : {
+              ...COMMITTED,
+              skippedLargeFiles: [{ path: 'assets/large.bin', size: 100_000_000 }],
+            }
+      }
+      return command === 'git_merge_remote' ? WORKTREE_CHANGED : defaultResponses(command)
+    })
+    const engine = createSyncEngine({
+      generation: 1,
+      getToken: async () => null,
+      canStartCycle: () => allowed,
+      onLargeFilesSkipped: () => {
+        if (stop) {
+          engine.stop()
+        } else {
+          allowed = false
+        }
+      },
+    })
+    await engine.syncNow()
+    expect(commandsOf(calls)).toEqual(
+      retry
+        ? ['git_commit_all', 'git_fetch', 'git_merge_remote', 'git_commit_all']
+        : ['git_commit_all'],
+    )
+    engine.stop()
+  })
+
   it('commits a save during fetch before retrying the merge without another fetch', async () => {
     const fetched = Promise.withResolvers<unknown>()
     let merges = 0

--- a/packages/core/src/sync/engine.test.ts
+++ b/packages/core/src/sync/engine.test.ts
@@ -20,6 +20,7 @@ const NON_FAST_FORWARD = {
   rejectionMessage: 'fetch first',
 }
 const MERGED = { kind: 'merged', conflictedPaths: [], changedFiles: [] }
+const WORKTREE_CHANGED = { kind: 'worktreeChanged', conflictedPaths: [], changedFiles: [] }
 const DELTA = { ahead: 1, behind: 0 }
 
 interface Call {
@@ -60,6 +61,137 @@ function commandsOf(calls: Call[]): string[] {
 }
 
 describe('createSyncEngine', () => {
+  it('commits a save during fetch before retrying the merge without another fetch', async () => {
+    const fetched = Promise.withResolvers<unknown>()
+    let merges = 0
+    let commits = 0
+    const calls = fakeGit((command) => {
+      if (command === 'git_fetch') {
+        return fetched.promise
+      }
+      if (command === 'git_commit_all') {
+        commits += 1
+        return commits === 1 ? CLEAN_COMMIT : COMMITTED
+      }
+      if (command === 'git_merge_remote') {
+        merges += 1
+        return merges === 1 ? WORKTREE_CHANGED : MERGED
+      }
+      return defaultResponses(command)
+    })
+    const statuses: SyncStatus[] = []
+    const engine = createSyncEngine({
+      generation: 17,
+      getToken: async () => null,
+      onStatus: (status) => {
+        statuses.push(status)
+      },
+    })
+    const syncing = engine.syncNow()
+    await vi.waitFor(() => expect(commandsOf(calls)).toContain('git_fetch'))
+    engine.noteChanged()
+    fetched.resolve({ ahead: 0, behind: 1 })
+    await syncing
+    expect(commandsOf(calls)).toEqual([
+      'git_commit_all',
+      'git_fetch',
+      'git_merge_remote',
+      'git_commit_all',
+      'git_merge_remote',
+      'git_push',
+    ])
+    expect(calls.every((call) => call.args['generation'] === 17)).toBe(true)
+    expect(statuses.at(-1)).toEqual({ state: 'idle' })
+    engine.stop()
+  })
+
+  it('pushes a retry snapshot even when another window already merged the remote', async () => {
+    let merges = 0
+    let commits = 0
+    const calls = fakeGit((command) => {
+      if (command === 'git_fetch') {
+        return { ahead: 0, behind: 1 }
+      }
+      if (command === 'git_commit_all') {
+        return ++commits === 1 ? CLEAN_COMMIT : COMMITTED
+      }
+      if (command === 'git_merge_remote') {
+        return ++merges === 1 ? WORKTREE_CHANGED : { ...MERGED, kind: 'upToDate' }
+      }
+      return defaultResponses(command)
+    })
+    const engine = createSyncEngine({ generation: 1, getToken: async () => null })
+    await engine.syncNow()
+    expect(commandsOf(calls).at(-1)).toBe('git_push')
+    engine.stop()
+  })
+
+  it('bounds dirty-worktree retries and never pushes a refused merge', async () => {
+    const calls = fakeGit((command) =>
+      command === 'git_merge_remote' ? WORKTREE_CHANGED : defaultResponses(command),
+    )
+    const statuses: SyncStatus[] = []
+    const engine = createSyncEngine({
+      generation: 1,
+      getToken: async () => null,
+      onStatus: (status) => {
+        statuses.push(status)
+      },
+    })
+    await engine.syncNow()
+    expect(commandsOf(calls).filter((command) => command === 'git_merge_remote')).toHaveLength(3)
+    expect(commandsOf(calls)).not.toContain('git_push')
+    expect(statuses.at(-1)).toMatchObject({ state: 'error', errorKind: 'other' })
+    engine.stop()
+  })
+
+  it('stops at the retry commit boundary when the graph is switched', async () => {
+    const snapshot = Promise.withResolvers<unknown>()
+    let commits = 0
+    const calls = fakeGit((command) => {
+      if (command === 'git_commit_all' && ++commits > 1) {
+        return snapshot.promise
+      }
+      return command === 'git_merge_remote' ? WORKTREE_CHANGED : defaultResponses(command)
+    })
+    const engine = createSyncEngine({ generation: 1, getToken: async () => null })
+    const syncing = engine.syncNow()
+    await vi.waitFor(() =>
+      expect(commandsOf(calls).filter((command) => command === 'git_commit_all')).toHaveLength(2),
+    )
+    engine.stop()
+    snapshot.resolve(COMMITTED)
+    await syncing
+    expect(commandsOf(calls)).toEqual([
+      'git_commit_all',
+      'git_fetch',
+      'git_merge_remote',
+      'git_commit_all',
+    ])
+  })
+
+  it('accepts native null mtimes and notifies removals before pushing', async () => {
+    const changes: unknown[] = []
+    fakeGit((command) =>
+      command === 'git_merge_remote'
+        ? {
+            ...MERGED,
+            changedFiles: [{ path: 'notes/deleted.md', kind: 'remove', modifiedMs: null }],
+          }
+        : defaultResponses(command),
+    )
+    const engine = createSyncEngine({
+      generation: 1,
+      getToken: async () => null,
+      onRemoteChanges: (batch) => {
+        changes.push(...batch)
+      },
+    })
+    await engine.syncNow()
+    expect(changes).toEqual([{ path: 'notes/deleted.md', kind: 'remove', modifiedMs: undefined }])
+    engine.stop()
+  })
+
   it('debounces edits into one commit→push cycle pinned to the generation', async () => {
     const calls = fakeGit(defaultResponses)
     const statuses: SyncStatus[] = []

--- a/packages/core/src/sync/engine.ts
+++ b/packages/core/src/sync/engine.ts
@@ -5,6 +5,7 @@ import {
   gitMergeRemote,
   gitPush,
   type ChangedFile,
+  type MergeOutcome,
   type SkippedFile,
 } from './commands'
 
@@ -14,7 +15,7 @@ import {
  * reach the UI — only {@link SyncStatus}.
  *
  * Invariants:
- * - **Never wedged.** Merges commit their conflicts (markers in the note), so
+ * - **Conflicts keep syncing.** Merges commit their conflicts (markers in the note), so
  *   a conflict pauses nothing; the indexer surfaces `Needs review` per note.
  * - **No write loops, no idle network.** Pull-applied file changes re-enter
  *   `noteChanged` via the watcher, but the next cycle finds nothing committed
@@ -314,7 +315,7 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
       // Launch/focus: pick up other devices' changes even with nothing to push.
       const delta = await step(gitFetch(token, options.generation))
       const merged = await merge(remoteChanges)
-      const localOnly = commit.committed || delta.ahead > 0
+      const localOnly = commit.committed || delta.ahead > 0 || merged.committed
       if (!localOnly && (merged.kind === 'upToDate' || merged.kind === 'fastForward')) {
         return // pulled cleanly and have nothing of our own — no push needed
       }
@@ -338,14 +339,30 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
   }
 
   /** Merge fetched changes and start any changed-file notification. */
-  async function merge(remoteChanges: (changes: ChangedFile[]) => void): Promise<{ kind: string }> {
-    return await step(gitMergeRemote(options.generation), (outcome) => {
-      // The command may already have rewritten files before suspension. Fan
-      // those changes out before the boundary gate stops subsequent Git work.
-      if (outcome.changedFiles.length > 0) {
-        remoteChanges(outcome.changedFiles)
+  async function merge(
+    remoteChanges: (changes: ChangedFile[]) => void,
+  ): Promise<{ kind: MergeOutcome['kind']; committed: boolean }> {
+    let committed = false
+    for (let attempt = 0; attempt < MAX_PUSH_ATTEMPTS; attempt++) {
+      const outcome = await step(gitMergeRemote(options.generation), (result) => {
+        if (result.changedFiles.length > 0) {
+          remoteChanges(result.changedFiles)
+        }
+      })
+      if (outcome.kind !== 'worktreeChanged') {
+        return { kind: outcome.kind, committed }
       }
-    }) // upToDate is a no-op
+      if (attempt + 1 < MAX_PUSH_ATTEMPTS) {
+        const snapshot = await step(gitCommitAll('Update notes', options.generation))
+        committed ||= snapshot.committed
+        if (snapshot.skippedLargeFiles.length > 0) {
+          options.onLargeFilesSkipped?.(snapshot.skippedLargeFiles)
+        }
+      }
+    }
+    throw new Error(
+      'Local files kept changing during Git sync. Nothing was overwritten; retry when editing pauses.',
+    )
   }
 
   function syncNow(): Promise<void> {

--- a/packages/core/src/sync/engine.ts
+++ b/packages/core/src/sync/engine.ts
@@ -5,6 +5,7 @@ import {
   gitMergeRemote,
   gitPush,
   type ChangedFile,
+  type CommitOutcome,
   type MergeOutcome,
   type SkippedFile,
 } from './commands'
@@ -296,10 +297,7 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
     remoteChanges: (changes: ChangedFile[]) => void,
   ): Promise<void> {
     const token = options.localOnly === true ? null : await step(options.getToken())
-    const commit = await step(gitCommitAll('Update notes', options.generation))
-    if (commit.skippedLargeFiles.length > 0) {
-      options.onLargeFilesSkipped?.(commit.skippedLargeFiles)
-    }
+    const commit = await step(gitCommitAll('Update notes', options.generation), reportSkippedFiles)
     if (options.localOnly === true) {
       return // the commit is the whole cycle — the repo has no remote
     }
@@ -353,11 +351,11 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
         return { kind: outcome.kind, committed }
       }
       if (attempt + 1 < MAX_PUSH_ATTEMPTS) {
-        const snapshot = await step(gitCommitAll('Update notes', options.generation))
+        const snapshot = await step(
+          gitCommitAll('Update notes', options.generation),
+          reportSkippedFiles,
+        )
         committed ||= snapshot.committed
-        if (snapshot.skippedLargeFiles.length > 0) {
-          options.onLargeFilesSkipped?.(snapshot.skippedLargeFiles)
-        }
       }
     }
     throw new Error(
@@ -367,6 +365,13 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
 
   function syncNow(): Promise<void> {
     return run('full')
+  }
+
+  /** Run commit notifications inside the step's cancellation/suppression boundary. */
+  function reportSkippedFiles(outcome: CommitOutcome): void {
+    if (outcome.skippedLargeFiles.length > 0) {
+      options.onLargeFilesSkipped?.(outcome.skippedLargeFiles)
+    }
   }
 
   function stop(): void {


### PR DESCRIPTION
## Summary

- Preserve edits saved during fetch: native merge refuses dirty worktrees, and the engine snapshots and retries without another network fetch (bounded to three attempts).
- Replace live forced checkout / mid-merge mutation with in-memory merge preparation and recoverable file installation. Canonical-root mutation gates coordinate native writers across windows; Git ref/index locks and no-clobber file claims protect checkout boundaries. Note saves wait off the UI thread and revalidate their generation after checkout rather than failing a quit-time flush.
- Keep all binary conflict versions with numbered, collision-safe filenames. Existing attachment references remain unchanged.
- Remove previously tracked `.reflect` entries from new backup commits and merged trees without touching local files. Pull and clone never install remote runtime data over an open SQLite database/WAL or durable chat history.
- Normalize native null modification times so deletion notifications reach the index instead of failing IPC validation.

The branch is based on `a28944d5`, still current `origin/master` at verification, matching the audited base. Regression tests exercise the actual repository primitives rather than importing the scratch audit harness.

## Safety and recovery

Original file inodes and failed-install displaced files are retained under the actual Git directory's `reflect-sync/checkout-*/`. This preserves late external writes through open descriptors as well as atomic-save races. Failed installations restore the index/worktree; an interruption or failed rollback leaves a marker that blocks committing a partial pull. See [the recovery contract](https://github.com/team-reflect/reflect-open/blob/codex/harden-git-sync/docs/git-sync-safety.md).

Archives deliberately have no automatic deletion. Existing history is not rewritten: old runtime-containing commits, including pre-adoption commits, can still be included in a normal history push. Non-regular/path-shape conflicts and filter-transformed worktrees can safely refuse; no external checkout filters are executed. Concurrent external directory restructuring is not coordinated. Crash/power-loss recovery is documented, not claimed as exhaustively fault-injected on every platform.

## Validation

- `pnpm check`
- `pnpm --filter @reflect/desktop build`
- `pnpm test --run packages/core/src/sync/commands.test.ts packages/core/src/sync/engine.test.ts apps/desktop/src/lib/backup-controller.test.tsx apps/desktop/src/editor/note-session.test.ts` — 126 passed
- `pnpm --filter @reflect/desktop sidecar` before desktop compilation
- `cargo test -p reflect-open git:: --lib` — 55 passed
- `cargo test -p reflect-open fs:: --lib` — 104 passed
- `cargo test -p reflect-open capture:: --lib` — 18 passed
- `cargo clippy -p reflect-open --all-targets -- -D warnings`
- `cargo fmt --all` / `git diff --check`

Deterministic tests cover commit/fetch/save interleaving, post-preflight edits, move/claim atomic-save races, partial rollback, late descriptor writes, existing index locks, interrupted-sync refusal, repeated binary collisions, runtime adoption/fast-forward/divergence/restore, an open SQLite WAL database, normal merge/rename behavior, bounded TS retries, graph-stop boundaries, and nullable removal mtimes.

Local validation ran on macOS arm64. The build reports existing large-chunk/plugin-timing warnings; Vitest reports existing native-config-loader warnings. No local check is blocked.

Bugbot was explicitly requested with `@cursor review`; Cursor replied that Bugbot is disabled for this repository. No repository/service settings were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Git synchronization now safely handles concurrent edits, interrupted operations, and failed checkouts while preserving original files and providing recovery information.
  - Local runtime data remains excluded from synchronized repositories and is protected during merges and restores.
  - Note saves and other file changes are coordinated to prevent conflicts during Git operations.
  - Sync now retries eligible worktree changes and reports when local edits prevent automatic updates.

- **Documentation**
  - Added guidance for sync safety, conflict handling, and recovery procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->