### PR TITLE
fix: make graph menu rows consistent and separate Preferences

### DIFF
--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -36,7 +36,7 @@ import { useGraph } from '@/providers/graph-provider'
 import { useSync, type BackupState } from '@/providers/sync-provider'
 import { useRouter } from '@/routing/router'
 
-const MENU_ITEM_CLASS = 'gap-2 px-2 py-1.5 text-[13px] text-text-secondary'
+const MENU_ITEM_CLASS = 'h-8 gap-2 px-2 py-0 text-[13px] text-text-secondary'
 const SETTINGS_BINDING = keybindingFor('settings.open')
 
 function graphSwitchBindingFor(index: number): string | null {
@@ -202,24 +202,22 @@ export function GraphFooter({ graph, context }: GraphFooterProps): ReactElement 
               <span className="min-w-0 flex-1 truncate">Open another graph…</span>
             </DropdownMenuItem>
           ) : null}
+          <DropdownMenuSeparator />
           <DropdownMenuItem
             onClick={() => void runCommand('settings.open', context)}
             className={MENU_ITEM_CLASS}
           >
             <Settings aria-hidden strokeWidth={1.75} className="size-3.5 shrink-0" />
-            <span className="min-w-0 flex-1 truncate">User settings</span>
+            <span className="min-w-0 flex-1 truncate">Preferences</span>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onClick={() => setAppsOpen(true)}
-            className={cn(MENU_ITEM_CLASS, 'min-h-10')}
-          >
+          <DropdownMenuItem onClick={() => setAppsOpen(true)} className={MENU_ITEM_CLASS}>
             <PanelsTopLeft aria-hidden strokeWidth={1.75} className="size-3.5 shrink-0" />
             <span className="min-w-0 flex-1 truncate">Get Reflect apps…</span>
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => openUrlSync('https://reflect.academy')}
-            className={cn(MENU_ITEM_CLASS, 'min-h-10')}
+            className={MENU_ITEM_CLASS}
           >
             <GraduationCap aria-hidden strokeWidth={1.75} className="size-3.5 shrink-0" />
             <span className="min-w-0 flex-1 truncate">Reflect Academy</span>

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -406,11 +406,11 @@ describe('Sidebar', () => {
     expect(pickAndOpen).not.toHaveBeenCalled()
   })
 
-  it('the graph footer opens user settings from the graph menu', async () => {
+  it('the graph footer opens preferences from the graph menu', async () => {
     const { view, navigate } = await renderSidebar()
 
     await view.getByRole('button', { name: /Notes/ }).click()
-    await page.getByRole('menuitem', { name: /user settings/i }).click()
+    await page.getByRole('menuitem', { name: 'Preferences' }).click()
 
     await vi.waitFor(() => expect(navigate).toHaveBeenCalledWith({ kind: 'settings' }))
   })


### PR DESCRIPTION
The graph popup had uneven row heights: shortcut badges made recent graphs taller, while Get Reflect apps and Reflect Academy each forced a 40px minimum.

Give every row a shared 32px height, including the graph color submenu. Rename “User settings” to “Preferences” and place it between separators in its own section. Update the existing sidebar test to use the new label.

Verification:
- `pnpm check` passed (typecheck and lint).
- `pnpm build` passed.
- `pnpm test --run apps/desktop/src/components/sidebar/sidebar.test.tsx` passed (22 tests).
- Browser verification confirmed 32px heights for every main-menu row and all nine color options, separators around Preferences, and navigation to Settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Updates**
  - Renamed the sidebar’s “User settings” option to “Preferences.”
  - Adjusted sidebar menu spacing and added a separator before Preferences.
  - Updated the Apps and Academy entries for more consistent spacing.

- **Bug Fixes**
  - Selecting Preferences now correctly navigates to Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->