### PR TITLE
fix: preserve edits and recovery data during Git sync

### DIFF
--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -498,8 +498,11 @@ pub async fn capture_screenshot_promote(
     state: State<'_, GraphState>,
 ) -> AppResult<()> {
     let root = root_for_generation(&state, generation)?;
-    let bytes = fs::read(inbox_file(&root, &spool_name)?)?;
-    let jpeg = downscale_jpeg(&bytes, max_dim)?;
+    let jpeg = crate::blocking::run_blocking(move || {
+        let bytes = fs::read(inbox_file(&root, &spool_name)?)?;
+        downscale_jpeg(&bytes, max_dim)
+    })
+    .await?;
     crate::fs::mutation::run(state.inner().clone(), generation, move |root| {
         persist_asset(root, &asset_path, &jpeg)
     })

--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -490,17 +490,20 @@ fn persist_asset(root: &Path, asset_path: &str, bytes: &[u8]) -> AppResult<()> {
 /// not move — the drain removes spool files only after the note is written,
 /// so a crash mid-drain re-runs cleanly.
 #[tauri::command]
-pub fn capture_screenshot_promote(
+pub async fn capture_screenshot_promote(
     spool_name: String,
     asset_path: String,
     max_dim: u32,
     generation: u64,
-    state: State<GraphState>,
+    state: State<'_, GraphState>,
 ) -> AppResult<()> {
     let root = root_for_generation(&state, generation)?;
     let bytes = fs::read(inbox_file(&root, &spool_name)?)?;
     let jpeg = downscale_jpeg(&bytes, max_dim)?;
-    persist_asset(&root, &asset_path, &jpeg)
+    crate::fs::mutation::run(state.inner().clone(), generation, move |root| {
+        persist_asset(root, &asset_path, &jpeg)
+    })
+    .await
 }
 
 /// Ask the platform link-preview service for one representative image and

--- a/apps/desktop/src-tauri/src/db/mod.rs
+++ b/apps/desktop/src-tauri/src/db/mod.rs
@@ -301,19 +301,51 @@ pub struct NoteMoveRequest {
     from_address: write::MovedNoteAddress,
 }
 
+/// Move a note and its index rows after waiting for checkout off the main thread.
 #[tauri::command]
-pub fn note_move_indexed<R: tauri::Runtime>(
+pub async fn note_move_indexed<R: tauri::Runtime>(
     request: NoteMoveRequest,
     generation: u64,
     app: tauri::AppHandle<R>,
-    graph: State<GraphState>,
-    index: State<IndexState>,
-    background_tasks: State<BackgroundTaskState>,
+    graph: State<'_, GraphState>,
 ) -> AppResult<()> {
+    let graph = graph.inner().clone();
+    crate::fs::mutation::run(graph.clone(), generation, move |_| {
+        // Acquire the worktree off-thread, then retain the existing short main-
+        // thread SQLite section: its iOS background assertion cannot expire
+        // until the native callback returns and releases the database lock.
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        let callback_app = app.clone();
+        app.run_on_main_thread(move || {
+            let outcome =
+                move_note_indexed_on_main_thread(&callback_app, &graph, generation, &request);
+            let _ = sender.send(outcome);
+        })
+        .map_err(|error| AppError::io(format!("could not schedule note move: {error}")))?;
+        receiver
+            .recv()
+            .map_err(|_| AppError::io("the application closed before the note move completed"))?
+    })
+    .await
+}
+
+/// Complete the indexed rename on the main thread while the worker owns the
+/// worktree scope. Recheck both graph and index after the queued callback runs.
+fn move_note_indexed_on_main_thread<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    graph: &GraphState,
+    generation: u64,
+    request: &NoteMoveRequest,
+) -> AppResult<()> {
+    let root = crate::fs::root_for_generation(graph, generation)?;
+    let background_tasks = app.state::<BackgroundTaskState>();
     let _background_task = background_task::scoped(&background_tasks, "Reflect note move");
-    let root = crate::fs::root_for_generation(&graph, generation)?;
+    let index = app.state::<IndexState>();
     {
         let mut state = lock_state(&index)?;
+        if state.root.as_deref() != Some(root.as_path()) {
+            return Err(AppError::io("the graph index changed before the note move"));
+        }
         let conn = state.conn.as_mut().ok_or_else(AppError::no_graph)?;
         move_rows(conn, &request.from, &request.to, &request.to_address)?;
         if let Err(err) = crate::fs::move_note_file(&root, &request.from, &request.to) {
@@ -329,9 +361,9 @@ pub fn note_move_indexed<R: tauri::Runtime>(
             return Err(err);
         }
     }
-    crate::fs::invalidate_file_catalog(&graph, &root);
-    emit_index_written(&app);
-    emit_note_moved(&app, &request.from, &request.to);
+    crate::fs::invalidate_file_catalog(graph, &root);
+    emit_index_written(app);
+    emit_note_moved(app, &request.from, &request.to);
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -1635,6 +1635,86 @@ fn apply_chunks_for_an_unindexed_path_is_a_cleaning_no_op() {
 
 // ---- note_move (Plan 17) ----------------------------------------------------
 
+#[test]
+fn indexed_move_rechecks_session_and_compensates_file_collisions() {
+    use tauri::Manager;
+
+    let app = tauri::test::mock_builder()
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .unwrap();
+    app.manage(crate::fs::GraphState::default());
+    app.manage(super::IndexState::default());
+    app.manage(crate::background_task::BackgroundTaskState::default());
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path();
+    std::fs::create_dir(root.join("notes")).unwrap();
+    std::fs::write(root.join("notes/a.md"), "local note\n").unwrap();
+    let graph = app.state::<crate::fs::GraphState>();
+    {
+        let mut inner = graph.0.lock().unwrap();
+        inner.root = Some(root.to_path_buf());
+        inner.generation = 2;
+    }
+    super::index_open(app.state(), app.state(), app.state()).unwrap();
+    let index = app.state::<super::IndexState>();
+    {
+        let state = super::lock_state(&index).unwrap();
+        index_note(state.conn.as_ref().unwrap(), "notes/a.md");
+    }
+    let request = super::NoteMoveRequest {
+        from: "notes/a.md".to_owned(),
+        to: "notes/b.md".to_owned(),
+        from_address: moved_address("notes/a.md"),
+        to_address: moved_address("notes/b.md"),
+    };
+
+    crate::fs::mutation::with_root(root, || {
+        // A graph switch occurred before the queued main-thread callback ran.
+        assert!(
+            super::move_note_indexed_on_main_thread(app.handle(), &graph, 1, &request).is_err()
+        );
+        // A new graph can also be active before its index has been rebound.
+        super::lock_state(&index)?.root = None;
+        assert!(
+            super::move_note_indexed_on_main_thread(app.handle(), &graph, 2, &request).is_err()
+        );
+        assert!(root.join("notes/a.md").exists());
+        assert!(!root.join("notes/b.md").exists());
+        super::lock_state(&index)?.root = Some(root.to_path_buf());
+        super::move_note_indexed_on_main_thread(app.handle(), &graph, 2, &request)
+    })
+    .unwrap();
+    assert_eq!(
+        std::fs::read(root.join("notes/b.md")).unwrap(),
+        b"local note\n"
+    );
+    assert!(!root.join("notes/a.md").exists());
+
+    std::fs::write(root.join("notes/c.md"), "occupied\n").unwrap();
+    let collision = super::NoteMoveRequest {
+        from: "notes/b.md".to_owned(),
+        to: "notes/c.md".to_owned(),
+        from_address: moved_address("notes/b.md"),
+        to_address: moved_address("notes/c.md"),
+    };
+    assert!(crate::fs::mutation::with_root(root, || {
+        super::move_note_indexed_on_main_thread(app.handle(), &graph, 2, &collision)
+    })
+    .is_err());
+    assert_eq!(
+        std::fs::read(root.join("notes/b.md")).unwrap(),
+        b"local note\n"
+    );
+    assert_eq!(
+        std::fs::read(root.join("notes/c.md")).unwrap(),
+        b"occupied\n"
+    );
+    let state = super::lock_state(&index).unwrap();
+    let rows = run_query(state.conn.as_ref().unwrap(), "SELECT path FROM notes", &[]).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["path"], "notes/b.md");
+}
+
 fn move_in_txn(conn: &mut Connection, from: &str, to: &str) -> crate::error::AppResult<()> {
     let tx = conn.transaction()?;
     tx.execute_batch("PRAGMA defer_foreign_keys = ON;")?;

--- a/apps/desktop/src-tauri/src/fs/assets.rs
+++ b/apps/desktop/src-tauri/src/fs/assets.rs
@@ -127,16 +127,11 @@ pub(super) fn staging_dir(root: &Path) -> AppResult<std::path::PathBuf> {
 
 /// Resolved `assets/` directory for a commit/import destination, traversal-
 /// and generation-guarded.
-fn assets_dir_for(
-    state: &State<GraphState>,
-    generation: u64,
-    name: &str,
-) -> AppResult<std::path::PathBuf> {
+fn assets_dir_for(root: &Path, name: &str) -> AppResult<std::path::PathBuf> {
     ensure_asset_name(name)?;
-    let root = root_for_generation(state, generation)?;
     // Resolve the target through the shared guard even though `name` is
     // already vetted — defense in depth, and it canonicalizes symlink games.
-    resolve(&root, &format!("assets/{name}"))?;
+    resolve(root, &format!("assets/{name}"))?;
     let dir = root.join("assets");
     fs::create_dir_all(&dir)?;
     Ok(dir)
@@ -187,12 +182,12 @@ pub fn asset_upload_append(request: Request<'_>, uploads: State<AssetUploads>) -
 /// under `desired_name` (or the first free `-2`-suffixed variant). Returns the
 /// final graph-relative `assets/…` path.
 #[tauri::command]
-pub fn asset_upload_commit(
+pub async fn asset_upload_commit(
     id: String,
     desired_name: String,
     generation: u64,
-    state: State<GraphState>,
-    uploads: State<AssetUploads>,
+    state: State<'_, GraphState>,
+    uploads: State<'_, AssetUploads>,
 ) -> AppResult<String> {
     let upload = lock_uploads(&uploads)?
         .remove(&id)
@@ -204,11 +199,12 @@ pub fn asset_upload_commit(
     }
     // Pin the root before persisting: after the file lands, a failed root
     // lookup would otherwise skip invalidation and strand a stale catalog.
-    let root = root_for_generation(&state, generation)?;
-    let assets_dir = assets_dir_for(&state, generation, &desired_name)?;
-    let final_name = persist_unique(upload.file, &assets_dir, &desired_name)?;
-    super::invalidate_file_catalog(&state, &root);
-    Ok(format!("assets/{final_name}"))
+    super::mutation::run(state.inner().clone(), generation, move |root| {
+        let assets_dir = assets_dir_for(root, &desired_name)?;
+        let final_name = persist_unique(upload.file, &assets_dir, &desired_name)?;
+        Ok(format!("assets/{final_name}"))
+    })
+    .await
 }
 
 /// Persist a staged upload at an exact target path, creating parent
@@ -242,12 +238,12 @@ fn persist_exact(temp: tempfile::NamedTempFile, target: &Path) -> AppResult<()> 
 /// it. Memo basenames carry millisecond precision; an existing file at
 /// `path` is a bug and fails loudly rather than being clobbered.
 #[tauri::command]
-pub fn asset_upload_commit_path(
+pub async fn asset_upload_commit_path(
     id: String,
     path: String,
     generation: u64,
-    state: State<GraphState>,
-    uploads: State<AssetUploads>,
+    state: State<'_, GraphState>,
+    uploads: State<'_, AssetUploads>,
 ) -> AppResult<()> {
     let upload = lock_uploads(&uploads)?
         .remove(&id)
@@ -257,11 +253,12 @@ pub fn asset_upload_commit_path(
             "upload was started for a different graph session; dropping it",
         ));
     }
-    let root = root_for_generation(&state, generation)?;
-    let target = resolve(&root, &path)?;
-    persist_exact(upload.file, &target)?;
-    super::invalidate_file_catalog(&state, &root);
-    Ok(())
+    super::mutation::run(state.inner().clone(), generation, move |root| {
+        let target = resolve(root, &path)?;
+        persist_exact(upload.file, &target)?;
+        Ok(())
+    })
+    .await
 }
 
 /// Discard an in-flight upload; dropping the temp file deletes it. Idempotent
@@ -276,11 +273,11 @@ pub fn asset_upload_abort(id: String, uploads: State<AssetUploads>) -> AppResult
 /// under `desired_name`, with the same collision policy as uploads. The bytes
 /// never cross the IPC. Returns the final graph-relative `assets/…` path.
 #[tauri::command]
-pub fn asset_import(
+pub async fn asset_import(
     source_path: String,
     desired_name: String,
     generation: u64,
-    state: State<GraphState>,
+    state: State<'_, GraphState>,
 ) -> AppResult<String> {
     let source = Path::new(&source_path);
     if !source.is_file() {
@@ -288,13 +285,15 @@ pub fn asset_import(
             "import source is not a file: {source_path}"
         )));
     }
-    let root = root_for_generation(&state, generation)?;
-    let mut temp = tempfile::NamedTempFile::new_in(staging_dir(&root)?)?;
-    std::io::copy(&mut fs::File::open(source)?, temp.as_file_mut())?;
-    let assets_dir = assets_dir_for(&state, generation, &desired_name)?;
-    let final_name = persist_unique(temp, &assets_dir, &desired_name)?;
-    super::invalidate_file_catalog(&state, &root);
-    Ok(format!("assets/{final_name}"))
+    super::mutation::run(state.inner().clone(), generation, move |root| {
+        let source = Path::new(&source_path);
+        let mut temp = tempfile::NamedTempFile::new_in(staging_dir(root)?)?;
+        std::io::copy(&mut fs::File::open(source)?, temp.as_file_mut())?;
+        let assets_dir = assets_dir_for(root, &desired_name)?;
+        let final_name = persist_unique(temp, &assets_dir, &desired_name)?;
+        Ok(format!("assets/{final_name}"))
+    })
+    .await
 }
 
 /// Copy `source` into the graph at `target`, staging the bytes under
@@ -325,22 +324,23 @@ fn import_exact(source: &Path, staging: &Path, target: &Path) -> AppResult<()> {
 /// `audio_memo_delete`, and the path *is* the memo's identity, so the
 /// `assets/` collision renaming of [`asset_import`] would corrupt it.
 #[tauri::command]
-pub fn audio_memo_import(
+pub async fn audio_memo_import(
     source_path: String,
     path: String,
     generation: u64,
-    state: State<GraphState>,
+    state: State<'_, GraphState>,
 ) -> AppResult<()> {
     if !path.starts_with("audio-memos/") {
         return Err(AppError::traversal(format!(
             "not an audio memo path: {path}"
         )));
     }
-    let root = root_for_generation(&state, generation)?;
-    let target = resolve(&root, &path)?;
-    import_exact(Path::new(&source_path), &staging_dir(&root)?, &target)?;
-    super::invalidate_file_catalog(&state, &root);
-    Ok(())
+    super::mutation::run(state.inner().clone(), generation, move |root| {
+        let target = resolve(root, &path)?;
+        import_exact(Path::new(&source_path), &staging_dir(root)?, &target)?;
+        Ok(())
+    })
+    .await
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/fs/mod.rs
+++ b/apps/desktop/src-tauri/src/fs/mod.rs
@@ -11,11 +11,12 @@ pub mod assets;
 mod import;
 mod import_assets;
 mod io;
+pub(crate) mod mutation;
 mod resolve;
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use serde::Serialize;
 use tauri::{Emitter, Manager, State};
@@ -83,8 +84,8 @@ pub struct GraphInner {
 }
 
 /// Tauri-managed state holding the currently open graph (root + generation).
-#[derive(Default)]
-pub struct GraphState(pub Mutex<GraphInner>);
+#[derive(Clone, Default)]
+pub struct GraphState(pub Arc<Mutex<GraphInner>>);
 
 /// Identity of an open graph, returned to the frontend.
 #[derive(Serialize)]
@@ -196,10 +197,7 @@ pub(crate) fn current_graph_info(state: &State<GraphState>) -> AppResult<GraphIn
 /// issued for. A stale generation means the graph was switched after the
 /// command was enqueued — the mutation must be rejected (loudly), or it would
 /// land in the *new* graph's same-named file.
-pub(crate) fn root_for_generation(
-    state: &State<GraphState>,
-    generation: u64,
-) -> AppResult<PathBuf> {
+pub(crate) fn root_for_generation(state: &GraphState, generation: u64) -> AppResult<PathBuf> {
     let inner = lock_graph(state)?;
     if inner.generation != generation {
         return Err(AppError::io(
@@ -292,14 +290,21 @@ pub async fn graph_import_reflect_v1_zip(
     // Writing is fast and local; throttle the events to ~100 per import so a
     // large graph doesn't flood the webview.
     let mut last_emitted = 0usize;
-    let summary = import::finalize_import(&root, prepared, downloads, |done, total| {
-        let step = (total / 100).max(1);
-        if done == total || done >= last_emitted + step {
-            last_emitted = done;
-            emit_import_progress(&app, "writing", done, total);
+    let cancelled = cancel.flag();
+    let summary = mutation::run(state.inner().clone(), generation, move |root| {
+        // Cancellation may arrive while this import waits for Git checkout.
+        if cancelled.load(std::sync::atomic::Ordering::SeqCst) {
+            return Err(AppError::io("import cancelled"));
         }
-    })?;
-    invalidate_file_catalog(&state, &root);
+        import::finalize_import(root, prepared, downloads, |done, total| {
+            let step = (total / 100).max(1);
+            if done == total || done >= last_emitted + step {
+                last_emitted = done;
+                emit_import_progress(&app, "writing", done, total);
+            }
+        })
+    })
+    .await?;
     Ok(summary)
 }
 
@@ -416,57 +421,60 @@ pub async fn note_read_local(
 /// with the value a later `list_files` will report — a `Date.now()` stamp
 /// never matches and costs a re-read on every reconcile.
 #[tauri::command]
-pub fn note_write(
+pub async fn note_write(
     path: String,
     contents: String,
     generation: u64,
-    state: State<GraphState>,
+    state: State<'_, GraphState>,
 ) -> AppResult<Option<u64>> {
-    let root = root_for_generation(&state, generation)?;
-    let modified_ms = atomic_write(&root, &resolve(&root, &path)?, &contents)?;
-    invalidate_file_catalog(&state, &root);
-    Ok(modified_ms)
+    mutation::run(state.inner().clone(), generation, move |root| {
+        let modified_ms = atomic_write(root, &resolve(root, &path)?, &contents)?;
+        Ok(modified_ms)
+    })
+    .await
 }
 
 /// Atomically create a note only when `path` is still free. Unlike
 /// [`note_write`], this is a no-clobber claim: a concurrent sync checkout or
 /// creator wins as `Collision`, with its file left byte-for-byte intact.
 #[tauri::command]
-pub fn note_create(
+pub async fn note_create(
     path: String,
     contents: String,
     generation: u64,
-    state: State<GraphState>,
+    state: State<'_, GraphState>,
 ) -> AppResult<NoteCreateOutcome> {
-    let root = root_for_generation(&state, generation)?;
-    let target = resolve(&root, &path)?;
-    match atomic_create(&root, &target, &contents)? {
-        AtomicCreateOutcome::Created(modified_ms) => {
-            invalidate_file_catalog(&state, &root);
-            Ok(NoteCreateOutcome::Created { modified_ms })
+    mutation::run(state.inner().clone(), generation, move |root| {
+        let target = resolve(root, &path)?;
+        match atomic_create(root, &target, &contents)? {
+            AtomicCreateOutcome::Created(modified_ms) => {
+                Ok(NoteCreateOutcome::Created { modified_ms })
+            }
+            AtomicCreateOutcome::Collision => Ok(NoteCreateOutcome::Collision),
         }
-        AtomicCreateOutcome::Collision => Ok(NoteCreateOutcome::Collision),
-    }
+    })
+    .await
 }
 
 /// Atomically write a binary asset (pasted/dropped image) by graph-relative
 /// path. Contents arrive base64-encoded — Tauri IPC args are JSON, and pasted
 /// images are small enough that the ~33% encoding overhead is irrelevant.
 #[tauri::command]
-pub fn asset_write(
+pub async fn asset_write(
     path: String,
     contents_base64: String,
     generation: u64,
-    state: State<GraphState>,
+    state: State<'_, GraphState>,
 ) -> AppResult<()> {
-    use base64::Engine;
-    let root = root_for_generation(&state, generation)?;
-    let bytes = base64::engine::general_purpose::STANDARD
-        .decode(contents_base64.as_bytes())
-        .map_err(|err| AppError::io(format!("invalid base64 asset payload: {err}")))?;
-    atomic_write_bytes(&root, &resolve(&root, &path)?, &bytes)?;
-    invalidate_file_catalog(&state, &root);
-    Ok(())
+    mutation::run(state.inner().clone(), generation, move |root| {
+        use base64::Engine;
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(contents_base64.as_bytes())
+            .map_err(|err| AppError::io(format!("invalid base64 asset payload: {err}")))?;
+        atomic_write_bytes(root, &resolve(root, &path)?, &bytes)?;
+        Ok(())
+    })
+    .await
 }
 
 /// Delete one recording under `audio-memos/`: cancelling a recording session
@@ -475,29 +483,35 @@ pub fn asset_write(
 /// file-delete IPC. Idempotent — a segment deleted twice (or never written)
 /// is fine.
 #[tauri::command]
-pub fn audio_memo_delete(path: String, generation: u64, state: State<GraphState>) -> AppResult<()> {
-    if !path.starts_with("audio-memos/") {
-        return Err(AppError::traversal(format!(
-            "not an audio memo path: {path}"
-        )));
-    }
-    let root = root_for_generation(&state, generation)?;
-    let abs = resolve(&root, &path)?;
-    // An iCloud-evicted segment exists only as its `.name.icloud` stub —
-    // mirror `note_delete` so a cancelled session's evicted parts still
-    // delete (Plan 21).
-    let target = if abs.exists() {
-        abs
-    } else {
-        eviction_placeholder(&abs)
-            .filter(|stub| stub.exists())
-            .unwrap_or(abs)
-    };
-    match fs::remove_file(target) {
-        Ok(()) => Ok(()),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(err.into()),
-    }
+pub async fn audio_memo_delete(
+    path: String,
+    generation: u64,
+    state: State<'_, GraphState>,
+) -> AppResult<()> {
+    mutation::run(state.inner().clone(), generation, move |root| {
+        if !path.starts_with("audio-memos/") {
+            return Err(AppError::traversal(format!(
+                "not an audio memo path: {path}"
+            )));
+        }
+        let abs = resolve(root, &path)?;
+        // An iCloud-evicted segment exists only as its `.name.icloud` stub —
+        // mirror `note_delete` so a cancelled session's evicted parts still
+        // delete (Plan 21).
+        let target = if abs.exists() {
+            abs
+        } else {
+            eviction_placeholder(&abs)
+                .filter(|stub| stub.exists())
+                .unwrap_or(abs)
+        };
+        match fs::remove_file(target) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    })
+    .await
 }
 
 /// The per-segment transcript cache lives under `.reflect/transcripts/`:
@@ -709,6 +723,7 @@ pub fn note_exists(path: String, state: State<GraphState>) -> AppResult<bool> {
 /// deleted or overwritten, the caller compensates, and the rename simply
 /// reports failed. One rule, no adoption heuristics; the filename drifts
 /// until the next settled rename retries.
+/// The caller must hold the graph's worktree mutation scope.
 pub(crate) fn move_note_file(root: &Path, from: &str, to: &str) -> AppResult<()> {
     let from_abs = resolve(root, from)?;
     let to_abs = resolve(root, to)?;
@@ -734,27 +749,32 @@ pub(crate) fn move_note_file(root: &Path, from: &str, to: &str) -> AppResult<()>
 /// `.reflect/trash/` instead (Plan 19), the same recoverability promise, and
 /// `.reflect/` is already excluded from sync and indexing.
 #[tauri::command]
-pub fn note_delete(path: String, generation: u64, state: State<GraphState>) -> AppResult<()> {
-    let root = root_for_generation(&state, generation)?;
-    let abs = resolve(&root, &path)?;
-    // An iCloud-evicted note exists only as its `.name.md.icloud` stub —
-    // trashing the logical path would fail and the note would be
-    // undeletable. Removing the stub deletes the iCloud item (Plan 21).
-    let target = if abs.exists() {
-        abs
-    } else {
-        eviction_placeholder(&abs)
-            .filter(|stub| stub.exists())
-            .unwrap_or(abs)
-    };
-    #[cfg(desktop)]
-    os_trash_delete(&target)?;
-    #[cfg(mobile)]
-    move_to_graph_trash(&root, &target)?;
-    // A deleted note's sync ancestor is meaningless — drop it (Plan 21).
-    crate::conflict::shadow::ShadowStore::new(&root).forget(&path);
-    invalidate_file_catalog(&state, &root);
-    Ok(())
+pub async fn note_delete(
+    path: String,
+    generation: u64,
+    state: State<'_, GraphState>,
+) -> AppResult<()> {
+    mutation::run(state.inner().clone(), generation, move |root| {
+        let abs = resolve(root, &path)?;
+        // An iCloud-evicted note exists only as its `.name.md.icloud` stub —
+        // trashing the logical path would fail and the note would be
+        // undeletable. Removing the stub deletes the iCloud item (Plan 21).
+        let target = if abs.exists() {
+            abs
+        } else {
+            eviction_placeholder(&abs)
+                .filter(|stub| stub.exists())
+                .unwrap_or(abs)
+        };
+        #[cfg(desktop)]
+        os_trash_delete(&target)?;
+        #[cfg(mobile)]
+        move_to_graph_trash(root, &target)?;
+        // A deleted note's sync ancestor is meaningless — drop it (Plan 21).
+        crate::conflict::shadow::ShadowStore::new(root).forget(&path);
+        Ok(())
+    })
+    .await
 }
 
 /// Move the open graph's **entire directory** to the OS trash (recoverable)
@@ -768,33 +788,42 @@ pub fn note_delete(path: String, generation: u64, state: State<GraphState>) -> A
 /// never trash the newly opened graph. Desktop-only: mobile's fixed roots
 /// have no OS trash and no delete UI.
 #[tauri::command]
-pub fn graph_delete(generation: u64, state: State<GraphState>) -> AppResult<()> {
+pub async fn graph_delete(generation: u64, state: State<'_, GraphState>) -> AppResult<()> {
     #[cfg(desktop)]
     {
-        // Check-and-invalidate under one lock hold — `root_for_generation`
-        // followed by a separate invalidation would leave a window where a
-        // pinned write still resolves the doomed root.
-        let root = {
-            let mut inner = lock_graph(&state)?;
-            if inner.generation != generation {
-                return Err(AppError::io(
-                    "the graph changed since this command was issued; dropping it",
-                ));
-            }
-            let root = inner.root.take().ok_or_else(AppError::no_graph)?;
-            inner.generation += 1;
-            inner.catalog = None;
-            inner.catalog_revision = inner.catalog_revision.wrapping_add(1);
-            root
-        };
-        os_trash_delete(&root)?;
-        // Recents is a convenience cache (same stance as `activate`): the
-        // directory is already in the trash, so a failure to persist must not
-        // report the delete as failed. A stale entry fails loudly on open.
-        if let Err(err) = crate::recents::forget(&root.to_string_lossy()) {
-            tracing::warn!(?err, "failed to forget deleted graph");
-        }
-        Ok(())
+        let state = state.inner().clone();
+        crate::blocking::run_blocking(move || {
+            let root = root_for_generation(&state, generation)?;
+            mutation::with_repository(&root, || {
+                mutation::with_generation(&state, generation, |_| {
+                    // Check-and-invalidate under one lock hold — `root_for_generation`
+                    // followed by a separate invalidation would leave a window where a
+                    // pinned write still resolves the doomed root.
+                    let root = {
+                        let mut inner = lock_graph(&state)?;
+                        if inner.generation != generation {
+                            return Err(AppError::io(
+                                "the graph changed since this command was issued; dropping it",
+                            ));
+                        }
+                        let root = inner.root.take().ok_or_else(AppError::no_graph)?;
+                        inner.generation += 1;
+                        inner.catalog = None;
+                        inner.catalog_revision = inner.catalog_revision.wrapping_add(1);
+                        root
+                    };
+                    os_trash_delete(&root)?;
+                    // Recents is a convenience cache (same stance as `activate`): the
+                    // directory is already in the trash, so a failure to persist must not
+                    // report the delete as failed. A stale entry fails loudly on open.
+                    if let Err(err) = crate::recents::forget(&root.to_string_lossy()) {
+                        tracing::warn!(?err, "failed to forget deleted graph");
+                    }
+                    Ok(())
+                })
+            })
+        })
+        .await
     }
     #[cfg(mobile)]
     {
@@ -1034,15 +1063,15 @@ mod transcript_cache_tests {
 mod file_catalog_tests {
     use super::{file_catalog, file_catalog_with, invalidate_file_catalog, GraphInner, GraphState};
     use std::fs;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
 
     fn graph_at(root: &std::path::Path, generation: u64) -> GraphState {
-        GraphState(Mutex::new(GraphInner {
+        GraphState(Arc::new(Mutex::new(GraphInner {
             generation,
             root: Some(root.to_path_buf()),
             catalog: None,
             catalog_revision: 0,
-        }))
+        })))
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/fs/mutation.rs
+++ b/apps/desktop/src-tauri/src/fs/mutation.rs
@@ -1,0 +1,172 @@
+//! Coordinate local graph mutations with Git checkout. Network operations
+//! only hold the repository lock; saves wait for local checkout, never fetch.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+
+use crate::error::{AppError, AppResult};
+
+use super::{invalidate_file_catalog, root_for_generation, GraphState};
+
+#[derive(Default)]
+struct GraphLocks {
+    repository: Mutex<()>,
+    worktree: Mutex<()>,
+}
+
+fn locks_for(root: &Path) -> AppResult<Arc<GraphLocks>> {
+    static LOCKS: OnceLock<Mutex<HashMap<PathBuf, Weak<GraphLocks>>>> = OnceLock::new();
+    let canonical = root.canonicalize()?;
+    let mut locks = LOCKS
+        .get_or_init(Mutex::default)
+        .lock()
+        .map_err(|_| AppError::io("graph mutation registry lock poisoned"))?;
+    locks.retain(|_, locks| locks.strong_count() > 0);
+    if let Some(existing) = locks.get(&canonical).and_then(Weak::upgrade) {
+        return Ok(existing);
+    }
+    let graph = Arc::new(GraphLocks::default());
+    locks.insert(canonical, Arc::downgrade(&graph));
+    Ok(graph)
+}
+
+/// Run one local filesystem mutation. Callers must not nest mutation scopes.
+pub(crate) fn with_root<T>(root: &Path, action: impl FnOnce() -> AppResult<T>) -> AppResult<T> {
+    let locks = locks_for(root)?;
+    let _guard = locks
+        .worktree
+        .lock()
+        .map_err(|_| AppError::io("graph worktree lock poisoned"))?;
+    action()
+}
+
+/// Serialize Git commands independently of ordinary graph writes. When a Git
+/// command needs both locks it must take this scope before the worktree scope.
+pub(crate) fn with_repository<T>(
+    root: &Path,
+    action: impl FnOnce() -> AppResult<T>,
+) -> AppResult<T> {
+    let locks = locks_for(root)?;
+    let _guard = locks
+        .repository
+        .lock()
+        .map_err(|_| AppError::io("graph repository lock poisoned"))?;
+    action()
+}
+
+/// Execute a generation-pinned mutation and invalidate the catalog even on
+/// failure, since filesystem operations can fail after changing some paths.
+pub(crate) fn with_generation<T>(
+    state: &GraphState,
+    generation: u64,
+    action: impl FnOnce(&Path) -> AppResult<T>,
+) -> AppResult<T> {
+    let root = root_for_generation(state, generation)?;
+    with_root(&root, || {
+        root_for_generation(state, generation)?;
+        let outcome = action(&root);
+        invalidate_file_catalog(state, &root);
+        outcome
+    })
+}
+
+/// Run local mutations on the blocking pool so waiting for checkout never
+/// blocks the native event loop or keyboard input.
+pub(crate) async fn run<T, F>(state: GraphState, generation: u64, action: F) -> AppResult<T>
+where
+    T: Send + 'static,
+    F: FnOnce(&Path) -> AppResult<T> + Send + 'static,
+{
+    crate::blocking::run_blocking(move || with_generation(&state, generation, action)).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::thread;
+
+    fn graph_at(root: &Path) -> GraphState {
+        let graph = GraphState::default();
+        {
+            let mut inner = graph.0.lock().unwrap();
+            inner.root = Some(root.to_path_buf());
+            inner.generation = 1;
+        }
+        graph
+    }
+
+    #[test]
+    fn network_wait_does_not_block_note_saves() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let graph = graph_at(root);
+        with_repository(root, || {
+            with_generation(&graph, 1, |root| {
+                super::super::atomic_write_bytes(
+                    root,
+                    &root.join("note.md"),
+                    b"saved during fetch",
+                )?;
+                Ok(())
+            })
+        })
+        .unwrap();
+        assert_eq!(
+            std::fs::read(root.join("note.md")).unwrap(),
+            b"saved during fetch"
+        );
+    }
+
+    #[test]
+    fn mutation_excludes_checkout_and_releases_on_error() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let locks = locks_for(root).unwrap();
+        let result: AppResult<()> = with_root(root, || {
+            assert!(locks.worktree.try_lock().is_err());
+            Err(AppError::io("injected checkout failure"))
+        });
+        assert!(result.is_err());
+        assert!(locks.worktree.try_lock().is_ok());
+        with_root(root, || Ok(())).unwrap();
+    }
+
+    #[test]
+    fn queued_save_rechecks_generation_after_checkout() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let graph = graph_at(root);
+        let (started_tx, started_rx) = mpsc::channel();
+        let writer_graph = graph.clone();
+        let locks = locks_for(root).unwrap();
+        let checkout = locks.worktree.lock().unwrap();
+        let writer = thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            with_generation(&writer_graph, 1, |root| {
+                std::fs::write(root.join("note.md"), b"stale save")?;
+                Ok(())
+            })
+        });
+        started_rx.recv().unwrap();
+        graph.0.lock().unwrap().generation = 2;
+        drop(checkout);
+        assert!(writer.join().unwrap().is_err());
+        assert!(!root.join("note.md").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn alternate_root_spellings_share_the_same_checkout_lock() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("graph");
+        std::fs::create_dir(&root).unwrap();
+        let alias = directory.path().join("alias");
+        std::os::unix::fs::symlink(&root, &alias).unwrap();
+        assert!(Arc::ptr_eq(
+            &locks_for(&root).unwrap(),
+            &locks_for(&alias).unwrap()
+        ));
+    }
+}

--- a/apps/desktop/src-tauri/src/git/commit.rs
+++ b/apps/desktop/src-tauri/src/git/commit.rs
@@ -1,7 +1,7 @@
 //! Stage-everything commit with the large-file guardrail.
 
 use std::cell::RefCell;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use git2::{Index, IndexAddOption};
 use serde::Serialize;
@@ -10,6 +10,7 @@ use crate::error::AppResult;
 
 use super::commit_message::message_for_commit;
 use super::repo::{ensure_clean_state, open_existing, signature};
+use super::runtime;
 
 /// A file whose *changes* were withheld from staging because it is at/above
 /// the size guardrail. Oversized-but-unchanged files are not reported — their
@@ -47,15 +48,16 @@ pub(super) fn commit_all(
 ) -> AppResult<CommitOutcome> {
     let repo = open_existing(root)?;
     ensure_clean_state(&repo)?;
-    // In-memory hard guarantee, independent of any on-disk ignore file: the
-    // runtime directory must never enter a backup commit (Plan 21 — a synced
-    // `.reflect/` is index corruption on every other device).
     repo.add_ignore_rule("/.reflect/")?;
 
     let mut index = repo.index()?;
-    let skipped = add_all_with_size_guard(&mut index, root, max_file_bytes)?;
-
     let parent = repo.head().ok().and_then(|head| head.peel_to_commit().ok());
+    let mut committed_index = Index::new()?;
+    if let Some(parent) = &parent {
+        committed_index.read_tree(&parent.tree()?)?;
+    }
+    runtime::remove_from_index(&mut index)?;
+    let skipped = add_all_with_size_guard(&mut index, &committed_index, root, max_file_bytes)?;
     if parent.is_none() && index.is_empty() {
         return Ok(CommitOutcome {
             committed: false,
@@ -97,6 +99,7 @@ pub(super) fn commit_all(
 /// files whose changes were withheld.
 fn add_all_with_size_guard(
     index: &mut Index,
+    committed_index: &Index,
     root: &Path,
     max_file_bytes: u64,
 ) -> AppResult<Vec<SkippedFile>> {
@@ -110,22 +113,17 @@ fn add_all_with_size_guard(
     // to whole seconds — a same-length edit inside that second is then
     // reported as withheld rather than silently matched, erring toward the
     // warning.
-    let tracked_stats: std::collections::HashMap<String, (u32, i32, u32)> = index
+    let tracked_entries: std::collections::HashMap<Vec<u8>, git2::IndexEntry> = index
         .iter()
-        .map(|entry| {
-            (
-                String::from_utf8_lossy(&entry.path).into_owned(),
-                (
-                    entry.file_size,
-                    entry.mtime.seconds(),
-                    entry.mtime.nanoseconds(),
-                ),
-            )
-        })
+        .map(|entry| (entry.path.clone(), entry))
         .collect();
 
     let skipped: RefCell<Vec<SkippedFile>> = RefCell::new(Vec::new());
+    let withheld: RefCell<Vec<PathBuf>> = RefCell::new(Vec::new());
     let mut size_guard = |path: &Path, _spec: &[u8]| -> i32 {
+        if runtime::is_runtime_path(path) {
+            return 1;
+        }
         let Ok(meta) = root.join(path).metadata() else {
             // Deleted file: let the staging proceed so the removal is recorded.
             return 0;
@@ -141,14 +139,22 @@ fn add_all_with_size_guard(
         let (file_secs, file_nsecs) = mtime
             .map(|duration| (duration.as_secs() as i32, duration.subsec_nanos()))
             .unwrap_or((0, 0));
-        let unchanged = match tracked_stats.get(&rel) {
-            Some(&(size, secs, nsecs)) => {
-                size == meta.len() as u32
-                    && secs == file_secs
-                    && (nsecs == 0 || nsecs == file_nsecs)
+        let committed = committed_index.get_path(path, 0);
+        let unchanged = match committed.as_ref().and_then(|entry| {
+            tracked_entries
+                .get(&entry.path)
+                .map(|tracked| (entry, tracked))
+        }) {
+            Some((entry, tracked)) => {
+                entry.id == tracked.id
+                    && u64::from(tracked.file_size) == meta.len()
+                    && tracked.mtime.seconds() == file_secs
+                    && tracked.mtime.nanoseconds() != 0
+                    && tracked.mtime.nanoseconds() == file_nsecs
             }
             None => false,
         };
+        withheld.borrow_mut().push(path.to_path_buf());
         let mut skipped = skipped.borrow_mut();
         if !unchanged && !skipped.iter().any(|file| file.path == rel) {
             skipped.push(SkippedFile {
@@ -159,11 +165,43 @@ fn add_all_with_size_guard(
         1 // keep the oversized content out of the index either way
     };
 
+    // add_all/update_all can skip their callback for files already staged
+    // with matching stats. Filter the existing index first so pre-staged
+    // oversized additions and updates cannot bypass the size guardrail.
+    index.remove_all(
+        ["*"],
+        Some(&mut |path: &Path, spec: &[u8]| {
+            if size_guard(path, spec) == 1 {
+                0
+            } else {
+                1
+            }
+        }),
+    )?;
     index.add_all(["*"], IndexAddOption::DEFAULT, Some(&mut size_guard))?;
     // add_all stages new + modified paths; update_all records deletions of
     // tracked files whose working copy is gone (and re-checks sizes for
     // tracked files that have since grown past the guardrail).
     index.update_all(["*"], Some(&mut size_guard))?;
+    // A file may already have oversized content staged by another Git tool.
+    // Merely skipping add_all would commit that blob despite the guardrail.
+    // Retain its last committed version, or keep a new large file untracked.
+    for path in withheld.into_inner() {
+        match committed_index.get_path(&path, 0) {
+            Some(entry) => {
+                let restore = tracked_entries
+                    .get(&entry.path)
+                    .filter(|tracked| tracked.id == entry.id)
+                    .unwrap_or(&entry);
+                index.add(restore)?;
+            }
+            None => {
+                if index.get_path(&path, 0).is_some() {
+                    index.remove_path(&path)?;
+                }
+            }
+        }
+    }
     index.write()?;
     Ok(skipped.into_inner())
 }

--- a/apps/desktop/src-tauri/src/git/merge.rs
+++ b/apps/desktop/src-tauri/src/git/merge.rs
@@ -20,15 +20,17 @@
 //! ```
 
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 
 use git2::build::CheckoutBuilder;
-use git2::{Index, IndexEntry, MergeOptions, Repository};
+use git2::{Index, IndexEntry, MergeFileInput, MergeFileOptions, Repository};
 use serde::Serialize;
 
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 
 use super::repo::{current_branch, ensure_clean_state, open_existing, signature};
+use super::runtime::{is_runtime_path, remove_from_index, without_runtime};
 
 /// Conflict-marker labels. "this device" is the local side, "other device"
 /// the remote one — product language, not branch names.
@@ -78,137 +80,213 @@ pub struct MergeOutcome {
     /// Deletions carry `modified_ms: None`; upserts carry the written file's
     /// real mtime.
     pub changed_files: Vec<ChangedFile>,
+    /// Saves withheld by the size guard during the commit immediately before merge.
+    pub skipped_large_files: Vec<super::commit::SkippedFile>,
 }
 
-/// One side of an index conflict, lifted out of the index so the borrow ends
-/// before we mutate it.
-struct ConflictSide {
-    path: String,
-    id: git2::Oid,
-}
-
-fn side_of(entry: Option<IndexEntry>) -> Option<ConflictSide> {
-    entry.map(|entry| ConflictSide {
-        path: String::from_utf8_lossy(&entry.path).into_owned(),
-        id: entry.id,
-    })
-}
-
-/// Merge the fetched `origin/<branch>` into the local branch. Pre-condition
-/// (the sync engine guarantees it): local changes are already committed.
+/// Merge the fetched `origin/<branch>` into the local branch. The native
+/// wrapper commits pending saves under the same worktree mutation lock held
+/// throughout this call. Safe checkout also rejects conflicting dirty files
+/// left by the size guard or another filesystem writer.
 pub(super) fn merge_remote(root: &Path) -> AppResult<MergeOutcome> {
     let repo = open_existing(root)?;
     ensure_clean_state(&repo)?;
     let branch = current_branch(&repo)?;
-    let Ok(remote_oid) = repo.refname_to_id(&format!("refs/remotes/origin/{branch}")) else {
-        // A brand-new (empty) backup repo has no remote branch until the
-        // first push creates it. Nothing to merge is success, not an error —
-        // the launch cycle (commit → fetch → merge → push) must fall through
-        // to that push.
-        return Ok(MergeOutcome {
-            kind: MergeKind::UpToDate,
-            conflicted_paths: Vec::new(),
-            changed_files: Vec::new(),
-        });
+    let remote_oid = match repo.refname_to_id(&format!("refs/remotes/origin/{branch}")) {
+        Ok(oid) => oid,
+        Err(error) if error.code() == git2::ErrorCode::NotFound => return Ok(up_to_date()),
+        Err(error) => return Err(error.into()),
     };
+
+    // Ref locks fail before checkout if another Git process is updating HEAD.
+    // Keep the old ref reachable until all working-tree and index writes succeed.
+    let refname = format!("refs/heads/{branch}");
+    let mut transaction = repo.transaction()?;
+    transaction.lock_ref("HEAD")?;
+    transaction.lock_ref(&refname)?;
+    if current_branch(&repo)? != branch {
+        return Err(AppError::io(
+            "the backup branch changed during sync; retry backup",
+        ));
+    }
     let annotated = repo.find_annotated_commit(remote_oid)?;
     let (analysis, _) = repo.merge_analysis(&[&annotated])?;
-
     if analysis.is_up_to_date() {
-        return Ok(MergeOutcome {
-            kind: MergeKind::UpToDate,
-            conflicted_paths: Vec::new(),
-            changed_files: Vec::new(),
-        });
+        return Ok(up_to_date());
     }
 
-    if analysis.is_unborn() || analysis.is_fast_forward() {
-        // Capture the outgoing tree before the ref moves (None on unborn).
-        let old_tree = repo.head().ok().and_then(|head| head.peel_to_tree().ok());
-        let new_tree = repo.find_commit(remote_oid)?.tree()?;
-        let mut changed_files = changed_between(&repo, old_tree.as_ref(), &new_tree)?;
-        let refname = format!("refs/heads/{branch}");
-        repo.reference(&refname, remote_oid, true, "reflect sync: fast-forward")?;
-        repo.set_head(&refname)?;
-        // Force is safe here: the pre-merge invariant is a committed working
-        // tree, so there is nothing uncommitted to clobber.
-        repo.checkout_head(Some(CheckoutBuilder::new().force()))?;
-        // Stamp mtimes only now — the checkout above is what wrote the files.
-        stamp_modified_times(root, &mut changed_files);
-        return Ok(MergeOutcome {
-            kind: MergeKind::FastForward,
-            conflicted_paths: Vec::new(),
-            changed_files,
-        });
-    }
-
-    let mut merge_opts = MergeOptions::new();
-    let mut checkout = CheckoutBuilder::new();
-    checkout
-        .allow_conflicts(true)
-        .conflict_style_merge(true)
-        .our_label(OUR_LABEL)
-        .their_label(THEIR_LABEL);
-    repo.merge(&[&annotated], Some(&mut merge_opts), Some(&mut checkout))?;
-
-    // From here the repo carries MERGE_* state; a failure that leaves it
-    // behind would trip `ensure_clean_state` on every later cycle and wedge
-    // sync until a manual repair — exactly what this design forbids. Clear it
-    // on every path; the next cycle re-derives anything a failed attempt lost.
-    let result = complete_merge(&repo, root, remote_oid);
-    if result.is_err() {
-        let _ = repo.cleanup_state();
-    }
-    let (conflicted_paths, changed_files) = result?;
-
-    let kind = if conflicted_paths.is_empty() {
-        MergeKind::Merged
-    } else {
-        MergeKind::MergedWithConflicts
+    let remote_commit = repo.find_commit(remote_oid)?;
+    let local_commit = match repo.head() {
+        Ok(head) => Some(head.peel_to_commit()?),
+        Err(error) if error.code() == git2::ErrorCode::UnbornBranch => None,
+        Err(error) => return Err(error.into()),
     };
+    let old_tree = local_commit
+        .as_ref()
+        .map(|commit| without_runtime(&repo, &commit.tree()?))
+        .transpose()?;
+    let sig = signature(&repo)?;
+    let (new_oid, tree, kind, conflicted_paths) =
+        if analysis.is_unborn() || analysis.is_fast_forward() {
+            let remote_tree = remote_commit.tree()?;
+            let tree = without_runtime(&repo, &remote_tree)?;
+            // A fetched tree may track another device's runtime database. Preserve
+            // its history, but make the new local tip exclude that directory.
+            let new_oid = if tree.id() == remote_tree.id() {
+                remote_oid
+            } else {
+                repo.commit(
+                    None,
+                    &sig,
+                    &sig,
+                    "Exclude device-local runtime files from backup",
+                    &tree,
+                    &[&remote_commit],
+                )?
+            };
+            (new_oid, tree, MergeKind::FastForward, Vec::new())
+        } else {
+            let local_commit = local_commit
+                .as_ref()
+                .ok_or_else(|| AppError::io("the backup branch has no local commit to merge"))?;
+            // Compute and resolve the complete merge in memory. No MERGE_* files
+            // or conflicted disk index can survive a failure and wedge later syncs.
+            let mut index = repo.merge_commits(local_commit, &remote_commit, None)?;
+            remove_from_index(&mut index)?;
+            let conflicted_paths = resolve_conflicts(&repo, root, &mut index)?;
+            let tree = repo.find_tree(index.write_tree_to(&repo)?)?;
+            let (kind, message) = if conflicted_paths.is_empty() {
+                (MergeKind::Merged, "Merge changes from other devices")
+            } else {
+                (
+                    MergeKind::MergedWithConflicts,
+                    "Merge changes from other devices (conflicts to review)",
+                )
+            };
+            let new_oid = repo.commit(
+                None,
+                &sig,
+                &sig,
+                message,
+                &tree,
+                &[local_commit, &remote_commit],
+            )?;
+            (new_oid, tree, kind, conflicted_paths)
+        };
+
+    let mut changed_files = changed_between(&repo, old_tree.as_ref(), &tree)?;
+    let existing_additions =
+        matching_additions(&repo, root, old_tree.as_ref(), &tree, &changed_files)?;
+    let checkout_paths: Vec<_> = changed_files
+        .iter()
+        .filter(|change| {
+            !existing_additions
+                .iter()
+                .any(|entry| entry.path == change.path.as_bytes())
+        })
+        .collect();
+    if !checkout_paths.is_empty() {
+        let mut checkout = CheckoutBuilder::new();
+        checkout
+            .safe()
+            .overwrite_ignored(false)
+            .disable_pathspec_match(true);
+        // Restrict the checkout to the sanitized tree diff. In particular,
+        // removing a previously tracked .reflect entry must never unlink the
+        // local SQLite database or durable chat history.
+        for change in checkout_paths {
+            checkout.path(&change.path);
+        }
+        repo.checkout_tree(tree.as_object(), Some(&mut checkout))?;
+    }
+    let mut index = repo.index()?;
+    for entry in existing_additions {
+        index.add(&entry)?;
+    }
+    remove_from_index(&mut index)?;
+    index.write()?;
+    transaction.set_target(
+        &refname,
+        new_oid,
+        Some(&sig),
+        "reflect sync: integrate remote changes",
+    )?;
+    transaction.commit()?;
+    stamp_modified_times(root, &mut changed_files);
     Ok(MergeOutcome {
         kind,
         conflicted_paths,
         changed_files,
+        skipped_large_files: Vec::new(),
     })
 }
 
-/// The post-`repo.merge` half: materialize conflicts, commit the merge with
-/// both parents, and clear the merge state. Split out so [`merge_remote`] can
-/// guarantee `cleanup_state` runs even when any step here fails. Returns the
-/// conflicted paths and every file the merge changed relative to local HEAD.
-fn complete_merge(
+/// Libgit2 treats any existing file at an added path as a checkout conflict,
+/// even when its bytes already match. Admit those additions without rewriting
+/// them: this covers atomically claimed conflict copies and the scaffold's
+/// identical .gitignore when adopting an unborn repository.
+fn matching_additions(
     repo: &Repository,
     root: &Path,
-    remote_oid: git2::Oid,
-) -> AppResult<(Vec<String>, Vec<ChangedFile>)> {
-    let mut index = repo.index()?;
-    let conflicted_paths = resolve_conflicts(repo, root, &mut index)?;
-    index.write()?;
+    old: Option<&git2::Tree>,
+    target: &git2::Tree,
+    changes: &[ChangedFile],
+) -> AppResult<Vec<IndexEntry>> {
+    let current_index = repo.index()?;
+    let mut target_index = Index::new()?;
+    target_index.read_tree(target)?;
+    let mut matches = Vec::new();
+    for change in changes {
+        if !matches!(change.kind, ChangeKind::Upsert) {
+            continue;
+        }
+        let path = Path::new(&change.path);
+        if let Some(old) = old {
+            match old.get_path(path) {
+                Ok(_) => continue,
+                Err(error) if error.code() == git2::ErrorCode::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+        let Some(entry) = target_index.get_path(path, 0) else {
+            continue;
+        };
+        if entry.mode != 0o100644 {
+            continue;
+        }
+        if current_index
+            .get_path(path, 0)
+            .is_some_and(|staged| staged.id != entry.id || staged.mode != entry.mode)
+        {
+            continue;
+        }
+        let target = root.join(path);
+        let metadata = match target.symlink_metadata() {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.into()),
+        };
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if metadata.permissions().mode() & 0o111 != 0 {
+                continue;
+            }
+        }
+        if metadata.file_type().is_file() && repo.blob_path(&target)? == entry.id {
+            matches.push(entry);
+        }
+    }
+    Ok(matches)
+}
 
-    let tree = repo.find_tree(index.write_tree()?)?;
-    let local_commit = repo.head()?.peel_to_commit()?;
-    let remote_commit = repo.find_commit(remote_oid)?;
-    // The working tree is final here (merge checkout + conflict resolution
-    // wrote everything), so the stamped mtimes are the files' real ones.
-    let mut changed_files = changed_between(repo, Some(&local_commit.tree()?), &tree)?;
-    stamp_modified_times(root, &mut changed_files);
-    let sig = signature(repo)?;
-    let message = if conflicted_paths.is_empty() {
-        "Merge changes from other devices"
-    } else {
-        "Merge changes from other devices (conflicts to review)"
-    };
-    repo.commit(
-        Some("HEAD"),
-        &sig,
-        &sig,
-        message,
-        &tree,
-        &[&local_commit, &remote_commit],
-    )?;
-    repo.cleanup_state()?;
-    Ok((conflicted_paths, changed_files))
+fn up_to_date() -> MergeOutcome {
+    MergeOutcome {
+        kind: MergeKind::UpToDate,
+        conflicted_paths: Vec::new(),
+        changed_files: Vec::new(),
+        skipped_large_files: Vec::new(),
+    }
 }
 
 /// Diff two trees into the watcher's change shape: what the merge wrote or
@@ -229,7 +307,10 @@ fn changed_between(
         };
         if let Some(path) = file.path() {
             out.push(ChangedFile {
-                path: path.to_string_lossy().replace('\\', "/"),
+                path: path
+                    .to_str()
+                    .ok_or_else(|| AppError::io("backup contains a non-UTF-8 file path"))?
+                    .to_owned(),
                 kind: if removed {
                     ChangeKind::Remove
                 } else {
@@ -258,112 +339,179 @@ fn stamp_modified_times(root: &Path, changes: &mut [ChangedFile]) {
     }
 }
 
-/// Turn every index conflict into committed working-tree content:
-///
-/// - **text vs text** — the merge checkout already wrote labeled markers into
-///   the file; stage it as-is (the user resolves by editing the note);
-/// - **edit vs delete** — keep the edited version, never silently delete;
-/// - **binary vs binary** — keep ours in place and the other device's copy
-///   alongside (`name (conflict).ext`);
-/// - **deleted on both** — confirm the removal.
+/// Resolve conflicted blobs in the in-memory index. Only binary conflict
+/// copies are materialized here, using an atomic no-clobber claim. A failed
+/// later checkout may leave that copy untracked; retaining it is intentional.
 fn resolve_conflicts(repo: &Repository, root: &Path, index: &mut Index) -> AppResult<Vec<String>> {
-    if !index.has_conflicts() {
-        return Ok(Vec::new());
-    }
-
-    struct OwnedConflict {
-        our: Option<ConflictSide>,
-        their: Option<ConflictSide>,
-        ancestor: Option<ConflictSide>,
-    }
-    let conflicts: Vec<OwnedConflict> = index
-        .conflicts()?
-        .filter_map(Result::ok)
-        .map(|conflict| OwnedConflict {
-            our: side_of(conflict.our),
-            their: side_of(conflict.their),
-            ancestor: side_of(conflict.ancestor),
-        })
-        .collect();
-
+    let conflicts = index.conflicts()?.collect::<Result<Vec<_>, _>>()?;
     let mut conflicted_paths = Vec::new();
     for conflict in conflicts {
+        let paths = [&conflict.ancestor, &conflict.our, &conflict.their]
+            .into_iter()
+            .flatten()
+            .map(entry_path)
+            .collect::<AppResult<std::collections::BTreeSet<_>>>()?;
+        for path in paths {
+            index.conflict_remove(Path::new(path))?;
+        }
         match (conflict.our, conflict.their) {
             (Some(our), Some(their)) => {
-                conflicted_paths.extend(resolve_both_edited(repo, root, index, our, their)?);
+                conflicted_paths.extend(resolve_both_edited(
+                    repo,
+                    root,
+                    index,
+                    conflict.ancestor,
+                    our,
+                    their,
+                )?);
             }
             (Some(edited), None) | (None, Some(edited)) => {
-                conflicted_paths.push(resolve_edit_vs_delete(repo, root, index, edited)?);
+                conflicted_paths.push(entry_path(&edited)?.to_owned());
+                add_resolved(index, edited)?;
             }
-            (None, None) => {
-                if let Some(ancestor) = conflict.ancestor {
-                    index.remove_path(Path::new(&ancestor.path))?;
-                }
-            }
+            (None, None) => {}
         }
     }
     Ok(conflicted_paths)
 }
 
-/// Both sides changed the file. Text: the merge checkout already wrote the
-/// labeled marker file, so staging the working copy clears the conflict
-/// entries. Binary: markers would corrupt the bytes — keep ours in place and
-/// write the other device's version alongside (`name (conflict).ext`).
+fn entry_path(entry: &IndexEntry) -> AppResult<&str> {
+    std::str::from_utf8(&entry.path)
+        .map_err(|_| AppError::io("backup contains a conflict with a non-UTF-8 path"))
+}
+
+fn add_resolved(index: &mut Index, mut entry: IndexEntry) -> AppResult<()> {
+    // Entries obtained from conflicts carry stage 1/2/3 bits. Resolved blobs
+    // must be written at stage zero, independent of their original side.
+    entry.flags &= !0x3000;
+    index.add(&entry)?;
+    Ok(())
+}
+
 fn resolve_both_edited(
     repo: &Repository,
     root: &Path,
     index: &mut Index,
-    our: ConflictSide,
-    their: ConflictSide,
+    ancestor: Option<IndexEntry>,
+    mut our: IndexEntry,
+    mut their: IndexEntry,
 ) -> AppResult<Vec<String>> {
-    let binary = repo.find_blob(our.id)?.is_binary() || repo.find_blob(their.id)?.is_binary();
-    if !binary {
-        index.add_path(Path::new(&our.path))?;
-        return Ok(vec![our.path]);
+    let our_path = entry_path(&our)?.to_owned();
+    let their_path = entry_path(&their)?.to_owned();
+    let our_blob = repo.find_blob(our.id)?;
+    let their_blob = repo.find_blob(their.id)?;
+    if our_path != their_path {
+        add_resolved(index, our)?;
+        add_resolved(index, their)?;
+        return Ok(vec![our_path, their_path]);
     }
-    write_blob(repo, root, &our.path, our.id)?;
-    let copy = conflict_copy_path(&their.path);
-    write_blob(repo, root, &copy, their.id)?;
-    index.add_path(Path::new(&our.path))?;
-    index.add_path(Path::new(&copy))?;
-    Ok(vec![our.path, copy])
+    let binary = our_blob.is_binary()
+        || their_blob.is_binary()
+        || our.mode & 0o170000 != 0o100000
+        || their.mode & 0o170000 != 0o100000;
+    if binary {
+        let copy = claim_conflict_copy(root, index, &their_path, their_blob.content())?;
+        their.path = copy.as_bytes().to_vec();
+        // A symlink's raw target is preserved as a regular conflict attachment.
+        their.mode = 0o100644;
+        add_resolved(index, our)?;
+        add_resolved(index, their)?;
+        return Ok(vec![our_path, copy]);
+    }
+    let ancestor_blob = ancestor
+        .as_ref()
+        .map(|entry| repo.find_blob(entry.id))
+        .transpose()?;
+    let mut base = MergeFileInput::new();
+    base.content(
+        ancestor_blob
+            .as_ref()
+            .map(|blob| blob.content())
+            .unwrap_or(&[]),
+    );
+    let mut ours = MergeFileInput::new();
+    ours.path(our_path.as_str()).content(our_blob.content());
+    let mut theirs = MergeFileInput::new();
+    theirs
+        .path(their_path.as_str())
+        .content(their_blob.content());
+    let mut options = MergeFileOptions::new();
+    options
+        .our_label(OUR_LABEL)
+        .their_label(THEIR_LABEL)
+        .style_standard(true);
+    let merged = git2::merge_file(&base, &ours, &theirs, Some(&mut options))?;
+    our.id = repo.blob(merged.content())?;
+    our.file_size = u32::try_from(merged.content().len())
+        .map_err(|_| AppError::io("merged note exceeds the Git index size limit"))?;
+    add_resolved(index, our)?;
+    Ok(vec![our_path])
 }
 
-/// One side edited what the other deleted (either direction): restore and
-/// stage the edited version — sync must never silently delete a note someone
-/// touched. The user removes it again if the deletion was intentional.
-fn resolve_edit_vs_delete(
-    repo: &Repository,
-    root: &Path,
-    index: &mut Index,
-    edited: ConflictSide,
-) -> AppResult<String> {
-    write_blob(repo, root, &edited.path, edited.id)?;
-    index.add_path(Path::new(&edited.path))?;
-    Ok(edited.path)
-}
-
-fn write_blob(repo: &Repository, root: &Path, rel: &str, id: git2::Oid) -> AppResult<()> {
-    let blob = repo.find_blob(id)?;
-    let target = root.join(rel);
-    if let Some(parent) = target.parent() {
-        fs::create_dir_all(parent)?;
+fn claim_conflict_copy(root: &Path, index: &Index, rel: &str, content: &[u8]) -> AppResult<String> {
+    let parent = Path::new(rel).parent().unwrap_or(Path::new(""));
+    if parent.components().any(|component| {
+        !matches!(component, std::path::Component::Normal(_))
+            || component.as_os_str().eq_ignore_ascii_case(".git")
+    }) || is_runtime_path(Path::new(rel))
+    {
+        return Err(AppError::io(
+            "backup conflict has an unsafe attachment path",
+        ));
     }
-    fs::write(target, blob.content())?;
-    Ok(())
+    let parent = root.join(parent);
+    let existing = parent
+        .ancestors()
+        .find(|ancestor| ancestor.exists())
+        .ok_or_else(|| AppError::io("backup conflict attachment directory is unavailable"))?;
+    if !existing.canonicalize()?.starts_with(root.canonicalize()?) {
+        return Err(AppError::io(
+            "backup conflict attachment directory is outside the graph",
+        ));
+    }
+    fs::create_dir_all(&parent)?;
+    let mut pending = tempfile::NamedTempFile::new_in(parent)?;
+    pending.write_all(content)?;
+    pending.as_file().sync_all()?;
+    for number in 1.. {
+        let copy = conflict_copy_path(rel, number);
+        let directory_prefix = format!("{copy}/");
+        if index.iter().any(|entry| {
+            entry.path.eq_ignore_ascii_case(copy.as_bytes())
+                || entry
+                    .path
+                    .get(..directory_prefix.len())
+                    .is_some_and(|prefix| prefix.eq_ignore_ascii_case(directory_prefix.as_bytes()))
+        }) {
+            continue;
+        }
+        match pending.persist_noclobber(root.join(&copy)) {
+            Ok(_) => return Ok(copy),
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+                pending = error.file;
+            }
+            Err(error) => return Err(error.error.into()),
+        }
+    }
+    unreachable!("the conflict copy counter cannot exhaust")
 }
 
 /// `assets/img.png` → `assets/img (conflict).png`; no extension → appended.
 /// Splits on the basename only — a dot in a *directory* name (`assets.v1/x`)
 /// must not relocate the copy out of the file's directory.
-fn conflict_copy_path(rel: &str) -> String {
+fn conflict_copy_path(rel: &str, number: usize) -> String {
     let (dir, file) = match rel.rsplit_once('/') {
         Some((dir, file)) => (Some(dir), file),
         None => (None, rel),
     };
+    let suffix = if number == 1 {
+        "conflict".to_owned()
+    } else {
+        format!("conflict {number}")
+    };
     let renamed = match file.rsplit_once('.') {
-        Some((stem, ext)) if !stem.is_empty() => format!("{stem} (conflict).{ext}"),
-        _ => format!("{file} (conflict)"),
+        Some((stem, ext)) if !stem.is_empty() => format!("{stem} ({suffix}).{ext}"),
+        _ => format!("{file} ({suffix})"),
     };
     match dir {
         Some(dir) => format!("{dir}/{renamed}"),
@@ -378,22 +526,64 @@ mod path_tests {
     #[test]
     fn conflict_copies_stay_in_their_directory() {
         assert_eq!(
-            conflict_copy_path("assets/img.png"),
+            conflict_copy_path("assets/img.png", 1),
             "assets/img (conflict).png"
         );
         assert_eq!(
-            conflict_copy_path("assets.v1/img"),
+            conflict_copy_path("assets.v1/img", 1),
             "assets.v1/img (conflict)"
         );
         assert_eq!(
-            conflict_copy_path("assets.v1/img.png"),
+            conflict_copy_path("assets.v1/img.png", 1),
             "assets.v1/img (conflict).png"
         );
-        assert_eq!(conflict_copy_path("topfile.bin"), "topfile (conflict).bin");
-        assert_eq!(conflict_copy_path("noext"), "noext (conflict)");
         assert_eq!(
-            conflict_copy_path("assets/.hidden"),
+            conflict_copy_path("topfile.bin", 1),
+            "topfile (conflict).bin"
+        );
+        assert_eq!(conflict_copy_path("noext", 1), "noext (conflict)");
+        assert_eq!(
+            conflict_copy_path("assets/.hidden", 1),
             "assets/.hidden (conflict)"
         );
+    }
+
+    #[test]
+    fn concurrent_binary_copy_claims_never_replace_another_copy() {
+        let directory = tempfile::tempdir().unwrap();
+        let existing = directory.path().join("image (conflict).bin");
+        std::fs::write(&existing, b"existing attachment").unwrap();
+        let ready = std::sync::Barrier::new(6);
+        std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..6)
+                .map(|number| {
+                    let directory = directory.path();
+                    let ready = &ready;
+                    scope.spawn(move || {
+                        let index = git2::Index::new().unwrap();
+                        let content = format!("remote attachment {number}");
+                        ready.wait();
+                        let copy = super::claim_conflict_copy(
+                            directory,
+                            &index,
+                            "image.bin",
+                            content.as_bytes(),
+                        )
+                        .unwrap();
+                        assert_eq!(
+                            std::fs::read_to_string(directory.join(&copy)).unwrap(),
+                            content
+                        );
+                        copy
+                    })
+                })
+                .collect();
+            let paths: std::collections::HashSet<_> = handles
+                .into_iter()
+                .map(|handle| handle.join().unwrap())
+                .collect();
+            assert_eq!(paths.len(), 6);
+        });
+        assert_eq!(std::fs::read(existing).unwrap(), b"existing attachment");
     }
 }

--- a/apps/desktop/src-tauri/src/git/merge_tests.rs
+++ b/apps/desktop/src-tauri/src/git/merge_tests.rs
@@ -1,0 +1,410 @@
+//! Regression coverage for dirty worktrees and failed pull application. Remote
+//! changes are published to a local repository so every interleaving is explicit.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use git2::{Oid, Repository, RepositoryInitOptions};
+use tempfile::{tempdir, TempDir};
+
+use super::commit::commit_all;
+use super::merge::{merge_remote, MergeKind};
+
+const LIMIT: u64 = 95 * 1024 * 1024;
+
+struct Fixture {
+    _directory: TempDir,
+    origin: PathBuf,
+    local: PathBuf,
+}
+
+fn write(root: &Path, path: &str, contents: impl AsRef<[u8]>) {
+    let target = root.join(path);
+    fs::create_dir_all(target.parent().unwrap()).unwrap();
+    fs::write(target, contents).unwrap();
+}
+
+fn commit(root: &Path) -> Oid {
+    commit_all(root, "test changes", LIMIT).unwrap();
+    head(root)
+}
+
+fn head(root: &Path) -> Oid {
+    Repository::open(root)
+        .unwrap()
+        .refname_to_id("HEAD")
+        .unwrap()
+}
+
+fn fixture() -> Fixture {
+    let directory = tempdir().unwrap();
+    let origin = directory.path().join("origin");
+    Repository::init_opts(&origin, RepositoryInitOptions::new().initial_head("main")).unwrap();
+    write(&origin, ".gitignore", "/.reflect/\n*.ignored\n");
+    write(&origin, "notes/shared.md", "base\n");
+    write(&origin, "assets/image.bin", b"base\0");
+    commit(&origin);
+    let local = directory.path().join("local");
+    Repository::clone(origin.to_str().unwrap(), &local).unwrap();
+    Fixture {
+        _directory: directory,
+        origin,
+        local,
+    }
+}
+
+fn fetch(root: &Path) {
+    Repository::open(root)
+        .unwrap()
+        .find_remote("origin")
+        .unwrap()
+        .fetch(&["main"], None, None)
+        .unwrap();
+}
+
+fn blob(root: &Path, commit_id: Oid, path: &str) -> Vec<u8> {
+    let repo = Repository::open(root).unwrap();
+    let tree = repo.find_commit(commit_id).unwrap().tree().unwrap();
+    let entry = tree.get_path(Path::new(path)).unwrap();
+    let blob = repo.find_blob(entry.id()).unwrap();
+    blob.content().to_vec()
+}
+
+#[test]
+fn fast_forward_refuses_a_note_saved_during_fetch_without_moving_head() {
+    let fixture = fixture();
+    write(&fixture.origin, "notes/shared.md", "remote revision\n");
+    commit(&fixture.origin);
+    let original = commit(&fixture.local);
+    let index = fs::read(fixture.local.join(".git/index")).unwrap();
+    write(
+        &fixture.local,
+        "notes/shared.md",
+        "autosave completed during fetch\n",
+    );
+    fetch(&fixture.local);
+
+    assert!(merge_remote(&fixture.local).is_err());
+    assert_eq!(head(&fixture.local), original);
+    assert_eq!(fs::read(fixture.local.join(".git/index")).unwrap(), index);
+    assert_eq!(
+        fs::read_to_string(fixture.local.join("notes/shared.md")).unwrap(),
+        "autosave completed during fetch\n"
+    );
+}
+
+#[test]
+fn committing_saves_after_fetch_merges_both_versions_and_retains_the_saved_parent() {
+    let fixture = fixture();
+    write(&fixture.origin, "notes/shared.md", "remote revision\n");
+    let remote = commit(&fixture.origin);
+    commit(&fixture.local);
+    write(&fixture.local, "notes/shared.md", "saved during fetch\n");
+    fetch(&fixture.local);
+    let saved = commit(&fixture.local);
+
+    let outcome = merge_remote(&fixture.local).unwrap();
+    assert!(matches!(outcome.kind, MergeKind::MergedWithConflicts));
+    let content = fs::read_to_string(fixture.local.join("notes/shared.md")).unwrap();
+    assert!(
+        content.contains("<<<<<<< this device\nsaved during fetch\n"),
+        "{content}"
+    );
+    assert!(
+        content.contains("remote revision\n>>>>>>> other device"),
+        "{content}"
+    );
+    let repo = Repository::open(&fixture.local).unwrap();
+    let merged = repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(merged.parent_id(0).unwrap(), saved);
+    assert_eq!(merged.parent_id(1).unwrap(), remote);
+    assert_eq!(
+        blob(&fixture.local, saved, "notes/shared.md"),
+        b"saved during fetch\n"
+    );
+    assert_eq!(repo.state(), git2::RepositoryState::Clean);
+    assert!(
+        !commit_all(&fixture.local, "no changes", LIMIT)
+            .unwrap()
+            .committed
+    );
+}
+
+#[test]
+fn fast_forward_preserves_unrelated_staged_changes() {
+    let fixture = fixture();
+    write(&fixture.origin, "notes/shared.md", "remote revision\n");
+    let remote = commit(&fixture.origin);
+    fetch(&fixture.local);
+    write(
+        &fixture.local,
+        "notes/staged.md",
+        "staged while network was active\n",
+    );
+    let repo = Repository::open(&fixture.local).unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new("notes/staged.md")).unwrap();
+    index.write().unwrap();
+    let staged_blob = index.get_path(Path::new("notes/staged.md"), 0).unwrap().id;
+
+    assert!(matches!(
+        merge_remote(&fixture.local).unwrap().kind,
+        MergeKind::FastForward
+    ));
+    assert_eq!(head(&fixture.local), remote);
+    let index = Repository::open(&fixture.local).unwrap().index().unwrap();
+    assert_eq!(
+        index.get_path(Path::new("notes/staged.md"), 0).unwrap().id,
+        staged_blob
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.local.join("notes/staged.md")).unwrap(),
+        "staged while network was active\n"
+    );
+}
+
+#[test]
+fn pull_refuses_untracked_and_ignored_collisions() {
+    for path in ["notes/untracked.md", "assets/file.ignored"] {
+        let fixture = fixture();
+        write(&fixture.origin, path, "remote file\n");
+        let repo = Repository::open(&fixture.origin).unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new(path)).unwrap();
+        index.write().unwrap();
+        let tree = repo.find_tree(index.write_tree().unwrap()).unwrap();
+        let parent = repo.head().unwrap().peel_to_commit().unwrap();
+        let signature = super::repo::signature(&repo).unwrap();
+        repo.commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            "remote file",
+            &tree,
+            &[&parent],
+        )
+        .unwrap();
+        write(&fixture.local, path, "keep my file\n");
+        fetch(&fixture.local);
+        let original = head(&fixture.local);
+        assert!(merge_remote(&fixture.local).is_err(), "{path}");
+        assert_eq!(head(&fixture.local), original);
+        assert_eq!(
+            fs::read_to_string(fixture.local.join(path)).unwrap(),
+            "keep my file\n"
+        );
+    }
+}
+
+#[test]
+fn divergent_merge_refuses_dirty_conflicted_note_and_recovers_after_commit() {
+    let fixture = fixture();
+    write(&fixture.origin, "notes/shared.md", "remote revision\n");
+    commit(&fixture.origin);
+    write(
+        &fixture.local,
+        "notes/shared.md",
+        "committed local revision\n",
+    );
+    let original = commit(&fixture.local);
+    fetch(&fixture.local);
+    write(&fixture.local, "notes/shared.md", "newer local autosave\n");
+
+    assert!(merge_remote(&fixture.local).is_err());
+    assert_eq!(head(&fixture.local), original);
+    assert_eq!(
+        fs::read_to_string(fixture.local.join("notes/shared.md")).unwrap(),
+        "newer local autosave\n"
+    );
+    let repo = Repository::open(&fixture.local).unwrap();
+    assert_eq!(repo.state(), git2::RepositoryState::Clean);
+    assert!(!repo.index().unwrap().has_conflicts());
+    commit(&fixture.local);
+    assert!(matches!(
+        merge_remote(&fixture.local).unwrap().kind,
+        MergeKind::MergedWithConflicts
+    ));
+}
+
+#[test]
+fn repeated_binary_conflicts_preserve_existing_local_and_incoming_copy_names() {
+    let fixture = fixture();
+    write(&fixture.origin, "assets/image.bin", b"remote first\0");
+    write(
+        &fixture.origin,
+        "assets/image (conflict 2).bin",
+        b"intentional remote file\0",
+    );
+    commit(&fixture.origin);
+    write(&fixture.local, "assets/image.bin", b"local first\0");
+    write(
+        &fixture.local,
+        "assets/image (conflict).bin",
+        b"previous conflict\0",
+    );
+    commit(&fixture.local);
+    fetch(&fixture.local);
+    assert!(matches!(
+        merge_remote(&fixture.local).unwrap().kind,
+        MergeKind::MergedWithConflicts
+    ));
+    assert_eq!(
+        fs::read(fixture.local.join("assets/image (conflict 3).bin")).unwrap(),
+        b"remote first\0"
+    );
+
+    write(&fixture.origin, "assets/image.bin", b"remote second\0");
+    commit(&fixture.origin);
+    write(&fixture.local, "assets/image.bin", b"local second\0");
+    commit(&fixture.local);
+    fetch(&fixture.local);
+    assert!(matches!(
+        merge_remote(&fixture.local).unwrap().kind,
+        MergeKind::MergedWithConflicts
+    ));
+    for (path, contents) in [
+        ("assets/image.bin", b"local second\0".as_slice()),
+        ("assets/image (conflict).bin", b"previous conflict\0"),
+        (
+            "assets/image (conflict 2).bin",
+            b"intentional remote file\0",
+        ),
+        ("assets/image (conflict 3).bin", b"remote first\0"),
+        ("assets/image (conflict 4).bin", b"remote second\0"),
+    ] {
+        assert_eq!(
+            fs::read(fixture.local.join(path)).unwrap(),
+            contents,
+            "{path}"
+        );
+        assert_eq!(
+            blob(&fixture.local, head(&fixture.local), path),
+            contents,
+            "{path}"
+        );
+    }
+    assert!(
+        !commit_all(&fixture.local, "no changes", LIMIT)
+            .unwrap()
+            .committed
+    );
+}
+
+#[test]
+fn failed_index_write_leaves_head_recoverable_and_retry_finishes() {
+    let fixture = fixture();
+    write(&fixture.origin, "notes/shared.md", "remote revision\n");
+    let remote = commit(&fixture.origin);
+    fetch(&fixture.local);
+    let original = head(&fixture.local);
+    fs::write(fixture.local.join(".git/index.lock"), "another writer").unwrap();
+    assert!(merge_remote(&fixture.local).is_err());
+    assert_eq!(head(&fixture.local), original);
+    assert_eq!(blob(&fixture.local, original, "notes/shared.md"), b"base\n");
+    assert_eq!(
+        Repository::open(&fixture.local).unwrap().state(),
+        git2::RepositoryState::Clean
+    );
+    fs::remove_file(fixture.local.join(".git/index.lock")).unwrap();
+    assert!(matches!(
+        merge_remote(&fixture.local).unwrap().kind,
+        MergeKind::FastForward
+    ));
+    assert_eq!(head(&fixture.local), remote);
+    assert_eq!(
+        fs::read_to_string(fixture.local.join("notes/shared.md")).unwrap(),
+        "remote revision\n"
+    );
+}
+
+#[test]
+fn failed_checkout_keeps_a_complete_binary_conflict_copy_and_original_index() {
+    let fixture = fixture();
+    write(&fixture.origin, "notes/shared.md", "remote note\n");
+    write(&fixture.origin, "assets/image.bin", b"remote attachment\0");
+    commit(&fixture.origin);
+    write(&fixture.local, "notes/shared.md", "committed local note\n");
+    write(&fixture.local, "assets/image.bin", b"local attachment\0");
+    let original = commit(&fixture.local);
+    fetch(&fixture.local);
+    let original_index = fs::read(fixture.local.join(".git/index")).unwrap();
+    write(&fixture.local, "notes/shared.md", "autosave after commit\n");
+
+    assert!(merge_remote(&fixture.local).is_err());
+    assert_eq!(head(&fixture.local), original);
+    assert_eq!(
+        fs::read(fixture.local.join(".git/index")).unwrap(),
+        original_index
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.local.join("notes/shared.md")).unwrap(),
+        "autosave after commit\n"
+    );
+    assert_eq!(
+        fs::read(fixture.local.join("assets/image.bin")).unwrap(),
+        b"local attachment\0"
+    );
+    assert_eq!(
+        fs::read(fixture.local.join("assets/image (conflict).bin")).unwrap(),
+        b"remote attachment\0"
+    );
+    assert_eq!(
+        Repository::open(&fixture.local).unwrap().state(),
+        git2::RepositoryState::Clean
+    );
+
+    commit(&fixture.local);
+    assert!(matches!(
+        merge_remote(&fixture.local).unwrap().kind,
+        MergeKind::MergedWithConflicts
+    ));
+    assert_eq!(
+        fs::read(fixture.local.join("assets/image (conflict).bin")).unwrap(),
+        b"remote attachment\0"
+    );
+}
+
+#[test]
+fn binary_copy_avoids_incoming_case_aliases_and_directories() {
+    let fixture = fixture();
+    write(&fixture.origin, "assets/image.bin", b"remote attachment\0");
+    write(
+        &fixture.origin,
+        "assets/image (CONFLICT).bin",
+        b"incoming attachment\0",
+    );
+    write(
+        &fixture.origin,
+        "assets/image (CONFLICT 2).bin/keep.md",
+        "incoming directory\n",
+    );
+    commit(&fixture.origin);
+    write(&fixture.local, "assets/image.bin", b"local attachment\0");
+    commit(&fixture.local);
+    fetch(&fixture.local);
+
+    assert!(matches!(
+        merge_remote(&fixture.local).unwrap().kind,
+        MergeKind::MergedWithConflicts
+    ));
+    for (path, contents) in [
+        ("assets/image.bin", b"local attachment\0".as_slice()),
+        ("assets/image (CONFLICT).bin", b"incoming attachment\0"),
+        (
+            "assets/image (CONFLICT 2).bin/keep.md",
+            b"incoming directory\n",
+        ),
+        ("assets/image (conflict 3).bin", b"remote attachment\0"),
+    ] {
+        assert_eq!(
+            fs::read(fixture.local.join(path)).unwrap(),
+            contents,
+            "{path}"
+        );
+        assert_eq!(
+            blob(&fixture.local, head(&fixture.local), path),
+            contents,
+            "{path}"
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/git/mod.rs
+++ b/apps/desktop/src-tauri/src/git/mod.rs
@@ -12,14 +12,18 @@
 //! resolves the root through `crate::fs::root_for_generation`, which fails
 //! when the active graph's generation has since moved (the user switched
 //! graphs after the command was issued). A stale command errors loudly instead
-//! of acting on the new graph, so commands never interleave across graphs.
+//! of acting on the new graph. Repository operations are serialized per root;
+//! local filesystem mutations share a separate checkout lock.
 //! The one exception is `git_clone`, which runs before any graph is open.
 
 mod commit;
 mod commit_message;
 mod merge;
+#[cfg(test)]
+mod merge_tests;
 mod remote;
 mod repo;
+mod runtime;
 #[cfg(test)]
 mod tests;
 
@@ -103,6 +107,8 @@ fn disconnect(root: &Path) -> AppResult<GitStatus> {
 
 fn setup(root: &Path, remote_url: Option<String>, branch: Option<String>) -> AppResult<GitStatus> {
     let repo = repo::open_or_init(root)?;
+    repo::ensure_clean_state(&repo)?;
+    runtime::exclude_from_index(&repo)?;
     repo::ensure_gitignore_defaults(root)?;
     if let Some(url) = remote_url {
         if repo.find_remote("origin").is_ok() {
@@ -118,11 +124,35 @@ fn setup(root: &Path, remote_url: Option<String>, branch: Option<String>) -> App
     status(root)
 }
 
+/// Serialize repository operations without holding the worktree during network
+/// waits, and reject stale queued commands after acquiring the repository lock.
+async fn run_git<T, F>(state: GraphState, generation: u64, action: F) -> AppResult<T>
+where
+    T: Send + 'static,
+    F: FnOnce(&Path, &GraphState) -> AppResult<T> + Send + 'static,
+{
+    run_blocking(move || {
+        let root = crate::fs::root_for_generation(&state, generation)?;
+        crate::fs::mutation::with_repository(&root, || {
+            crate::fs::root_for_generation(&state, generation)?;
+            action(&root, &state)
+        })
+    })
+    .await
+}
+
+/// Snapshot saves that completed during fetch and merge under one local lock.
+fn commit_and_merge(root: &Path) -> AppResult<MergeOutcome> {
+    let snapshot = commit::commit_all(root, "Save changes before sync", MAX_FILE_BYTES)?;
+    let mut outcome = merge::merge_remote(root)?;
+    outcome.skipped_large_files = snapshot.skipped_large_files;
+    Ok(outcome)
+}
+
 /// Snapshot the backup repository (cheap, no network).
 #[tauri::command]
 pub async fn git_status(generation: u64, state: State<'_, GraphState>) -> AppResult<GitStatus> {
-    let root = crate::fs::root_for_generation(&state, generation)?;
-    run_blocking(move || status(&root)).await
+    run_git(state.inner().clone(), generation, |root, _| status(root)).await
 }
 
 /// Initialize (or adopt) the graph's repository, optionally point `origin` at
@@ -137,16 +167,22 @@ pub async fn git_setup(
     generation: u64,
     state: State<'_, GraphState>,
 ) -> AppResult<GitStatus> {
-    let root = crate::fs::root_for_generation(&state, generation)?;
-    run_blocking(move || setup(&root, remote_url, branch)).await
+    run_git(state.inner().clone(), generation, move |_, state| {
+        crate::fs::mutation::with_generation(state, generation, |root| {
+            setup(root, remote_url, branch)
+        })
+    })
+    .await
 }
 
 /// Stop backing this graph up (drop `origin`; repo, history, and the
 /// machine-level credential all stay).
 #[tauri::command]
 pub async fn git_disconnect(generation: u64, state: State<'_, GraphState>) -> AppResult<GitStatus> {
-    let root = crate::fs::root_for_generation(&state, generation)?;
-    run_blocking(move || disconnect(&root)).await
+    run_git(state.inner().clone(), generation, |root, _| {
+        disconnect(root)
+    })
+    .await
 }
 
 /// Clone a backup repository into `path` (restore on a fresh machine). Runs
@@ -164,9 +200,13 @@ pub async fn git_commit_all(
     generation: u64,
     state: State<'_, GraphState>,
 ) -> AppResult<CommitOutcome> {
-    let root = crate::fs::root_for_generation(&state, generation)?;
     let started = std::time::Instant::now();
-    let outcome = run_blocking(move || commit::commit_all(&root, &message, MAX_FILE_BYTES)).await;
+    let outcome = run_git(state.inner().clone(), generation, move |_, state| {
+        crate::fs::mutation::with_generation(state, generation, |root| {
+            commit::commit_all(root, &message, MAX_FILE_BYTES)
+        })
+    })
+    .await;
     if let Ok(outcome) = &outcome {
         tracing::info!(
             committed = outcome.committed,
@@ -185,8 +225,10 @@ pub async fn git_fetch(
     generation: u64,
     state: State<'_, GraphState>,
 ) -> AppResult<RemoteDelta> {
-    let root = crate::fs::root_for_generation(&state, generation)?;
-    run_blocking(move || remote::fetch(&root, token)).await
+    run_git(state.inner().clone(), generation, move |root, _| {
+        remote::fetch(root, token)
+    })
+    .await
 }
 
 /// Merge the fetched remote branch; conflicts are committed into the notes as
@@ -196,13 +238,10 @@ pub async fn git_merge_remote(
     generation: u64,
     state: State<'_, GraphState>,
 ) -> AppResult<MergeOutcome> {
-    let root = crate::fs::root_for_generation(&state, generation)?;
-    let outcome = run_blocking(move || merge::merge_remote(&root)).await;
-    // Invalidate on both arms: a failed merge can still have moved the tree
-    // partway through checkout, and a stale catalog would pin the old view.
-    let root = crate::fs::root_for_generation(&state, generation)?;
-    crate::fs::invalidate_file_catalog(&state, &root);
-    outcome
+    run_git(state.inner().clone(), generation, move |_, state| {
+        crate::fs::mutation::with_generation(state, generation, commit_and_merge)
+    })
+    .await
 }
 
 /// Push the current branch to `origin`; rejections come back as data so the
@@ -213,6 +252,8 @@ pub async fn git_push(
     generation: u64,
     state: State<'_, GraphState>,
 ) -> AppResult<PushOutcome> {
-    let root = crate::fs::root_for_generation(&state, generation)?;
-    run_blocking(move || remote::push(&root, token)).await
+    run_git(state.inner().clone(), generation, move |root, _| {
+        remote::push(root, token)
+    })
+    .await
 }

--- a/apps/desktop/src-tauri/src/git/remote.rs
+++ b/apps/desktop/src-tauri/src/git/remote.rs
@@ -14,7 +14,8 @@ use serde::Serialize;
 
 use crate::error::{AppError, AppResult};
 
-use super::repo::{current_branch, open_existing};
+use super::repo::{current_branch, open_existing, signature};
+use super::runtime;
 
 /// Where the local branch stands relative to its last-fetched remote
 /// counterpart (no network — call after `fetch`).
@@ -173,9 +174,41 @@ fn count_commits(repo: &Repository, from: git2::Oid) -> AppResult<usize> {
 pub(super) fn clone(url: &str, target: &Path, token: Option<String>) -> AppResult<()> {
     let mut fetch_options = FetchOptions::new();
     fetch_options.remote_callbacks(callbacks_with_credentials(token));
-    git2::build::RepoBuilder::new()
+    let mut no_checkout = git2::build::CheckoutBuilder::new();
+    no_checkout.dry_run();
+    let repo = git2::build::RepoBuilder::new()
         .fetch_options(fetch_options)
+        .with_checkout(no_checkout)
         .clone(url, target)?;
+    let parent = match repo.head() {
+        Ok(head) => head.peel_to_commit()?,
+        Err(error) if error.code() == git2::ErrorCode::UnbornBranch => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    let tree = runtime::without_runtime(&repo, &parent.tree()?)?;
+    let mut checkout = git2::build::CheckoutBuilder::new();
+    checkout
+        .safe()
+        .recreate_missing(true)
+        .overwrite_ignored(false);
+    // No checkout has run, so excluding runtime here prevents even a transient
+    // copy of another device's SQLite database or chat history on restore.
+    repo.checkout_tree(tree.as_object(), Some(&mut checkout))?;
+    let mut index = repo.index()?;
+    index.read_tree(&tree)?;
+    index.write()?;
+    if tree.id() != parent.tree_id() {
+        let signature = signature(&repo)?;
+        repo.commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            "Exclude device-local runtime data from backup",
+            &tree,
+            &[&parent],
+        )?;
+    }
+    runtime::exclude_from_index(&repo)?;
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/git/repo.rs
+++ b/apps/desktop/src-tauri/src/git/repo.rs
@@ -45,6 +45,11 @@ pub(super) fn ensure_clean_state(repo: &Repository) -> AppResult<()> {
             repo.state()
         )));
     }
+    if repo.index()?.has_conflicts() {
+        return Err(AppError::io(
+            "the backup repository has unresolved index conflicts; finish or abort them with git first",
+        ));
+    }
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/git/runtime.rs
+++ b/apps/desktop/src-tauri/src/git/runtime.rs
@@ -7,15 +7,20 @@ use git2::{Index, Repository, Tree};
 use crate::error::AppResult;
 
 /// Whether a graph-relative path addresses the reserved runtime directory.
-/// Case variants are reserved too because macOS and Windows commonly use
-/// case-insensitive filesystems.
+/// Case variants and Windows trailing-dot/space aliases are reserved on every
+/// platform so a portable backup cannot address another device's live database.
 pub(super) fn is_runtime_path(path: &Path) -> bool {
-    path.components().next().is_some_and(|component| {
-        component
-            .as_os_str()
-            .to_string_lossy()
-            .eq_ignore_ascii_case(".reflect")
-    })
+    path.components()
+        .next()
+        .is_some_and(|component| is_runtime_name(component.as_os_str().as_encoded_bytes()))
+}
+
+fn is_runtime_name(name: &[u8]) -> bool {
+    let end = name
+        .iter()
+        .rposition(|byte| *byte != b'.' && *byte != b' ')
+        .map_or(0, |position| position + 1);
+    name[..end].eq_ignore_ascii_case(b".reflect")
 }
 
 /// Remove runtime entries from the index without touching their working copies.
@@ -51,7 +56,7 @@ pub(super) fn without_runtime<'repo>(
 ) -> AppResult<Tree<'repo>> {
     let mut builder = repo.treebuilder(Some(tree))?;
     for entry in tree.iter() {
-        if entry.name_bytes().eq_ignore_ascii_case(b".reflect") {
+        if is_runtime_name(entry.name_bytes()) {
             builder.remove(entry.name_bytes())?;
         }
     }

--- a/apps/desktop/src-tauri/src/git/runtime.rs
+++ b/apps/desktop/src-tauri/src/git/runtime.rs
@@ -1,0 +1,63 @@
+//! Keep device-local runtime data out of Git's index and working-tree updates.
+
+use std::path::Path;
+
+use git2::{Index, Repository, Tree};
+
+use crate::error::AppResult;
+
+/// Whether a graph-relative path addresses the reserved runtime directory.
+/// Case variants are reserved too because macOS and Windows commonly use
+/// case-insensitive filesystems.
+pub(super) fn is_runtime_path(path: &Path) -> bool {
+    path.components().next().is_some_and(|component| {
+        component
+            .as_os_str()
+            .to_string_lossy()
+            .eq_ignore_ascii_case(".reflect")
+    })
+}
+
+/// Remove runtime entries from the index without touching their working copies.
+/// Ignore rules alone cannot exclude files tracked by an adopted repository.
+pub(super) fn remove_from_index(index: &mut Index) -> AppResult<()> {
+    index.remove_all(
+        ["*"],
+        Some(&mut |path: &Path, _spec: &[u8]| {
+            if is_runtime_path(path) {
+                0
+            } else {
+                1
+            }
+        }),
+    )?;
+    Ok(())
+}
+
+/// Apply runtime exclusion when adopting or restoring a backup repository.
+pub(super) fn exclude_from_index(repo: &Repository) -> AppResult<()> {
+    repo.add_ignore_rule("/.reflect/")?;
+    let mut index = repo.index()?;
+    remove_from_index(&mut index)?;
+    index.write()?;
+    Ok(())
+}
+
+/// Build a tree containing only portable graph data. The original tree and
+/// historical commits remain intact; no runtime files are read or removed.
+pub(super) fn without_runtime<'repo>(
+    repo: &'repo Repository,
+    tree: &Tree<'_>,
+) -> AppResult<Tree<'repo>> {
+    let mut builder = repo.treebuilder(Some(tree))?;
+    for entry in tree.iter() {
+        if entry.name_bytes().eq_ignore_ascii_case(b".reflect") {
+            builder.remove(entry.name_bytes())?;
+        }
+    }
+    Ok(repo.find_tree(builder.write()?)?)
+}
+
+#[cfg(test)]
+#[path = "runtime_tests.rs"]
+mod tests;

--- a/apps/desktop/src-tauri/src/git/runtime_tests.rs
+++ b/apps/desktop/src-tauri/src/git/runtime_tests.rs
@@ -254,3 +254,130 @@ fn size_guard_withholds_already_staged_large_additions_and_updates() {
         b"too large to back up"
     );
 }
+
+const RUNTIME_ALIASES: [&str; 3] = [".reflect.", ".reflect ", ".ReFlEcT. . "];
+
+/// Construct foreign history directly from objects. Windows cannot create these
+/// literal directory names, but it can fetch them from a different filesystem.
+fn foreign_commit_with_runtime_aliases(repo: &Repository) {
+    let parent = repo.head().unwrap().peel_to_commit().unwrap();
+    let previous = parent.tree().unwrap();
+    let mut root = repo.treebuilder(Some(&previous)).unwrap();
+    let runtime_blob = repo.blob(b"foreign runtime bytes").unwrap();
+    let mut runtime = repo.treebuilder(None).unwrap();
+    runtime
+        .insert("index.sqlite", runtime_blob, 0o100644)
+        .unwrap();
+    let runtime_tree = runtime.write().unwrap();
+    for alias in RUNTIME_ALIASES {
+        root.insert(alias, runtime_tree, 0o040000).unwrap();
+    }
+    let tree = repo.find_tree(root.write().unwrap()).unwrap();
+    let signature = git2::Signature::now("Other client", "other@example.com").unwrap();
+    repo.commit(
+        Some("HEAD"),
+        &signature,
+        &signature,
+        "Foreign runtime aliases",
+        &tree,
+        &[&parent],
+    )
+    .unwrap();
+    let mut index = repo.index().unwrap();
+    index.read_tree(&tree).unwrap();
+    index.write().unwrap();
+}
+
+fn assert_no_runtime_aliases(repo: &Repository) {
+    let tree = repo.head().unwrap().peel_to_tree().unwrap();
+    let mut index = repo.index().unwrap();
+    index.read(true).unwrap();
+    for alias in RUNTIME_ALIASES {
+        assert!(tree.get_name(alias).is_none(), "{alias}");
+        assert!(
+            index
+                .get_path(Path::new(&format!("{alias}/index.sqlite")), 0)
+                .is_none(),
+            "{alias}"
+        );
+    }
+    assert_no_runtime(repo);
+}
+
+#[test]
+fn runtime_classification_reserves_windows_aliases_without_lossy_decoding() {
+    for path in [
+        ".reflect",
+        ".REFLECT/index.sqlite",
+        ".reflect./index.sqlite",
+        ".reflect /index.sqlite-wal",
+        ".ReFlEcT. . /index.sqlite-shm",
+    ] {
+        assert!(super::is_runtime_path(Path::new(path)), "{path}");
+    }
+    for path in [
+        "notes/.reflect/index.sqlite",
+        ".reflect-backup/a",
+        ".reflect.backup/a",
+        "notes/a.md",
+    ] {
+        assert!(!super::is_runtime_path(Path::new(path)), "{path}");
+    }
+    assert!(!super::is_runtime_name(b".reflect\xff"));
+    assert!(!super::is_runtime_name(b"... "));
+}
+
+#[test]
+fn adopting_tracked_runtime_aliases_preserves_the_local_database() {
+    let directory = tempdir().unwrap();
+    let repo = init(directory.path());
+    write(directory.path(), "notes/a.md", b"portable note\n");
+    foreign_commit(&repo);
+    foreign_commit_with_runtime_aliases(&repo);
+    write(
+        directory.path(),
+        ".reflect/index.sqlite",
+        b"durable local chat history",
+    );
+    write(
+        directory.path(),
+        ".reflect/index.sqlite-wal",
+        b"uncheckpointed local chat",
+    );
+
+    setup(directory.path(), None, None).unwrap();
+    commit_all(directory.path(), "Backup", MAX_FILE_BYTES).unwrap();
+
+    assert_no_runtime_aliases(&repo);
+    assert_eq!(
+        fs::read(directory.path().join(".reflect/index.sqlite")).unwrap(),
+        b"durable local chat history"
+    );
+    assert_eq!(
+        fs::read(directory.path().join(".reflect/index.sqlite-wal")).unwrap(),
+        b"uncheckpointed local chat"
+    );
+}
+
+#[test]
+fn clone_excludes_foreign_runtime_aliases_before_checkout() {
+    let directory = tempdir().unwrap();
+    let source = directory.path().join("source");
+    let repo = init(&source);
+    write(&source, "notes/a.md", b"portable note\n");
+    foreign_commit(&repo);
+    foreign_commit_with_runtime_aliases(&repo);
+    let target = directory.path().join("restored");
+
+    remote::clone(source.to_str().unwrap(), &target, None).unwrap();
+
+    assert_no_runtime_aliases(&Repository::open(&target).unwrap());
+    assert!(!target.join(".reflect").exists());
+    for alias in RUNTIME_ALIASES {
+        assert!(!target.join(alias).exists(), "{alias}");
+    }
+    assert_eq!(
+        fs::read(target.join("notes/a.md")).unwrap(),
+        b"portable note\n"
+    );
+}

--- a/apps/desktop/src-tauri/src/git/runtime_tests.rs
+++ b/apps/desktop/src-tauri/src/git/runtime_tests.rs
@@ -1,0 +1,256 @@
+use std::fs;
+use std::path::Path;
+
+use git2::{IndexAddOption, Repository, RepositoryInitOptions};
+use tempfile::tempdir;
+
+use super::super::commit::commit_all;
+use super::super::merge::merge_remote;
+use super::super::remote;
+use super::super::{setup, MAX_FILE_BYTES};
+
+fn write(root: &Path, path: &str, bytes: &[u8]) {
+    let target = root.join(path);
+    fs::create_dir_all(target.parent().unwrap()).unwrap();
+    fs::write(target, bytes).unwrap();
+}
+
+fn init(root: &Path) -> Repository {
+    Repository::init_opts(root, RepositoryInitOptions::new().initial_head("main")).unwrap()
+}
+
+/// Model a repository maintained by a different Git client, including files
+/// that client chose to track despite Reflect's runtime ignore defaults.
+fn foreign_commit(repo: &Repository) {
+    let mut index = repo.index().unwrap();
+    index.add_all(["*"], IndexAddOption::FORCE, None).unwrap();
+    index.update_all(["*"], None).unwrap();
+    index.write().unwrap();
+    let tree = repo.find_tree(index.write_tree().unwrap()).unwrap();
+    let parent = repo.head().ok().map(|head| head.peel_to_commit().unwrap());
+    let parents: Vec<_> = parent.iter().collect();
+    let signature = git2::Signature::now("Other client", "other@example.com").unwrap();
+    repo.commit(
+        Some("HEAD"),
+        &signature,
+        &signature,
+        "Foreign change",
+        &tree,
+        &parents,
+    )
+    .unwrap();
+}
+
+fn assert_no_runtime(repo: &Repository) {
+    let tree = repo.head().unwrap().peel_to_tree().unwrap();
+    assert!(tree
+        .iter()
+        .all(|entry| !entry.name_bytes().eq_ignore_ascii_case(b".reflect")));
+    let mut index = repo.index().unwrap();
+    index.read(true).unwrap();
+    assert!(index.iter().all(|entry| {
+        !entry
+            .path
+            .split(|byte| *byte == b'/')
+            .next()
+            .unwrap()
+            .eq_ignore_ascii_case(b".reflect")
+    }));
+}
+
+#[test]
+fn adopting_tracked_runtime_untracks_it_without_removing_local_chat_data() {
+    let dir = tempdir().unwrap();
+    let repo = init(dir.path());
+    write(dir.path(), ".reflect/index.sqlite", b"old shared runtime");
+    write(dir.path(), "notes/a.md", b"note\n");
+    foreign_commit(&repo);
+    write(
+        dir.path(),
+        ".reflect/index.sqlite",
+        b"durable local chat history",
+    );
+    write(
+        dir.path(),
+        ".reflect/index.sqlite-wal",
+        b"live sqlite writes",
+    );
+
+    setup(dir.path(), None, None).unwrap();
+    let mut index = repo.index().unwrap();
+    index.read(true).unwrap();
+    assert!(index
+        .get_path(Path::new(".reflect/index.sqlite"), 0)
+        .is_none());
+    commit_all(dir.path(), "Backup", MAX_FILE_BYTES).unwrap();
+
+    assert_no_runtime(&repo);
+    assert_eq!(
+        fs::read(dir.path().join(".reflect/index.sqlite")).unwrap(),
+        b"durable local chat history"
+    );
+    assert_eq!(
+        fs::read(dir.path().join(".reflect/index.sqlite-wal")).unwrap(),
+        b"live sqlite writes"
+    );
+    assert!(
+        !commit_all(dir.path(), "Backup", MAX_FILE_BYTES)
+            .unwrap()
+            .committed
+    );
+}
+
+#[test]
+fn commits_exclude_prestaged_and_case_variant_runtime_without_ignore_files() {
+    let dir = tempdir().unwrap();
+    let repo = init(dir.path());
+    write(dir.path(), ".ReFlEcT/index.sqlite", b"local private chat");
+    write(dir.path(), "notes/a.md", b"note\n");
+    let mut index = repo.index().unwrap();
+    index.add_all(["*"], IndexAddOption::FORCE, None).unwrap();
+    index.write().unwrap();
+
+    commit_all(dir.path(), "Backup", MAX_FILE_BYTES).unwrap();
+
+    assert_no_runtime(&repo);
+    assert_eq!(
+        fs::read(dir.path().join(".ReFlEcT/index.sqlite")).unwrap(),
+        b"local private chat"
+    );
+}
+
+#[test]
+fn clone_never_restores_another_devices_runtime() {
+    let dir = tempdir().unwrap();
+    let source = dir.path().join("source");
+    let repo = init(&source);
+    write(
+        &source,
+        ".reflect/index.sqlite",
+        b"remote device's chat history",
+    );
+    write(&source, "notes/a.md", b"portable note\n");
+    foreign_commit(&repo);
+    let target = dir.path().join("restored");
+
+    remote::clone(source.to_str().unwrap(), &target, None).unwrap();
+
+    assert!(!target.join(".reflect").exists());
+    assert_eq!(
+        fs::read(target.join("notes/a.md")).unwrap(),
+        b"portable note\n"
+    );
+    assert_no_runtime(&Repository::open(&target).unwrap());
+}
+
+#[test]
+fn fast_forward_excludes_remote_runtime_and_preserves_local_chat_bytes() {
+    let dir = tempdir().unwrap();
+    let source = dir.path().join("source");
+    let repo = init(&source);
+    write(&source, "notes/a.md", b"base\n");
+    foreign_commit(&repo);
+    let target = dir.path().join("target");
+    let local = Repository::clone(source.to_str().unwrap(), &target).unwrap();
+    write(&target, ".reflect/index.sqlite", b"local durable chat");
+    write(
+        &target,
+        ".reflect/index.sqlite-wal",
+        b"local uncheckpointed chat",
+    );
+    write(&source, ".reflect/index.sqlite", b"foreign runtime");
+    write(&source, "notes/a.md", b"remote update\n");
+    foreign_commit(&repo);
+
+    remote::fetch(&target, None).unwrap();
+    let outcome = merge_remote(&target).unwrap();
+
+    assert_no_runtime(&local);
+    assert_eq!(
+        fs::read(target.join(".reflect/index.sqlite")).unwrap(),
+        b"local durable chat"
+    );
+    assert_eq!(
+        fs::read(target.join(".reflect/index.sqlite-wal")).unwrap(),
+        b"local uncheckpointed chat"
+    );
+    assert_eq!(
+        fs::read(target.join("notes/a.md")).unwrap(),
+        b"remote update\n"
+    );
+    assert!(outcome
+        .changed_files
+        .iter()
+        .all(|change| !change.path.starts_with(".reflect")));
+}
+
+#[test]
+fn divergent_merge_ignores_runtime_conflicts_and_preserves_local_chat_bytes() {
+    let dir = tempdir().unwrap();
+    let source = dir.path().join("source");
+    let repo = init(&source);
+    write(&source, "notes/a.md", b"base\n");
+    write(&source, ".reflect/index.sqlite", b"historical runtime");
+    foreign_commit(&repo);
+    let target = dir.path().join("target");
+    let local = Repository::clone(source.to_str().unwrap(), &target).unwrap();
+    write(&target, ".reflect/index.sqlite", b"local durable chat");
+    write(&target, "notes/local.md", b"local note\n");
+    commit_all(&target, "Local backup", MAX_FILE_BYTES).unwrap();
+    write(
+        &source,
+        ".reflect/index.sqlite",
+        b"different foreign runtime",
+    );
+    write(&source, "notes/a.md", b"remote update\n");
+    foreign_commit(&repo);
+
+    remote::fetch(&target, None).unwrap();
+    let outcome = merge_remote(&target).unwrap();
+
+    assert_no_runtime(&local);
+    assert!(outcome.conflicted_paths.is_empty());
+    assert_eq!(
+        fs::read(target.join(".reflect/index.sqlite")).unwrap(),
+        b"local durable chat"
+    );
+    assert_eq!(
+        fs::read(target.join("notes/a.md")).unwrap(),
+        b"remote update\n"
+    );
+    assert_eq!(
+        fs::read(target.join("notes/local.md")).unwrap(),
+        b"local note\n"
+    );
+}
+
+#[test]
+fn size_guard_withholds_already_staged_large_additions_and_updates() {
+    let dir = tempdir().unwrap();
+    let repo = init(dir.path());
+    write(dir.path(), "assets/existing.bin", b"small");
+    commit_all(dir.path(), "Base", MAX_FILE_BYTES).unwrap();
+    write(dir.path(), "assets/existing.bin", b"too large to back up");
+    write(dir.path(), "assets/new.bin", b"also too large to back up");
+    let mut index = repo.index().unwrap();
+    index.add_all(["*"], IndexAddOption::DEFAULT, None).unwrap();
+    index.write().unwrap();
+    write(dir.path(), "notes/a.md", b"note\n");
+
+    let outcome = commit_all(dir.path(), "Backup", 10).unwrap();
+
+    assert!(outcome.committed);
+    assert_eq!(outcome.skipped_large_files.len(), 2);
+    let tree = repo.head().unwrap().peel_to_tree().unwrap();
+    assert!(tree.get_path(Path::new("assets/new.bin")).is_err());
+    let entry = tree.get_path(Path::new("assets/existing.bin")).unwrap();
+    assert_eq!(repo.find_blob(entry.id()).unwrap().content(), b"small");
+    assert_eq!(
+        fs::read(dir.path().join("assets/new.bin")).unwrap(),
+        b"also too large to back up"
+    );
+    assert_eq!(
+        fs::read(dir.path().join("assets/existing.bin")).unwrap(),
+        b"too large to back up"
+    );
+}

--- a/apps/desktop/src-tauri/src/git/tests.rs
+++ b/apps/desktop/src-tauri/src/git/tests.rs
@@ -740,7 +740,7 @@ fn rename_rename_conflict_keeps_both_names_and_confirms_the_removal() {
 
 #[cfg(unix)]
 #[test]
-fn failed_merge_completion_still_clears_the_merge_state() {
+fn failed_checkout_leaves_no_merge_state_and_recovers_after_repair() {
     use std::os::unix::fs::PermissionsExt;
 
     let fixture = fixture();
@@ -758,8 +758,8 @@ fn failed_merge_completion_still_clears_the_merge_state() {
     commit_all(root_a, "a delete", MAX_FILE_BYTES).unwrap();
     fetch(root_a, None).unwrap();
 
-    // Make restoring the surviving edit fail mid-completion: the notes
-    // directory refuses new files, so write_blob cannot recreate keep.md.
+    // Make checkout of the surviving edit fail: the notes directory refuses
+    // new files, so checkout cannot recreate keep.md.
     let notes_dir = root_a.join("notes");
     fs::set_permissions(&notes_dir, fs::Permissions::from_mode(0o555)).unwrap();
     let result = merge_remote(root_a);
@@ -948,4 +948,116 @@ fn diverging_renames_keep_both_files_and_never_wedge() {
     assert!(read(root_a, "notes/title-a.md").contains("Title A"));
     assert!(read(root_a, "notes/title-b.md").contains("Title B"));
     assert!(push(root_a, None).unwrap().pushed);
+}
+
+fn graph_state(root: &Path) -> crate::fs::GraphState {
+    let graph = crate::fs::GraphState::default();
+    {
+        let mut inner = graph.0.lock().unwrap();
+        inner.generation = 1;
+        inner.root = Some(root.to_path_buf());
+    }
+    graph
+}
+
+#[test]
+fn sync_snapshots_note_saved_during_fetch_before_merging() {
+    let fixture = fixture();
+    write(&fixture.graph_a, "notes/race.md", "base\n");
+    commit_all(&fixture.graph_a, "initial", MAX_FILE_BYTES).unwrap();
+    push(&fixture.graph_a, None).unwrap();
+    let local = second_device(&fixture);
+    let graph = graph_state(&local);
+    write(&fixture.graph_a, "notes/race.md", "remote revision\n");
+    commit_all(&fixture.graph_a, "remote", MAX_FILE_BYTES).unwrap();
+    push(&fixture.graph_a, None).unwrap();
+    commit_all(&local, "before fetch", MAX_FILE_BYTES).unwrap();
+
+    // A save is permitted while fetch owns the repository, but no worktree lock.
+    crate::fs::mutation::with_repository(&local, || {
+        crate::fs::mutation::with_generation(&graph, 1, |root| {
+            crate::fs::atomic_write_bytes(
+                root,
+                &root.join("notes/race.md"),
+                b"local edit saved during fetch\n",
+            )?;
+            Ok(())
+        })?;
+        fetch(&local, None)
+    })
+    .unwrap();
+    let outcome = tauri::async_runtime::block_on(super::run_git(graph, 1, |_, state| {
+        crate::fs::mutation::with_generation(state, 1, super::commit_and_merge)
+    }))
+    .unwrap();
+    assert!(matches!(outcome.kind, MergeKind::MergedWithConflicts));
+    let content = read(&local, "notes/race.md");
+    assert!(content.contains("local edit saved during fetch"));
+    assert!(content.contains("remote revision"));
+    let repo = Repository::open(&local).unwrap();
+    let merged = repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(merged.parent_count(), 2);
+}
+
+#[test]
+fn save_queued_during_checkout_lands_after_the_remote_revision_is_committed() {
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    let fixture = fixture();
+    write(&fixture.graph_a, "notes/race.md", "base\n");
+    commit_all(&fixture.graph_a, "initial", MAX_FILE_BYTES).unwrap();
+    push(&fixture.graph_a, None).unwrap();
+    let local = second_device(&fixture);
+    let graph = graph_state(&local);
+    write(&fixture.graph_a, "notes/race.md", "remote revision\n");
+    commit_all(&fixture.graph_a, "remote", MAX_FILE_BYTES).unwrap();
+    push(&fixture.graph_a, None).unwrap();
+    fetch(&local, None).unwrap();
+
+    let (attempting_tx, attempting_rx) = mpsc::channel();
+    let (saved_tx, saved_rx) = mpsc::channel();
+    let writer_graph = graph.clone();
+    let writer = crate::fs::mutation::with_generation(&graph, 1, |root| {
+        // Pause at the commit/checkout boundary with the production scope held.
+        commit_all(root, "before checkout", MAX_FILE_BYTES)?;
+        let writer = thread::spawn(move || {
+            attempting_tx.send(()).unwrap();
+            crate::fs::mutation::with_generation(&writer_graph, 1, |root| {
+                crate::fs::atomic_write_bytes(
+                    root,
+                    &root.join("notes/race.md"),
+                    b"save queued during checkout\n",
+                )?;
+                saved_tx.send(()).unwrap();
+                Ok(())
+            })
+        });
+        attempting_rx.recv().unwrap();
+        assert!(saved_rx.recv_timeout(Duration::from_millis(100)).is_err());
+        let outcome = merge_remote(root)?;
+        assert!(matches!(outcome.kind, MergeKind::FastForward));
+        assert_eq!(read(root, "notes/race.md"), "remote revision\n");
+        Ok(writer)
+    })
+    .unwrap();
+    writer.join().unwrap().unwrap();
+    saved_rx.recv().unwrap();
+    assert_eq!(
+        read(&local, "notes/race.md"),
+        "save queued during checkout\n"
+    );
+    let repo = Repository::open(&local).unwrap();
+    let tree = repo.head().unwrap().peel_to_tree().unwrap();
+    let entry = tree.get_path(Path::new("notes/race.md")).unwrap();
+    assert_eq!(
+        repo.find_blob(entry.id()).unwrap().content(),
+        b"remote revision\n"
+    );
+    assert!(
+        commit_all(&local, "save after checkout", MAX_FILE_BYTES)
+            .unwrap()
+            .committed
+    );
 }

--- a/apps/desktop/src-tauri/src/icloud/sweep.rs
+++ b/apps/desktop/src-tauri/src/icloud/sweep.rs
@@ -122,11 +122,10 @@ pub async fn icloud_conflicts_scan(
 ) -> AppResult<SweepOutcome> {
     let started = std::time::Instant::now();
     let root = crate::fs::root_for_generation(&state, generation)?;
-    let sweep_root = root.clone();
-    let outcome = crate::blocking::run_blocking(move || {
+    let outcome = crate::fs::mutation::run(state.inner().clone(), generation, move |root| {
         let candidates = conflict_candidates(scope, &ingested_paths);
         run_sweep(
-            &sweep_root,
+            root,
             &skip_paths,
             &ingested_paths,
             record_baseline,

--- a/apps/desktop/src/editor/note-session-state.ts
+++ b/apps/desktop/src/editor/note-session-state.ts
@@ -49,6 +49,8 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
   let saveTimer: ReturnType<typeof setTimeout> | null = null
   /** Serializes writes so a flush can't interleave with a debounced save. */
   let saveChain: Promise<void> = Promise.resolve()
+  /** Invalidates external reads captured before a local save finished. */
+  let writeRevision = 0
   /** Settles when the current initial load has committed its state. */
   let loadPromise: Promise<void> = Promise.resolve()
   /**
@@ -127,6 +129,7 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
         inFlightWrite = content
         try {
           await write(path, content)
+          writeRevision += 1
           disk = content
           dirty = header + buffer !== content
           missing = false // the landed write created the file if it was missing
@@ -240,6 +243,7 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
    * external-change path).
    */
   async function reconcileFromDisk(): Promise<void> {
+    const readRevision = writeRevision
     let content: string
     try {
       content = await io.read(path)
@@ -247,6 +251,13 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
       return // deleted/unreadable between event and read; nothing to reconcile
     }
     if (disposed) {
+      return
+    }
+    if (readRevision !== writeRevision) {
+      // A save queued behind Git checkout may finish before the checkout's
+      // read response arrives. Re-read instead of accepting those older bytes
+      // into an editor that the save has just marked clean.
+      await reconcileFromDisk()
       return
     }
     if (content === disk || content === inFlightWrite) {
@@ -404,6 +415,7 @@ export function createNoteSession(options: NoteSessionOptions): NoteSession {
     const patched = upsertFrontmatter(conflict, frontmatterPatchToYaml(patch))
     if (patched !== conflict) {
       await io.write(path, patched)
+      writeRevision += 1
       conflict = patched
       disk = patched
       emit()

--- a/apps/desktop/src/editor/note-session.test.ts
+++ b/apps/desktop/src/editor/note-session.test.ts
@@ -219,6 +219,60 @@ describe('createNoteSession', () => {
     expect(snapshots.at(-1)?.dirty).toBe(false)
   })
 
+  it('re-reads a merge notification if a queued save finishes while its read is in flight', async () => {
+    let disk = '# Before sync\n'
+    const read = vi.fn(async () => disk)
+    const writeGate: { resolve: (() => void) | null } = { resolve: null }
+    const readGate: { resolve: ((content: string) => void) | null } = { resolve: null }
+    const applied: string[] = []
+    const session = createNoteSession({
+      path: 'notes/a.md',
+      io: {
+        read,
+        write: async (_path, content) => {
+          await new Promise<void>((resolve) => {
+            writeGate.resolve = resolve
+          })
+          disk = content
+        },
+      },
+      classify: () => 'exact',
+      onSnapshot: () => {},
+      applyContent: (content) => {
+        applied.push(content)
+      },
+    })
+    session.load()
+    await vi.advanceTimersByTimeAsync(0)
+
+    session.editorChanged('# Saved during checkout\n')
+    const saving = session.flush()
+    await vi.advanceTimersByTimeAsync(0)
+    // Checkout lands first; its notification reads those bytes while the
+    // local write is still waiting for the native filesystem guard.
+    disk = '# Pulled contents\n'
+    read.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          readGate.resolve = resolve
+        }),
+    )
+    session.externalChanged()
+    await vi.advanceTimersByTimeAsync(0)
+
+    writeGate.resolve?.()
+    await saving
+    expect(session.isDirty()).toBe(false)
+    readGate.resolve?.('# Pulled contents\n')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(disk).toBe('# Saved during checkout\n')
+    expect(session.content()).toBe(disk)
+    expect(applied).toEqual([])
+    expect(read).toHaveBeenCalledTimes(3)
+    session.dispose()
+  })
+
   it('re-gates protection when external content stops being representable', async () => {
     const lossyWhenTasks = (markdown: string): RoundTripFidelity =>
       markdown.includes('+ [ ]') ? 'lossy' : 'exact'

--- a/apps/desktop/src/lib/backup-controller.test.tsx
+++ b/apps/desktop/src/lib/backup-controller.test.tsx
@@ -8,6 +8,7 @@ import {
 } from '@reflect/core'
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
 import { setPlatformSurface } from '@/lib/platform-surface'
+import { flushBackup } from './backup-flush'
 import { createBackupController, type BackupState } from './backup-controller'
 
 // providerFetch routes GitHub API calls through the Tauri HTTP plugin
@@ -28,7 +29,12 @@ const GRAPH: GraphInfo = { root: '/g', name: 'G', generation: 3 }
 
 const AUTH = JSON.stringify({ kind: 'pat', token: 'ghp_abc' })
 const CLEAN_COMMIT = { committed: false, sha: null, ahead: 0, skippedLargeFiles: [] }
-const UP_TO_DATE = { kind: 'upToDate', conflictedPaths: [], changedFiles: [] }
+const UP_TO_DATE = {
+  kind: 'upToDate',
+  conflictedPaths: [],
+  skippedLargeFiles: [],
+  changedFiles: [],
+}
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -38,6 +44,9 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 interface FakeOptions {
+  /** Hold each listed command's first call until `releaseCommand(command)`. */
+  gateCommands?: string[]
+  failDisconnect?: boolean
   auth?: string | null
   /** Hold the direct index write until `releaseIndexApply()` (the convergence barrier). */
   gateIndexApply?: boolean
@@ -83,16 +92,31 @@ function fakeBridge(options: FakeOptions = {}) {
   let indexApplyCount = 0
   const mergeOutcomes = [...(options.mergeOutcomes ?? [])]
   const pushOutcomes = [...(options.pushOutcomes ?? [])]
+  const gates = new Map<string, { promise: Promise<void>; release: () => void }>()
+  for (const command of options.gateCommands ?? []) {
+    let release = (): void => {}
+    const promise = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    gates.set(command, { promise, release })
+  }
+  const gated = new Set<string>()
   setBridge({
     invoke: async (command, args) => {
       calls.push(command)
       invocations.push({ command, args })
+      const statusAtCall = { ...status }
+      const gate = gates.get(command)
+      if (gate !== undefined && !gated.has(command)) {
+        gated.add(command)
+        await gate.promise
+      }
       switch (command) {
         case 'git_status':
           if (options.failStatus === true) {
             throw { kind: 'io', message: 'broken repo' }
           }
-          return status
+          return statusAtCall
         case 'git_setup':
           status.initialized = true
           status.remoteUrl = typeof args['remoteUrl'] === 'string' ? args['remoteUrl'] : null
@@ -135,6 +159,9 @@ function fakeBridge(options: FakeOptions = {}) {
           }
           return null
         case 'git_disconnect':
+          if (options.failDisconnect === true) {
+            throw { kind: 'io', message: 'disconnect failed' }
+          }
           status.remoteUrl = null
           return status
         default:
@@ -159,6 +186,7 @@ function fakeBridge(options: FakeOptions = {}) {
     status,
     releaseListen: () => releaseListen?.(),
     releaseIndexApply: () => releaseIndexApply?.(),
+    releaseCommand: (command: string) => gates.get(command)?.release(),
   }
 }
 
@@ -373,6 +401,51 @@ describe('createBackupController', () => {
     controller.dispose()
   })
 
+  it('ignores an older connection probe after a newer start has adopted the graph', async () => {
+    const { calls, status, releaseCommand } = fakeBridge({ gateCommands: ['git_status'] })
+    const controller = createBackupController({ graph: GRAPH, indexGeneration: null })
+    const firstStart = controller.start()
+    await vi.waitFor(() => {
+      expect(calls).toContain('git_status')
+    })
+
+    status.remoteUrl = null
+    await controller.start()
+    await vi.waitFor(() => {
+      expect(commitCount(calls)).toBe(1)
+    })
+    releaseCommand('git_status')
+    await firstStart
+
+    expect(controller.getState()).toEqual({ phase: 'disconnected' })
+    expect(commitCount(calls)).toBe(1)
+    expect(calls).not.toContain('git_fetch')
+    controller.dispose()
+  })
+
+  it('an old graph controller cannot clear the current graph quit-commit hook', async () => {
+    const { invocations } = fakeBridge({ remoteUrl: null })
+    const first = createBackupController({ graph: GRAPH, indexGeneration: null })
+    const second = createBackupController({
+      graph: { ...GRAPH, generation: 4 },
+      indexGeneration: null,
+    })
+    await first.start()
+    await second.start()
+    await vi.waitFor(() => {
+      expect(invocations.filter(({ command }) => command === 'git_commit_all')).toHaveLength(2)
+    })
+    first.dispose()
+    invocations.length = 0
+
+    await flushBackup()
+
+    expect(invocations).toEqual([
+      { command: 'git_commit_all', args: { message: 'Update notes', generation: 4 } },
+    ])
+    second.dispose()
+  })
+
   it('local history keeps committing on edits — still with no network', async () => {
     // A repo without a remote (e.g. after disconnectGraph) needs no git_setup.
     const { calls } = fakeBridge({ auth: null, remoteUrl: null })
@@ -422,6 +495,51 @@ describe('createBackupController', () => {
 
     expect(calls).toContain('git_disconnect')
     expect(controller.getState()).toEqual({ phase: 'disconnected' })
+    controller.dispose()
+  })
+
+  it.each(['disconnectGraph', 'signOut'] as const)(
+    '%s stops an in-flight fetch before awaiting the connection change',
+    async (action) => {
+      const command = action === 'disconnectGraph' ? 'git_disconnect' : 'secret_delete'
+      const { calls, releaseCommand } = fakeBridge({ gateCommands: ['git_fetch', command] })
+      const controller = createBackupController({ graph: GRAPH, indexGeneration: null })
+      await controller.start()
+      await vi.waitFor(() => {
+        expect(calls).toContain('git_fetch')
+      })
+
+      const updating = controller[action]()
+      await vi.waitFor(() => {
+        expect(calls).toContain(command)
+      })
+      releaseCommand('git_fetch')
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(calls).not.toContain('git_merge_remote')
+      expect(calls).not.toContain('git_push')
+      releaseCommand(command)
+      await updating
+      expect(controller.getState()).toEqual({ phase: 'disconnected' })
+      controller.dispose()
+    },
+  )
+
+  it('restores the sync lifecycle when disconnect fails', async () => {
+    const { calls } = fakeBridge({ failDisconnect: true })
+    const controller = createBackupController({ graph: GRAPH, indexGeneration: null })
+    await controller.start()
+    await vi.waitFor(() => {
+      expect(calls).toContain('git_fetch')
+    })
+
+    await expect(controller.disconnectGraph()).rejects.toMatchObject({
+      message: 'disconnect failed',
+    })
+    await vi.waitFor(() => {
+      expect(calls.filter((command) => command === 'git_fetch')).toHaveLength(2)
+    })
+    expect(controller.getState()).toMatchObject({ phase: 'connected' })
     controller.dispose()
   })
 
@@ -660,6 +778,7 @@ describe('createBackupController', () => {
       mergeOutcome: {
         kind: 'merged',
         conflictedPaths: [],
+        skippedLargeFiles: [],
         changedFiles: [
           { path: 'notes/from-b.md', kind: 'upsert', modifiedMs: 123 },
           { path: 'daily/2026-06-11.md', kind: 'remove' },
@@ -706,8 +825,13 @@ describe('createBackupController', () => {
     const { calls, releaseIndexApply } = fakeBridge({
       gateIndexApply: true,
       mergeOutcomes: [
-        { kind: 'merged', conflictedPaths: [], changedFiles: [firstChange] },
-        { kind: 'merged', conflictedPaths: [], changedFiles: [secondChange] },
+        { kind: 'merged', conflictedPaths: [], skippedLargeFiles: [], changedFiles: [firstChange] },
+        {
+          kind: 'merged',
+          conflictedPaths: [],
+          skippedLargeFiles: [],
+          changedFiles: [secondChange],
+        },
       ],
       pushOutcomes: [
         { pushed: false, nonFastForward: true, rejectionMessage: 'fetch first' },
@@ -755,11 +879,13 @@ describe('createBackupController', () => {
         {
           kind: 'merged',
           conflictedPaths: [],
+          skippedLargeFiles: [],
           changedFiles: [{ path: 'notes/from-remote-1.md', kind: 'upsert', modifiedMs: 123 }],
         },
         {
           kind: 'merged',
           conflictedPaths: [],
+          skippedLargeFiles: [],
           changedFiles: [{ path: 'notes/from-remote-2.md', kind: 'upsert', modifiedMs: 456 }],
         },
       ],
@@ -792,6 +918,7 @@ describe('createBackupController', () => {
       mergeOutcome: {
         kind: 'fastForward',
         conflictedPaths: [],
+        skippedLargeFiles: [],
         changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert', modifiedMs: 123 }],
       },
     })
@@ -823,6 +950,7 @@ describe('createBackupController', () => {
       mergeOutcome: {
         kind: 'fastForward',
         conflictedPaths: [],
+        skippedLargeFiles: [],
         changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert', modifiedMs: 123 }],
       },
     })
@@ -851,6 +979,7 @@ describe('createBackupController', () => {
         mergeOutcome: {
           kind: 'merged',
           conflictedPaths: [],
+          skippedLargeFiles: [],
           changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert', modifiedMs: 123 }],
         },
       })

--- a/apps/desktop/src/lib/backup-controller.ts
+++ b/apps/desktop/src/lib/backup-controller.ts
@@ -25,7 +25,7 @@ import {
   type SyncStatus,
   type Unlisten,
 } from '@reflect/core'
-import { setBackupFlusher } from '@/lib/backup-flush'
+import { registerBackupFlusher } from '@/lib/backup-flush'
 import { invalidateGithubAuth } from '@/lib/github-auth-state'
 import { startOperation } from '@/lib/operations'
 import { isNativeShell } from '@/lib/platform'
@@ -135,11 +135,16 @@ export function createBackupController(options: BackupControllerOptions): Backup
   let disposed = false
   let engine: SyncEngine | null = null
   let unlisten: Unlisten | null = null
+  let releaseBackupFlusher: (() => void) | null = null
   const domDisposers: Array<() => void> = []
   /** Serializes direct index writes without delaying synchronous file-change fanout. */
   let remoteIndexTail: Promise<void> = Promise.resolve()
-  /** Invalidates index work that was queued before a controller teardown/restart. */
+  /** Invalidates pending startup and index work after a teardown/restart. */
   let remoteIndexEpoch = 0
+
+  function isCurrent(epoch: number): boolean {
+    return !disposed && epoch === remoteIndexEpoch
+  }
 
   function setState(next: BackupState): void {
     if (disposed) {
@@ -161,7 +166,8 @@ export function createBackupController(options: BackupControllerOptions): Backup
     for (const dispose of domDisposers.splice(0)) {
       dispose()
     }
-    setBackupFlusher(null)
+    releaseBackupFlusher?.()
+    releaseBackupFlusher = null
   }
 
   function onRemoteChanges(changes: ChangedFile[]): void | Promise<void> {
@@ -214,7 +220,11 @@ export function createBackupController(options: BackupControllerOptions): Backup
    * quit-time flusher. Returns false when teardown or a restart won the race
    * against the subscribe — the engine is already stopped in that case.
    */
-  async function adoptEngine(next: SyncEngine): Promise<boolean> {
+  async function adoptEngine(next: SyncEngine, epoch: number): Promise<boolean> {
+    if (!isCurrent(epoch)) {
+      next.stop()
+      return false
+    }
     engine = next
     // Spooled capture envelopes (`.reflect/inbox/`) are git-ignored and
     // drained within seconds — they must not tick the commit debounce. The
@@ -224,14 +234,14 @@ export function createBackupController(options: BackupControllerOptions): Backup
         next.noteChanged()
       }
     })
-    if (disposed || engine !== next) {
+    if (!isCurrent(epoch) || engine !== next) {
       subscription()
       next.stop()
       return false
     }
     unlisten = subscription
     // Quit-time commit (local only — never a network push on the way out).
-    setBackupFlusher(async () => {
+    releaseBackupFlusher = registerBackupFlusher(async () => {
       await gitCommitAll('Update notes', generation)
     })
     return true
@@ -258,15 +268,18 @@ export function createBackupController(options: BackupControllerOptions): Backup
    * instruction for fixing that remote, and losing it to a watcher that
    * happened not to come up would be the worse trade.
    */
-  async function startLocalHistory(initialized: boolean): Promise<void> {
+  async function startLocalHistory(initialized: boolean, epoch: number): Promise<void> {
     // Real git on a real folder — a shell capability the browser-dev bridge
     // honestly lacks, so don't start (and noisily fail) the commit loop there.
-    if (isMobileSurface() || !isNativeShell()) {
+    if (!isCurrent(epoch) || isMobileSurface() || !isNativeShell()) {
       return
     }
     try {
       if (!initialized) {
         await gitSetup(null, null, generation)
+      }
+      if (!isCurrent(epoch)) {
+        return
       }
       const next = createSyncEngine({
         generation,
@@ -280,11 +293,14 @@ export function createBackupController(options: BackupControllerOptions): Backup
           }
         },
       })
-      if (!(await adoptEngine(next))) {
+      if (!(await adoptEngine(next, epoch)) || !isCurrent(epoch)) {
         return
       }
       void next.syncNow() // first snapshot: commit whatever is already pending
     } catch (error) {
+      if (!isCurrent(epoch)) {
+        return
+      }
       // `adoptEngine` assigns the engine before its first await, so a
       // half-built lifecycle takes the same teardown as every other failure.
       // No zombie engine keeps timers alive behind the caller's state.
@@ -295,6 +311,7 @@ export function createBackupController(options: BackupControllerOptions): Backup
 
   async function start(): Promise<void> {
     teardown()
+    const epoch = remoteIndexEpoch
     if (disposed) {
       return
     }
@@ -311,12 +328,12 @@ export function createBackupController(options: BackupControllerOptions): Backup
           return null
         }),
       ])
-      if (disposed) {
+      if (!isCurrent(epoch)) {
         return
       }
       if (!status.initialized || status.remoteUrl === null) {
         setState({ phase: 'disconnected' })
-        await startLocalHistory(status.initialized)
+        await startLocalHistory(status.initialized, epoch)
         return
       }
       const remoteUrl = status.remoteUrl
@@ -326,7 +343,7 @@ export function createBackupController(options: BackupControllerOptions): Backup
         // Generic remotes adopt without it — their credentials live with the
         // user's own git tooling (ssh agent), not in our keychain.
         setState({ phase: 'disconnected' })
-        await startLocalHistory(status.initialized)
+        await startLocalHistory(status.initialized, epoch)
         return
       }
       if (repo === null && /^https?:\/\//i.test(remoteUrl)) {
@@ -346,7 +363,7 @@ export function createBackupController(options: BackupControllerOptions): Backup
               'HTTPS isn’t supported for this host yet — switch the remote to its SSH form: git remote set-url origin git@<host>:<owner>/<repo>.git',
           },
         })
-        await startLocalHistory(status.initialized)
+        await startLocalHistory(status.initialized, epoch)
         return
       }
       const next = createSyncEngine({
@@ -372,7 +389,7 @@ export function createBackupController(options: BackupControllerOptions): Backup
         onRemoteChanges,
       })
       setState({ phase: 'connected', remoteUrl, repo, status: { state: 'idle' } })
-      if (!(await adoptEngine(next))) {
+      if (!(await adoptEngine(next, epoch)) || !isCurrent(epoch)) {
         return
       }
 
@@ -407,6 +424,9 @@ export function createBackupController(options: BackupControllerOptions): Backup
 
       void next.syncNow() // launch pull: pick up other devices' changes
     } catch (error) {
+      if (!isCurrent(epoch)) {
+        return
+      }
       // Any partially-built lifecycle is torn down whole — no zombie engine
       // keeps timers or git work running behind a disconnected UI.
       teardown()
@@ -426,8 +446,24 @@ export function createBackupController(options: BackupControllerOptions): Backup
   }
 
   async function connectRemote(remoteUrl: string, branch: string): Promise<void> {
-    await gitSetup(remoteUrl, branch, generation)
-    await start()
+    await updateConnection(() => gitSetup(remoteUrl, branch, generation))
+  }
+
+  async function updateConnection(update: () => Promise<unknown>): Promise<void> {
+    if (disposed) {
+      return
+    }
+    // Stop before the first await: an in-flight fetch can otherwise finish
+    // and push using the old credential or a newly reassigned origin.
+    teardown()
+    const epoch = remoteIndexEpoch
+    try {
+      await update()
+    } finally {
+      if (isCurrent(epoch)) {
+        await start()
+      }
+    }
   }
 
   return {
@@ -469,13 +505,13 @@ export function createBackupController(options: BackupControllerOptions): Backup
       return 'connected'
     },
     disconnectGraph: async () => {
-      await gitDisconnect(generation)
-      await start()
+      await updateConnection(() => gitDisconnect(generation))
     },
     signOut: async () => {
-      await clearGithubAuth()
-      invalidateGithubAuth()
-      await start()
+      await updateConnection(async () => {
+        await clearGithubAuth()
+        invalidateGithubAuth()
+      })
     },
     backUpNow: async () => {
       await engine?.syncNow()

--- a/apps/desktop/src/lib/backup-flush.ts
+++ b/apps/desktop/src/lib/backup-flush.ts
@@ -9,9 +9,14 @@
 
 let flusher: (() => Promise<void>) | null = null
 
-/** Install (or clear, with `null`) the active graph's quit-commit hook. */
-export function setBackupFlusher(next: (() => Promise<void>) | null): void {
+/** Install a graph's quit-commit hook; release only this registration on teardown. */
+export function registerBackupFlusher(next: () => Promise<void>): () => void {
   flusher = next
+  return () => {
+    if (flusher === next) {
+      flusher = null
+    }
+  }
 }
 
 /** Run the registered quit-commit, if any. Never throws, never blocks quit. */

--- a/docs/generic-git-remotes.md
+++ b/docs/generic-git-remotes.md
@@ -45,7 +45,8 @@ remote is adopted automatically.
 ## When it fails
 
 Failures surface in Settings → Backup (and the sidebar dot) and retry on
-focus — sync never wedges.
+focus. See [Git backup and recovery](./git-backup-safety.md) for save ordering,
+conflict copies, runtime exclusion, and interrupted operations.
 
 - **"the SSH agent offered no key this host accepts"** — `ssh-add` your key,
   confirm `ssh -T git@<host>` works, refocus Reflect.

--- a/docs/git-backup-safety.md
+++ b/docs/git-backup-safety.md
@@ -1,0 +1,57 @@
+# Git backup and recovery
+
+GitHub and generic Git remotes use the same native commit, fetch, merge, and
+push implementation. Local history commits happen before credential refresh,
+so an authentication or network failure does not prevent local snapshots.
+
+## Saves during sync
+
+Fetch and push serialize repository operations without holding the graph's
+filesystem mutation lock. Note saves continue during those network waits.
+Immediately before applying a pull, Reflect takes the mutation lock, commits
+saves that have reached disk, and holds the lock through merge and checkout.
+Note saves, note creation/deletion/renames, asset promotion, import finalization,
+and native conflict sweeps use that same lock. Waiting saves run off the main
+thread and continue after checkout.
+
+Overlapping committed note edits become labeled conflict markers. Both original
+versions remain in the merge commit's parents. A save queued during checkout
+lands afterwards, with the pulled version retained in Git history. The editor
+re-reads a disk notification if a local save completed while its read was pending.
+
+Merge results are computed in memory. Checkout uses libgit2's safe mode and does
+not overwrite ignored files. Branch references advance only after checkout and
+index writes succeed. A conflicting dirty path causes an error with the local
+file preserved. Reflect does not force-reset the working tree on failure. An I/O
+failure can leave partially applied files or a preserved conflict copy; the old
+branch remains reachable, and subsequent snapshots retain the files on disk.
+External filesystem tools do not participate in Reflect's in-process lock, so
+safe checkout is an additional check, not a filesystem transaction across other
+processes.
+
+## Attachments and runtime files
+
+Binary conflicts keep the local attachment and atomically claim a separate file
+for the remote attachment. Names progress from `image (conflict).png` to
+`image (conflict 2).png`, and so on. Existing files are never reused for a new
+conflict. A copy retained after a later sync failure is deliberate recovery data.
+The size limit also applies to files staged by another Git tool before Reflect
+runs; withheld updates retain their previous committed version.
+
+The root `.reflect` directory (including case variants) is excluded from new
+Reflect commits and incoming checkouts, even when an adopted repository already
+tracks it. Adoption removes its entries from the Git index without deleting
+local files. Restoring through Reflect does not check out another device's
+runtime files. Local SQLite data and durable chat history stay on the device.
+
+This does not rewrite existing Git history: runtime data already committed in
+older revisions remains in those revisions. Durable chat history is not part of
+Git backup, and rebuilding the note index must preserve it.
+
+## Interrupted operations
+
+A queued command rechecks the graph generation after acquiring its lock. Stopping
+or replacing a backup controller prevents later commands from the old cycle;
+an already-running native command can finish. Disconnect waits behind repository
+operations before removing the remote. Reflect refuses to adopt or commit an
+unfinished external Git operation or an index containing unresolved conflicts.

--- a/docs/git-backup-safety.md
+++ b/docs/git-backup-safety.md
@@ -41,9 +41,9 @@ runs; withheld updates retain their previous committed version.
 The root `.reflect` directory (including case variants and trailing-dot/space
 filename aliases) is excluded from new Reflect commits and incoming checkouts,
 even when an adopted repository already tracks it. Adoption removes its entries
-from the Git index without deleting
-local files. Restoring through Reflect does not check out another device's
-runtime files. Local SQLite data and durable chat history stay on the device.
+from the Git index without deleting local files. Restoring through Reflect does
+not check out another device's runtime files. Local SQLite data and durable chat
+history stay on the device.
 
 This does not rewrite existing Git history: runtime data already committed in
 older revisions remains in those revisions. Durable chat history is not part of

--- a/docs/git-backup-safety.md
+++ b/docs/git-backup-safety.md
@@ -38,9 +38,10 @@ conflict. A copy retained after a later sync failure is deliberate recovery data
 The size limit also applies to files staged by another Git tool before Reflect
 runs; withheld updates retain their previous committed version.
 
-The root `.reflect` directory (including case variants) is excluded from new
-Reflect commits and incoming checkouts, even when an adopted repository already
-tracks it. Adoption removes its entries from the Git index without deleting
+The root `.reflect` directory (including case variants and trailing-dot/space
+filename aliases) is excluded from new Reflect commits and incoming checkouts,
+even when an adopted repository already tracks it. Adoption removes its entries
+from the Git index without deleting
 local files. Restoring through Reflect does not check out another device's
 runtime files. Local SQLite data and durable chat history stay on the device.
 

--- a/packages/core/src/sync/commands.test.ts
+++ b/packages/core/src/sync/commands.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { setBridge } from '../ipc/bridge'
+import { gitMergeRemote } from './commands'
+
+afterEach(() => {
+  setBridge(null)
+})
+
+function respondWithChanges(changedFiles: unknown[]) {
+  const invoke = vi.fn(async () => ({
+    kind: 'merged',
+    conflictedPaths: [],
+    skippedLargeFiles: [],
+    changedFiles,
+  }))
+  setBridge({ invoke, listen: async () => () => {} })
+  return invoke
+}
+
+describe('gitMergeRemote', () => {
+  it('normalizes native deletion timestamps without changing upsert timestamps', async () => {
+    const invoke = respondWithChanges([
+      { path: 'notes/deleted.md', kind: 'remove', modifiedMs: null },
+      { path: 'notes/updated.md', kind: 'upsert', modifiedMs: 1788540000123 },
+    ])
+
+    const result = await gitMergeRemote(7)
+
+    expect(invoke).toHaveBeenCalledWith('git_merge_remote', { generation: 7 })
+    expect(result.changedFiles).toEqual([
+      { path: 'notes/deleted.md', kind: 'remove', modifiedMs: undefined },
+      { path: 'notes/updated.md', kind: 'upsert', modifiedMs: 1788540000123 },
+    ])
+  })
+
+  it('accepts unavailable and omitted upsert timestamps for downstream fallback', async () => {
+    respondWithChanges([
+      { path: 'notes/no-metadata.md', kind: 'upsert', modifiedMs: null },
+      { path: 'notes/omitted.md', kind: 'upsert' },
+    ])
+
+    const result = await gitMergeRemote(7)
+
+    expect(result.changedFiles.map((change) => change.modifiedMs)).toEqual([undefined, undefined])
+  })
+
+  it('still rejects malformed timestamps at the IPC boundary', async () => {
+    respondWithChanges([{ path: 'notes/invalid.md', kind: 'upsert', modifiedMs: 'yesterday' }])
+
+    await expect(gitMergeRemote(7)).rejects.toMatchObject({ kind: 'parse' })
+  })
+})

--- a/packages/core/src/sync/commands.ts
+++ b/packages/core/src/sync/commands.ts
@@ -60,6 +60,8 @@ export type ChangedFile = z.infer<typeof changedFileSchema>
 export const mergeOutcomeSchema = z.object({
   kind: z.enum(['upToDate', 'fastForward', 'merged', 'mergedWithConflicts']),
   conflictedPaths: z.array(z.string()),
+  /** Files withheld when saves made during fetch are committed before merging. */
+  skippedLargeFiles: z.array(skippedFileSchema),
   /**
    * Every file the merge changed. The caller reindexes these directly —
    * pulls must not depend on the file watcher being up (on launch it may

--- a/packages/core/src/sync/commands.ts
+++ b/packages/core/src/sync/commands.ts
@@ -52,8 +52,11 @@ export type RemoteDelta = z.infer<typeof remoteDeltaSchema>
 export const changedFileSchema = z.object({
   path: z.string(),
   kind: z.enum(['upsert', 'remove']),
-  /** Last-modified time (epoch ms; upserts only) — real mtime for the reindex. */
-  modifiedMs: z.number().optional(),
+  /** Native Option timestamps serialize as null; consumers use an optional mtime. */
+  modifiedMs: z
+    .number()
+    .nullish()
+    .transform((modifiedMs) => modifiedMs ?? undefined),
 })
 export type ChangedFile = z.infer<typeof changedFileSchema>
 

--- a/packages/core/src/sync/engine.test.ts
+++ b/packages/core/src/sync/engine.test.ts
@@ -355,6 +355,41 @@ describe('createSyncEngine', () => {
     engine.stop()
   })
 
+  it('notifies native merge deletions and completes the required push', async () => {
+    const calls = fakeGit((command) =>
+      command === 'git_merge_remote'
+        ? {
+            ...MERGED,
+            changedFiles: [{ path: 'notes/deleted.md', kind: 'remove', modifiedMs: null }],
+          }
+        : defaultResponses(command),
+    )
+    const onRemoteChanges = vi.fn()
+    const statuses: SyncStatus[] = []
+    const engine = createSyncEngine({
+      generation: 1,
+      getToken: async () => 'tok',
+      onRemoteChanges,
+      onStatus: (status) => {
+        statuses.push(status)
+      },
+    })
+
+    await engine.syncNow()
+
+    expect(onRemoteChanges).toHaveBeenCalledWith([
+      { path: 'notes/deleted.md', kind: 'remove', modifiedMs: undefined },
+    ])
+    expect(commandsOf(calls)).toEqual([
+      'git_commit_all',
+      'git_fetch',
+      'git_merge_remote',
+      'git_push',
+    ])
+    expect(statuses.at(-1)).toEqual({ state: 'idle' })
+    engine.stop()
+  })
+
   it('continues through push while remote-change handling runs, then waits before idle', async () => {
     const calls = fakeGit((command) =>
       command === 'git_merge_remote'

--- a/packages/core/src/sync/engine.test.ts
+++ b/packages/core/src/sync/engine.test.ts
@@ -19,8 +19,16 @@ const NON_FAST_FORWARD = {
   nonFastForward: true,
   rejectionMessage: 'fetch first',
 }
-const MERGED = { kind: 'merged', conflictedPaths: [], changedFiles: [] }
+const MERGED = { kind: 'merged', conflictedPaths: [], skippedLargeFiles: [], changedFiles: [] }
 const DELTA = { ahead: 1, behind: 0 }
+const STATUS = {
+  initialized: true,
+  branch: 'main',
+  remoteUrl: '/remote',
+  ahead: 0,
+  behind: 0,
+  inProgress: false,
+}
 
 interface Call {
   command: string
@@ -50,6 +58,8 @@ function defaultResponses(command: string): unknown {
       return DELTA
     case 'git_merge_remote':
       return MERGED
+    case 'git_status':
+      return STATUS
     default:
       return null
   }
@@ -152,7 +162,7 @@ describe('createSyncEngine', () => {
       ['network', { state: 'offline' }],
       ['auth', { state: 'error', errorKind: 'auth' }],
     ] as const) {
-      fakeGit(defaultResponses)
+      const calls = fakeGit(defaultResponses)
       const statuses: SyncStatus[] = []
       const engine = createSyncEngine({
         generation: 1,
@@ -166,6 +176,7 @@ describe('createSyncEngine', () => {
       })
       engine.noteChanged()
       await vi.runAllTimersAsync()
+      expect(commandsOf(calls)).toEqual(['git_commit_all'])
       expect(statuses.at(-1)).toMatchObject(expected)
       engine.stop()
     }
@@ -316,6 +327,7 @@ describe('createSyncEngine', () => {
         ? {
             kind: 'merged',
             conflictedPaths: [],
+            skippedLargeFiles: [],
             changedFiles: [
               { path: 'notes/from-b.md', kind: 'upsert' },
               { path: 'notes/gone.md', kind: 'remove' },
@@ -349,6 +361,7 @@ describe('createSyncEngine', () => {
         ? {
             kind: 'merged',
             conflictedPaths: [],
+            skippedLargeFiles: [],
             changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert' }],
           }
         : defaultResponses(command),
@@ -396,6 +409,7 @@ describe('createSyncEngine', () => {
         return {
           kind: 'merged',
           conflictedPaths: [],
+          skippedLargeFiles: [],
           changedFiles: [{ path: `notes/remote-${mergeCount}.md`, kind: 'upsert' }],
         }
       }
@@ -454,6 +468,7 @@ describe('createSyncEngine', () => {
         ? {
             kind: 'merged',
             conflictedPaths: [],
+            skippedLargeFiles: [],
             changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert' }],
           }
         : defaultResponses(command),
@@ -505,6 +520,7 @@ describe('createSyncEngine', () => {
         return {
           kind: 'merged',
           conflictedPaths: [],
+          skippedLargeFiles: [],
           changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert' }],
         }
       }
@@ -580,6 +596,7 @@ describe('createSyncEngine', () => {
     mergeGate.resolve?.({
       kind: 'merged',
       conflictedPaths: [],
+      skippedLargeFiles: [],
       changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert' }],
     })
     await syncing
@@ -595,6 +612,7 @@ describe('createSyncEngine', () => {
         ? {
             kind: 'merged',
             conflictedPaths: [],
+            skippedLargeFiles: [],
             changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert' }],
           }
         : defaultResponses(command),
@@ -638,6 +656,7 @@ describe('createSyncEngine', () => {
         ? {
             kind: 'merged',
             conflictedPaths: [],
+            skippedLargeFiles: [],
             changedFiles: [{ path: 'notes/from-remote.md', kind: 'upsert' }],
           }
         : defaultResponses(command),
@@ -758,7 +777,7 @@ describe('createSyncEngine', () => {
         return { ahead: 0, behind: 0 }
       }
       if (command === 'git_merge_remote') {
-        return { kind: 'upToDate', conflictedPaths: [], changedFiles: [] }
+        return { kind: 'upToDate', conflictedPaths: [], skippedLargeFiles: [], changedFiles: [] }
       }
       return defaultResponses(command)
     })
@@ -766,7 +785,12 @@ describe('createSyncEngine', () => {
 
     await engine.syncNow()
 
-    expect(commandsOf(calls)).toEqual(['git_commit_all', 'git_fetch', 'git_merge_remote'])
+    expect(commandsOf(calls)).toEqual([
+      'git_commit_all',
+      'git_fetch',
+      'git_merge_remote',
+      'git_status',
+    ])
     engine.stop()
   })
 
@@ -788,6 +812,48 @@ describe('createSyncEngine', () => {
       'git_merge_remote',
       'git_push',
     ])
+    engine.stop()
+  })
+
+  it('pushes saves committed by the native merge after an initially clean fetch', async () => {
+    const skipped = [{ path: 'assets/new-movie.mp4', size: 200_000_000 }]
+    const calls = fakeGit((command) => {
+      if (command === 'git_commit_all') {
+        return CLEAN_COMMIT
+      }
+      if (command === 'git_fetch') {
+        return { ahead: 0, behind: 0 }
+      }
+      if (command === 'git_merge_remote') {
+        return {
+          kind: 'upToDate',
+          conflictedPaths: [],
+          skippedLargeFiles: skipped,
+          changedFiles: [],
+        }
+      }
+      if (command === 'git_status') {
+        return { ...STATUS, ahead: 1 }
+      }
+      return defaultResponses(command)
+    })
+    const onLargeFilesSkipped = vi.fn()
+    const engine = createSyncEngine({
+      generation: 1,
+      getToken: async () => 'tok',
+      onLargeFilesSkipped,
+    })
+
+    await engine.syncNow()
+
+    expect(commandsOf(calls)).toEqual([
+      'git_commit_all',
+      'git_fetch',
+      'git_merge_remote',
+      'git_status',
+      'git_push',
+    ])
+    expect(onLargeFilesSkipped).toHaveBeenCalledWith(skipped)
     engine.stop()
   })
 
@@ -817,6 +883,23 @@ describe('createSyncEngine', () => {
     await vi.runAllTimersAsync()
 
     expect(calls).toHaveLength(0)
+  })
+
+  it('does not issue a commit if a syncing status observer stops the engine', async () => {
+    const calls = fakeGit(defaultResponses)
+    const engine = createSyncEngine({
+      generation: 1,
+      getToken: async () => 'tok',
+      onStatus: (status) => {
+        if (status.state === 'syncing') {
+          engine.stop()
+        }
+      },
+    })
+
+    await engine.syncNow()
+
+    expect(calls).toEqual([])
   })
 
   it('passes a missing credential through as a null token (Rust owns the failure)', async () => {
@@ -884,6 +967,10 @@ describe('createSyncEngine', () => {
     const first = engine.syncNow()
     const second = engine.syncNow()
     const third = engine.syncNow()
+    let completed = false
+    void second.then(() => {
+      completed = true
+    })
     await vi.runAllTimersAsync()
     // Only the first cycle has started; the others coalesced, not interleaved.
     expect(commandsOf(calls)).toEqual([
@@ -895,9 +982,13 @@ describe('createSyncEngine', () => {
 
     pushGates.shift()?.(PUSHED)
     await vi.runAllTimersAsync()
+    // A manual backup queued mid-cycle must not resolve while its own push
+    // is still in flight.
+    expect(completed).toBe(false)
     pushGates.shift()?.(PUSHED)
     await vi.runAllTimersAsync()
     await Promise.all([first, second, third])
+    expect(completed).toBe(true)
 
     // The two queued requests collapsed into a single full follow-up cycle.
     expect(commandsOf(calls)).toEqual([

--- a/packages/core/src/sync/engine.ts
+++ b/packages/core/src/sync/engine.ts
@@ -4,6 +4,7 @@ import {
   gitFetch,
   gitMergeRemote,
   gitPush,
+  gitStatus,
   type ChangedFile,
   type SkippedFile,
 } from './commands'
@@ -105,7 +106,7 @@ export interface SyncEngineOptions {
 export interface SyncEngine {
   /** Mark the graph dirty (watcher file-change event); debounced. */
   noteChanged(): void
-  /** Full cycle now — commit, pull/merge, push. For launch/focus/manual. */
+  /** Full cycle now; waits for any queued follow-up to finish. For launch/focus/manual. */
   syncNow(): Promise<void>
   /**
    * Abort the engine: cancel timers, suppress further status emissions, and
@@ -246,59 +247,75 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
       rerunMode = rerunMode === 'full' || mode === 'full' ? 'full' : 'push'
       return await running
     }
-    running = (async () => {
-      const remoteChangeTasks: Promise<void>[] = []
-      // This cycle commits everything dirty so far — a pending debounce pass
-      // (e.g. queued before a launch/focus/manual sync) would only duplicate it.
-      if (timer !== null) {
-        clearTimeout(timer)
-        timer = null
-      }
-      deadline = null
-      emit({ state: 'syncing' })
+    // Defer admission until `running` is installed, including synchronous
+    // status callbacks that request another cycle.
+    running = Promise.resolve().then(async () => {
+      let nextMode: 'push' | 'full' | null = mode
       try {
-        await cycle(mode, (changes) => {
-          remoteChangeTasks.push(startRemoteChanges(changes))
-        })
-        await settleRemoteChanges(remoteChangeTasks)
-        emit({ state: 'idle' })
-      } catch (error) {
-        if (error instanceof CycleSuppressedError) {
-          // A merge can land and queue its changed files just before the owner
-          // suppresses later Git commands. Preserve the old boundary: finish
-          // that notification before the suppressed cycle settles to idle.
-          try {
-            await settleRemoteChanges(remoteChangeTasks, false)
-            emit({ state: 'idle' })
-          } catch (notificationError) {
-            if (!signal.aborted) {
-              emit(statusForError(notificationError))
-            }
+        do {
+          if (signal.aborted || options.canStartCycle?.() === false) {
+            break
           }
-        } else if (!signal.aborted) {
-          emit(statusForError(error))
-        }
+          await runCycle(nextMode)
+          nextMode = rerunMode
+          rerunMode = null
+        } while (nextMode !== null)
       } finally {
         running = null
-        if (rerunMode !== null && !signal.aborted) {
-          const next = rerunMode
-          rerunMode = null
-          void run(next)
-        }
+        rerunMode = null
       }
-    })()
+    })
     return await running
+  }
+
+  async function runCycle(mode: 'push' | 'full'): Promise<void> {
+    const remoteChangeTasks: Promise<void>[] = []
+    // This cycle commits everything dirty so far — a pending debounce pass
+    // (e.g. queued before a launch/focus/manual sync) would only duplicate it.
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+    deadline = null
+    try {
+      emit({ state: 'syncing' })
+      signal.throwIfAborted()
+      if (options.canStartCycle?.() === false) {
+        throw new CycleSuppressedError()
+      }
+      await cycle(mode, (changes) => {
+        remoteChangeTasks.push(startRemoteChanges(changes))
+      })
+      await settleRemoteChanges(remoteChangeTasks)
+      emit({ state: 'idle' })
+    } catch (error) {
+      if (error instanceof CycleSuppressedError) {
+        // A merge can land and queue its changed files just before the owner
+        // suppresses later Git commands. Preserve the old boundary: finish
+        // that notification before the suppressed cycle settles to idle.
+        try {
+          await settleRemoteChanges(remoteChangeTasks, false)
+          emit({ state: 'idle' })
+        } catch (notificationError) {
+          if (!signal.aborted) {
+            emit(statusForError(notificationError))
+          }
+        }
+      } else if (!signal.aborted) {
+        emit(statusForError(error))
+      }
+    }
   }
 
   async function cycle(
     mode: 'push' | 'full',
     remoteChanges: (changes: ChangedFile[]) => void,
   ): Promise<void> {
-    const token = options.localOnly === true ? null : await step(options.getToken())
-    const commit = await step(gitCommitAll('Update notes', options.generation))
-    if (commit.skippedLargeFiles.length > 0) {
-      options.onLargeFilesSkipped?.(commit.skippedLargeFiles)
-    }
+    const commit = await step(gitCommitAll('Update notes', options.generation), (outcome) => {
+      if (outcome.skippedLargeFiles.length > 0) {
+        options.onLargeFilesSkipped?.(outcome.skippedLargeFiles)
+      }
+    })
     if (options.localOnly === true) {
       return // the commit is the whole cycle — the repo has no remote
     }
@@ -310,13 +327,22 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
       if (!commit.committed && commit.ahead === 0) {
         return
       }
-    } else {
+    }
+    // Local history must survive offline/auth failures during token refresh.
+    const token = await step(options.getToken())
+    if (mode === 'full') {
       // Launch/focus: pick up other devices' changes even with nothing to push.
       const delta = await step(gitFetch(token, options.generation))
       const merged = await merge(remoteChanges)
       const localOnly = commit.committed || delta.ahead > 0
       if (!localOnly && (merged.kind === 'upToDate' || merged.kind === 'fastForward')) {
-        return // pulled cleanly and have nothing of our own — no push needed
+        // The native merge snapshots saves that landed during fetch under its
+        // write lock. The earlier commit/fetch cannot tell whether those new
+        // local commits still need to be pushed.
+        const status = await step(gitStatus(options.generation))
+        if (status.ahead === 0) {
+          return
+        }
       }
     }
     for (let attempt = 0; attempt < MAX_PUSH_ATTEMPTS; attempt++) {
@@ -340,6 +366,10 @@ export function createSyncEngine(options: SyncEngineOptions): SyncEngine {
   /** Merge fetched changes and start any changed-file notification. */
   async function merge(remoteChanges: (changes: ChangedFile[]) => void): Promise<{ kind: string }> {
     return await step(gitMergeRemote(options.generation), (outcome) => {
+      if (outcome.skippedLargeFiles.length > 0) {
+        options.onLargeFilesSkipped?.(outcome.skippedLargeFiles)
+      }
+      signal.throwIfAborted()
       // The command may already have rewritten files before suspension. Fan
       // those changes out before the boundary gate stops subsequent Git work.
       if (outcome.changedFiles.length > 0) {


### PR DESCRIPTION
Fixes a data-loss window where a note saved during fetch could be overwritten by a forced fast-forward checkout. Reflect now snapshots those saves under the same local mutation lock used by checkout. Network waits leave editing responsive; saves queued during checkout land afterwards, and delayed editor reads cannot replace the newly saved buffer.

The same pull path now computes merges in memory, uses safe checkout before moving branch refs, preserves unrelated staging, and retains recoverable history and complete conflict copies when applying a pull fails. Binary conflicts claim numbered filenames atomically, including protection against existing files and incoming case aliases.

Runtime exclusion now removes previously tracked `.reflect` entries (including case and trailing-dot/space aliases) from future commits and filters incoming checkouts and restores without deleting local SQLite or durable chat data. Pre-staged oversized files cannot bypass the attachment size guard. Backup lifecycle fixes preserve local commits on auth failure, push saves captured after fetch, await queued manual cycles, and prevent stale startup/disconnect work from reviving an old controller. Native deletion events with null timestamps now reach the editor and complete the sync cycle. Imports and renames share the checkout boundary, including cancellation and native event-loop handling.

Validation:

- Reproduced all three original audit failures against current master before editing.
- `pnpm check` and `pnpm build` passed.
- 161 targeted TypeScript tests passed across sync command boundaries, engine, backup controller, note session, and document binding.
- `cargo fmt --all --check` and `cargo clippy -p reflect-open --all-targets -- -D warnings` passed.
- 288 targeted Rust tests passed: Git (60), filesystem (105), index (64), iCloud (41), and capture (18). Desktop sidecars were staged first.
- Regression coverage includes saves during fetch/checkout, dirty and ignored checkout collisions, failed index writes, repeated/concurrent binary conflicts, tracked runtime adoption/pull/clone and Windows filename aliases, native null deletion timestamps, and stale editor reads after a save.

Existing Git history is not rewritten, so runtime blobs already committed in old revisions remain there. The mutation lock coordinates Reflect's own writers; external filesystem tools do not participate. An I/O failure may leave some pulled files applied or a complete conflict copy on disk while the previous branch tip remains recoverable. These boundaries are documented in `docs/git-backup-safety.md`.

Supersedes #1214, which was produced by the previously cancelled duplicate CLI run. Its branch is preserved. Bugbot is disabled for this repository; the repository’s CodeRabbit review remains enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Git backup and sync behavior, including safer merges, conflict-copy preservation, and clearer reporting when oversized files are skipped.
  - Local runtime data remains protected during cloning, merging, and remote operations.
  - Local history can continue saving even when remote credentials or connectivity are unavailable.

- **Bug Fixes**
  - Prevented stale external file updates from overwriting newer editor changes.
  - Improved reliability for concurrent saves, imports, note moves, and graph operations.
  - Added safeguards for unresolved Git conflicts and interrupted operations.

- **Documentation**
  - Added guidance for Git backup safety, recovery, conflict handling, and runtime-file protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->