### PR TITLE
refactor: drop the unread note_text table

### DIFF
--- a/apps/desktop/src-tauri/src/db/tests.rs
+++ b/apps/desktop/src-tauri/src/db/tests.rs
@@ -527,7 +527,7 @@ fn templates_are_invisible_to_backlink_resolution() {
 }
 
 #[test]
-fn asset_description_text_is_searchable_but_stays_out_of_preview_and_note_text() {
+fn asset_description_text_is_searchable_but_stays_out_of_the_preview() {
     let conn = migrated();
     // The note body says nothing about a waterfall; only the asset description
     // (folded into the FTS body, Plan 20) does.
@@ -556,7 +556,7 @@ fn asset_description_text_is_searchable_but_stays_out_of_preview_and_note_text()
     .unwrap();
     assert_eq!(body_hits.len(), 1);
 
-    // The asset text never leaks into the preview or the AI-reachable note_text.
+    // The asset text never leaks into the preview.
     let preview: String = conn
         .query_row(
             "SELECT preview FROM notes WHERE path = 'notes/a.md'",
@@ -567,17 +567,6 @@ fn asset_description_text_is_searchable_but_stays_out_of_preview_and_note_text()
     assert!(
         !preview.contains("waterfall"),
         "preview must not carry asset text"
-    );
-    let note_body: String = conn
-        .query_row(
-            "SELECT text FROM note_text WHERE note_path = 'notes/a.md'",
-            [],
-            |row| row.get(0),
-        )
-        .unwrap();
-    assert!(
-        !note_body.contains("waterfall"),
-        "note_text must not carry asset text"
     );
 }
 
@@ -870,7 +859,6 @@ fn clear_cascades_to_child_tables() {
     // Deleting notes cascades to children; search_fts is cleared explicitly.
     for table in [
         "notes",
-        "note_text",
         "links",
         "tags",
         "aliases",
@@ -1069,7 +1057,7 @@ fn kind_invariant_migration_wipes_the_projection_for_reindex() {
 
     migrate(&mut conn).expect("migrate to latest");
 
-    for table in ["notes", "note_text", "links", "tags", "tasks", "search_fts"] {
+    for table in ["notes", "links", "tags", "tasks", "search_fts"] {
         let count: i64 = conn
             .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| {
                 row.get(0)
@@ -1705,12 +1693,8 @@ fn move_note_migrates_every_row_and_preserves_derived_state() {
     .unwrap();
     assert!(gone.is_empty());
 
-    // Children followed: text, outgoing links, FTS, embedding chunks (vectors kept).
+    // Children followed: outgoing links, FTS, embedding chunks (vectors kept).
     for (sql, expected) in [
-        (
-            "SELECT count(*) AS n FROM note_text WHERE note_path = 'notes/kept-title.md'",
-            1,
-        ),
         (
             "SELECT count(*) AS n FROM links WHERE source_path = 'notes/kept-title.md'",
             1,

--- a/apps/desktop/src-tauri/src/db/write.rs
+++ b/apps/desktop/src-tauri/src/db/write.rs
@@ -40,7 +40,7 @@ pub struct IndexedNote {
     pub(super) mtime: i64,
     pub(super) text: String,
     /// Description text of referenced assets (Plan 20), folded into the FTS
-    /// `body` only — never `note_text`, `preview`, or anything AI-reachable.
+    /// `body` only — never `preview` or anything AI-reachable.
     #[serde(default)]
     pub(super) asset_text: String,
     pub(super) preview: String,
@@ -166,8 +166,6 @@ pub(super) fn apply_note(conn: &Connection, note: &IndexedNote) -> AppResult<()>
         note.preview,
         i64::from(note.has_content),
     ])?;
-    conn.prepare_cached("INSERT INTO note_text(note_path, text) VALUES(?1, ?2)")?
-        .execute(params![note.path, note.text])?;
     {
         let mut stmt = conn.prepare_cached(
             "INSERT INTO links(source_path, kind, target_raw, target_key, target_path_key, alias, pos_from, pos_to)
@@ -244,8 +242,8 @@ pub(super) fn apply_note(conn: &Connection, note: &IndexedNote) -> AppResult<()>
     }
     // The FTS body carries the note text plus any referenced assets' description
     // text (Plan 20), so a query matching a description surfaces the note. Only
-    // the search index is enriched — `note_text`, `preview`, and AI-reachable
-    // text above stay the note body alone.
+    // the search index is enriched — `preview` and the AI-reachable text above
+    // stay the note body alone.
     let search_body = if note.asset_text.is_empty() {
         note.text.clone()
     } else {
@@ -325,8 +323,6 @@ pub(super) fn move_note(
         )?
         .execute(params![to, address.basename_key, claim_tier::BASENAME])?;
     }
-    conn.prepare_cached("UPDATE note_text SET note_path = ?2 WHERE note_path = ?1")?
-        .execute(params![from, to])?;
     conn.prepare_cached("UPDATE links SET source_path = ?2 WHERE source_path = ?1")?
         .execute(params![from, to])?;
     conn.prepare_cached("UPDATE tags SET note_path = ?2 WHERE note_path = ?1")?

--- a/apps/desktop/src/dev/dev-index-db.ts
+++ b/apps/desktop/src/dev/dev-index-db.ts
@@ -143,7 +143,6 @@ export async function createDevIndexDb(): Promise<DevIndexDb> {
           note.hasContent,
         ],
       )
-      run(db, 'INSERT INTO note_text(note_path, text) VALUES(?, ?)', [note.path, note.text])
       for (const link of note.links) {
         run(
           db,
@@ -261,7 +260,6 @@ export async function createDevIndexDb(): Promise<DevIndexDb> {
             )
           }
         }
-        run(db, 'UPDATE note_text SET note_path = ? WHERE note_path = ?', [to, from])
         run(db, 'UPDATE links SET source_path = ? WHERE source_path = ?', [to, from])
         run(db, 'UPDATE tags SET note_path = ? WHERE note_path = ?', [to, from])
         run(db, 'UPDATE aliases SET note_path = ? WHERE note_path = ?', [to, from])

--- a/crates/index-schema/migrations/0022_drop_note_text.sql
+++ b/crates/index-schema/migrations/0022_drop_note_text.sql
@@ -1,0 +1,10 @@
+-- `note_text` held a note's extracted plain text "for FTS + AI context"
+-- (Plan 03/04). Neither consumer is still there: FTS has `search_fts.body`,
+-- the AI's read_notes tool reads the file from disk, and All Notes moved to
+-- the stored `notes.preview` column. No query has read it since, so every note
+-- write has been storing a second copy of the body that nothing consults.
+--
+-- Dropping it changes no other row's derivation, so this needs no projection
+-- version bump and no reindex.
+
+DROP TABLE note_text;

--- a/crates/index-schema/src/lib.rs
+++ b/crates/index-schema/src/lib.rs
@@ -23,7 +23,7 @@ pub const INDEX_FILE: &str = "index.sqlite";
 /// `user_version` after every migration has run. Read-only consumers compare
 /// this against `PRAGMA user_version` to detect an index written by a newer
 /// (or older) app than they were built for.
-pub const LATEST_SCHEMA_VERSION: usize = 21;
+pub const LATEST_SCHEMA_VERSION: usize = 22;
 
 /// The `index_meta` key holding the TS-owned projection version (the rows'
 /// derivation version, distinct from the schema version above).
@@ -66,6 +66,7 @@ mod schema {
                 "../migrations/0020_backlink_name_fallback.sql"
             )),
             M::up(include_str!("../migrations/0021_note_has_content.sql")),
+            M::up(include_str!("../migrations/0022_drop_note_text.sql")),
         ])
     });
 

--- a/packages/core/src/indexing/note-list.test.ts
+++ b/packages/core/src/indexing/note-list.test.ts
@@ -65,10 +65,8 @@ describe('listNotes', () => {
     const [command, args] = mockInvoke.mock.calls[0]!
     expect(command).toBe('db_query')
     const sql = String(args['sql'])
-    // The snippet is the stored projection column — no note_text join, no
-    // per-query derivation.
+    // The snippet is the stored projection column, not a per-query derivation.
     expect(sql).toContain('"preview"')
-    expect(sql).not.toContain('note_text')
     // `kind = 'note'` excludes dailies (the stream is their home) and templates.
     expect(sql).toContain('"notes"."kind" = ?')
     // Pinned notes lead (explicit order first), then recency — V1's list

--- a/packages/db/src/schema.gen.ts
+++ b/packages/db/src/schema.gen.ts
@@ -114,11 +114,6 @@ export interface Notes {
   updatedAt: Generated<number>;
 }
 
-export interface NoteText {
-  notePath: string;
-  text: string;
-}
-
 export interface SearchFts {
   body: string | null;
   path: string | null;
@@ -154,7 +149,6 @@ export interface DB {
   noteEmails: NoteEmails;
   noteKeys: NoteKeys;
   notes: Notes;
-  noteText: NoteText;
   searchFts: SearchFts;
   tags: Tags;
   tasks: Tasks;


### PR DESCRIPTION
Stacked on #1227.

`note_text` held a note's extracted plain text "for FTS + AI context" (Plan 03/04). Neither consumer is still there: FTS has its own `search_fts.body`, the AI's `read_notes` tool reads the file from disk, and All Notes moved to the stored `notes.preview` column. No query has read the table since, so every note write has been storing a second copy of the body that nothing consults.

Dropping it changes no other row's derivation, so this needs no projection version bump and no reindex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the local database schema and note indexing to remove an unused text projection.
  * Existing note previews, search, links, embeddings, and task-related indexing continue to work as before.
  * Updated database migration handling and validation to support the latest schema version without requiring a full reindex.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->