### PR TITLE
fix: defer surface focus while a dialog is open

### DIFF
--- a/apps/desktop/src/components/all-notes/all-notes-screen.tsx
+++ b/apps/desktop/src/components/all-notes/all-notes-screen.tsx
@@ -5,6 +5,7 @@ import { Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { useNoteLinkNavigation } from '@/hooks/use-note-link-navigation'
+import { requestSurfaceFocus } from '@/lib/request-surface-focus'
 import { queryKeys } from '@/lib/query-client'
 import type { ModClickEvent } from '@/lib/windows/open-in-new-window'
 import { useListSelection } from '@/lib/selection/use-list-selection'
@@ -121,7 +122,7 @@ export function AllNotesScreen({ tag }: AllNotesScreenProps): ReactElement {
   // Move focus into the surface on mount so the shortcuts work the moment you
   // navigate here, without first clicking the list (mirrors the Tasks view).
   useEffect(() => {
-    rootRef.current?.focus({ preventScroll: true })
+    return requestSurfaceFocus(rootRef.current, { preventScroll: true })
   }, [])
 
   return (

--- a/apps/desktop/src/components/chat/chat-input.tsx
+++ b/apps/desktop/src/components/chat/chat-input.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactElement } from 'react'
+import { useEffect, useMemo, useRef, type ReactElement } from 'react'
 import { ArrowUp, Plus, Square, X } from 'lucide-react'
 import { getIsComposing } from '@meowdown/core'
 import { ShortcutKeys } from '@/components/shortcut-keys'
@@ -23,6 +23,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { imageFilesFrom } from '@/lib/chat-attachments'
 import { groupModelOptions } from '@/lib/chat-model-groups'
 import { keybindingFor } from '@/lib/commands/app-commands'
+import { requestSurfaceFocus } from '@/lib/request-surface-focus'
 import { useChatSession } from '@/providers/chat-provider'
 import { ChatHistoryMenu } from './chat-history-menu'
 
@@ -38,6 +39,10 @@ const NEW_CHAT_BINDING = keybindingFor('chat.new')
  * conversations; "New chat" appears once there's a conversation to leave.
  */
 export function ChatInput(): ReactElement {
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+  useEffect(() => {
+    return requestSurfaceFocus(inputRef.current)
+  }, [])
   const {
     turns,
     status,
@@ -107,6 +112,7 @@ export function ChatInput(): ReactElement {
           </AttachmentGroup>
         ) : null}
         <textarea
+          ref={inputRef}
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
           onKeyDown={(event) => {
@@ -133,7 +139,6 @@ export function ChatInput(): ReactElement {
           placeholder="Ask about your notes…"
           aria-label="Chat message"
           rows={2}
-          autoFocus
           /* Opts out of the global :focus-visible outline (styles/index.css);
              the wrapper's focus-within border is the focus treatment here. */
           data-slot="textarea"

--- a/apps/desktop/src/components/tasks/tasks-screen.tsx
+++ b/apps/desktop/src/components/tasks/tasks-screen.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useBridgeReady } from '@/hooks/use-bridge-ready'
 import { useNoteLinkNavigation } from '@/hooks/use-note-link-navigation'
+import { requestSurfaceFocus } from '@/lib/request-surface-focus'
 import { useRecentlyCompleted } from '@/lib/tasks/recently-completed'
 import { sameTask, taskKey } from '@/lib/tasks/task-identity'
 import type { InsertTaskTarget } from '@/lib/tasks/task-insert-target'
@@ -235,7 +236,7 @@ export function TasksScreen(): ReactElement {
   // you navigate here — without it, focus would linger on the sidebar link that
   // navigated, where the scoping guard (rightly) backs the shortcuts off.
   useEffect(() => {
-    rootRef.current?.focus({ preventScroll: true })
+    return requestSurfaceFocus(rootRef.current, { preventScroll: true })
   }, [])
 
   return (

--- a/apps/desktop/src/lib/request-surface-focus.test.tsx
+++ b/apps/desktop/src/lib/request-surface-focus.test.tsx
@@ -47,23 +47,15 @@ function LateFeature({
 function ModalFocusHarness({
   children,
   nextDialogOnClose = false,
-  onRestoreFocus,
 }: {
   children: ReactNode
   nextDialogOnClose?: boolean
-  onRestoreFocus?: () => void
 }): ReactElement {
   const [modal, setModal] = useState<'first' | 'second' | null>('first')
   const previousRef = useRef<HTMLButtonElement>(null)
   return (
     <>
-      <button
-        ref={previousRef}
-        autoFocus
-        onFocus={() => {
-          if (modal === null) onRestoreFocus?.()
-        }}
-      >
+      <button ref={previousRef} autoFocus>
         Previous surface
       </button>
       {children}
@@ -73,10 +65,12 @@ function ModalFocusHarness({
           if (!open) setModal(nextDialogOnClose ? 'second' : null)
         }}
       >
-        <DialogContent {...(nextDialogOnClose ? {} : { finalFocus: previousRef })}>
+        <DialogContent>
           <DialogTitle>Quick capture</DialogTitle>
           <DialogDescription>Add a note.</DialogDescription>
-          <input aria-label="Dialog input" autoFocus />
+          {/* No `autoFocus`: React would focus this input during the popup's own
+              commit, before Base UI records the element to return focus to. */}
+          <input aria-label="Dialog input" />
         </DialogContent>
       </Dialog>
       <Dialog
@@ -88,7 +82,7 @@ function ModalFocusHarness({
         <DialogContent finalFocus={previousRef}>
           <DialogTitle>Newer dialog</DialogTitle>
           <DialogDescription>A newer action.</DialogDescription>
-          <input aria-label="Newer input" autoFocus />
+          <input aria-label="Newer input" />
         </DialogContent>
       </Dialog>
     </>
@@ -121,7 +115,7 @@ describe('requestSurfaceFocus', () => {
     expect(target?.selectionEnd).toBe('Existing query'.length)
   })
 
-  it('also waits when the feature loads during the dialog exit animation', async () => {
+  it('focuses immediately while the dialog is still animating out, and keeps focus after it unmounts', async () => {
     const loading = deferred<void>()
     await render(
       <ModalFocusHarness>
@@ -129,20 +123,21 @@ describe('requestSurfaceFocus', () => {
       </ModalFocusHarness>,
     )
     await expect.element(page.getByRole('textbox', { name: 'Dialog input' })).toHaveFocus()
+    // The test browser runs with reduced motion, which collapses the dialog's
+    // CSS exit animation, so a paused WAAPI animation holds the popup in its
+    // closing state instead.
     const popup = page.getByRole('dialog').element()
     const exitAnimation = popup.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 1000 })
     exitAnimation.pause()
     await userEvent.keyboard('{Escape}')
     await vi.waitFor(() => expect(popup.hasAttribute('data-closed')).toBe(true))
     loading.resolve()
-    await vi.waitFor(() => {
-      const target = document.querySelector('[aria-label="Background search"]')
-      expect(target).not.toBeNull()
-      expect(target?.closest('[inert], [data-base-ui-inert], [aria-hidden="true"]')).toBeNull()
-    })
-    await expect.element(page.getByRole('textbox', { name: 'Background search' })).not.toHaveFocus()
-    exitAnimation.finish()
     await expect.element(page.getByRole('textbox', { name: 'Background search' })).toHaveFocus()
+    expect(popup.isConnected).toBe(true)
+    exitAnimation.finish()
+    await expect.element(page.getByRole('dialog')).not.toBeInTheDocument()
+    await expect.element(page.getByRole('textbox', { name: 'Background search' })).toHaveFocus()
+    await expect.element(page.getByRole('button', { name: 'Previous surface' })).not.toHaveFocus()
   })
 
   it('preserves a blocked arrival through StrictMode effect cleanup', async () => {
@@ -229,26 +224,5 @@ describe('requestSurfaceFocus', () => {
     await expect.element(page.getByRole('textbox', { name: 'Newer input' })).toHaveFocus()
     await userEvent.keyboard('{Escape}')
     await expect.element(page.getByRole('button', { name: 'Previous surface' })).toHaveFocus()
-  })
-
-  it('respects newer focus chosen after the modal restores its previous target', async () => {
-    const loading = deferred<void>()
-    await render(
-      <ModalFocusHarness
-        onRestoreFocus={() =>
-          document.querySelector<HTMLInputElement>('[aria-label="New action"]')?.focus()
-        }
-      >
-        <LateFeature ready={loading.promise} label="Background search" />
-        <input aria-label="New action" />
-      </ModalFocusHarness>,
-    )
-    await expect.element(page.getByRole('textbox', { name: 'Dialog input' })).toHaveFocus()
-    loading.resolve()
-    await vi.waitFor(() =>
-      expect(document.querySelector('[aria-label="Background search"]')).not.toBeNull(),
-    )
-    await userEvent.keyboard('{Escape}')
-    await expect.element(page.getByRole('textbox', { name: 'New action' })).toHaveFocus()
   })
 })

--- a/apps/desktop/src/lib/request-surface-focus.test.tsx
+++ b/apps/desktop/src/lib/request-surface-focus.test.tsx
@@ -1,0 +1,254 @@
+import { StrictMode, useEffect, useRef, useState, type ReactElement, type ReactNode } from 'react'
+import { cleanup, render } from 'vitest-browser-react'
+import { page, userEvent } from 'vitest/browser'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useArrivalFocus } from '@/mobile/use-arrival-focus'
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
+import { deferred } from '@/test-utils/deferred'
+
+interface FeatureInputProps {
+  label: string
+  arrivalSeq?: number
+  arrivalFocusEditor?: boolean
+  selectText?: boolean
+}
+
+function FeatureInput({
+  label,
+  arrivalSeq = 0,
+  arrivalFocusEditor = true,
+  selectText = false,
+}: FeatureInputProps): ReactElement {
+  const target = useRef<HTMLInputElement>(null)
+  useArrivalFocus({ arrivalSeq, arrivalFocusEditor, target, selectText })
+  return <input ref={target} aria-label={label} defaultValue="Existing query" />
+}
+
+// Stands in for a screen whose content arrives after the route does: the
+// focus target only mounts once `ready` resolves, the way a lazily loaded
+// feature or a late query result would.
+function LateFeature({
+  ready,
+  ...props
+}: FeatureInputProps & { ready: Promise<void> }): ReactElement | null {
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    let active = true
+    void ready.then(() => {
+      if (active) setMounted(true)
+    })
+    return () => {
+      active = false
+    }
+  }, [ready])
+  return mounted ? <FeatureInput {...props} /> : null
+}
+
+function ModalFocusHarness({
+  children,
+  nextDialogOnClose = false,
+  onRestoreFocus,
+}: {
+  children: ReactNode
+  nextDialogOnClose?: boolean
+  onRestoreFocus?: () => void
+}): ReactElement {
+  const [modal, setModal] = useState<'first' | 'second' | null>('first')
+  const previousRef = useRef<HTMLButtonElement>(null)
+  return (
+    <>
+      <button
+        ref={previousRef}
+        autoFocus
+        onFocus={() => {
+          if (modal === null) onRestoreFocus?.()
+        }}
+      >
+        Previous surface
+      </button>
+      {children}
+      <Dialog
+        open={modal === 'first'}
+        onOpenChange={(open) => {
+          if (!open) setModal(nextDialogOnClose ? 'second' : null)
+        }}
+      >
+        <DialogContent {...(nextDialogOnClose ? {} : { finalFocus: previousRef })}>
+          <DialogTitle>Quick capture</DialogTitle>
+          <DialogDescription>Add a note.</DialogDescription>
+          <input aria-label="Dialog input" autoFocus />
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={modal === 'second'}
+        onOpenChange={(open) => {
+          if (!open) setModal(null)
+        }}
+      >
+        <DialogContent finalFocus={previousRef}>
+          <DialogTitle>Newer dialog</DialogTitle>
+          <DialogDescription>A newer action.</DialogDescription>
+          <input aria-label="Newer input" autoFocus />
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+afterEach(async () => {
+  await cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('requestSurfaceFocus', () => {
+  it('waits for a dialog to close before focusing the feature that loaded behind it', async () => {
+    const loading = deferred<void>()
+    await render(
+      <ModalFocusHarness>
+        <LateFeature ready={loading.promise} label="Background search" selectText />
+      </ModalFocusHarness>,
+    )
+    await expect.element(page.getByRole('textbox', { name: 'Dialog input' })).toHaveFocus()
+    loading.resolve()
+    await vi.waitFor(() =>
+      expect(document.querySelector('[aria-label="Background search"]')).not.toBeNull(),
+    )
+    await expect.element(page.getByRole('textbox', { name: 'Dialog input' })).toHaveFocus()
+    await userEvent.keyboard('{Escape}')
+    await expect.element(page.getByRole('textbox', { name: 'Background search' })).toHaveFocus()
+    const target = document.querySelector<HTMLInputElement>('[aria-label="Background search"]')
+    expect(target?.selectionStart).toBe(0)
+    expect(target?.selectionEnd).toBe('Existing query'.length)
+  })
+
+  it('also waits when the feature loads during the dialog exit animation', async () => {
+    const loading = deferred<void>()
+    await render(
+      <ModalFocusHarness>
+        <LateFeature ready={loading.promise} label="Background search" />
+      </ModalFocusHarness>,
+    )
+    await expect.element(page.getByRole('textbox', { name: 'Dialog input' })).toHaveFocus()
+    const popup = page.getByRole('dialog').element()
+    const exitAnimation = popup.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 1000 })
+    exitAnimation.pause()
+    await userEvent.keyboard('{Escape}')
+    await vi.waitFor(() => expect(popup.hasAttribute('data-closed')).toBe(true))
+    loading.resolve()
+    await vi.waitFor(() => {
+      const target = document.querySelector('[aria-label="Background search"]')
+      expect(target).not.toBeNull()
+      expect(target?.closest('[inert], [data-base-ui-inert], [aria-hidden="true"]')).toBeNull()
+    })
+    await expect.element(page.getByRole('textbox', { name: 'Background search' })).not.toHaveFocus()
+    exitAnimation.finish()
+    await expect.element(page.getByRole('textbox', { name: 'Background search' })).toHaveFocus()
+  })
+
+  it('preserves a blocked arrival through StrictMode effect cleanup', async () => {
+    const loading = deferred<void>()
+    await render(
+      <StrictMode>
+        <ModalFocusHarness>
+          <LateFeature ready={loading.promise} label="Background search" />
+        </ModalFocusHarness>
+      </StrictMode>,
+    )
+    await expect.element(page.getByRole('textbox', { name: 'Dialog input' })).toHaveFocus()
+    loading.resolve()
+    await vi.waitFor(() =>
+      expect(document.querySelector('[aria-label="Background search"]')).not.toBeNull(),
+    )
+    await userEvent.keyboard('{Escape}')
+    await expect.element(page.getByRole('textbox', { name: 'Background search' })).toHaveFocus()
+  })
+
+  it('cancels pending modal focus when its destination unmounts', async () => {
+    const loading = deferred<void>()
+    const view = await render(
+      <ModalFocusHarness>
+        <LateFeature ready={loading.promise} label="Abandoned search" />
+      </ModalFocusHarness>,
+    )
+    await expect.element(page.getByRole('textbox', { name: 'Dialog input' })).toHaveFocus()
+    loading.resolve()
+    await vi.waitFor(() =>
+      expect(document.querySelector('[aria-label="Abandoned search"]')).not.toBeNull(),
+    )
+    await view.rerender(
+      <ModalFocusHarness>
+        <input aria-label="New route" />
+      </ModalFocusHarness>,
+    )
+    await userEvent.keyboard('{Escape}')
+    await expect.element(page.getByRole('button', { name: 'Previous surface' })).toHaveFocus()
+    await expect
+      .element(page.getByRole('textbox', { name: 'Abandoned search' }))
+      .not.toBeInTheDocument()
+  })
+
+  it('cancels a pending focus arrival when a newer arrival does not request focus', async () => {
+    const loading = deferred<void>()
+    const view = await render(
+      <ModalFocusHarness>
+        <LateFeature ready={loading.promise} label="Background search" arrivalSeq={1} />
+      </ModalFocusHarness>,
+    )
+    await expect.element(page.getByRole('textbox', { name: 'Dialog input' })).toHaveFocus()
+    loading.resolve()
+    await vi.waitFor(() =>
+      expect(document.querySelector('[aria-label="Background search"]')).not.toBeNull(),
+    )
+    await view.rerender(
+      <ModalFocusHarness>
+        <LateFeature
+          ready={loading.promise}
+          label="Background search"
+          arrivalSeq={2}
+          arrivalFocusEditor={false}
+        />
+      </ModalFocusHarness>,
+    )
+    await userEvent.keyboard('{Escape}')
+    await expect.element(page.getByRole('button', { name: 'Previous surface' })).toHaveFocus()
+  })
+
+  it('lets a newer modal supersede the pending route focus', async () => {
+    const loading = deferred<void>()
+    await render(
+      <ModalFocusHarness nextDialogOnClose>
+        <LateFeature ready={loading.promise} label="Background search" />
+      </ModalFocusHarness>,
+    )
+    await expect.element(page.getByRole('textbox', { name: 'Dialog input' })).toHaveFocus()
+    loading.resolve()
+    await vi.waitFor(() =>
+      expect(document.querySelector('[aria-label="Background search"]')).not.toBeNull(),
+    )
+    await userEvent.keyboard('{Escape}')
+    await expect.element(page.getByRole('textbox', { name: 'Newer input' })).toHaveFocus()
+    await userEvent.keyboard('{Escape}')
+    await expect.element(page.getByRole('button', { name: 'Previous surface' })).toHaveFocus()
+  })
+
+  it('respects newer focus chosen after the modal restores its previous target', async () => {
+    const loading = deferred<void>()
+    await render(
+      <ModalFocusHarness
+        onRestoreFocus={() =>
+          document.querySelector<HTMLInputElement>('[aria-label="New action"]')?.focus()
+        }
+      >
+        <LateFeature ready={loading.promise} label="Background search" />
+        <input aria-label="New action" />
+      </ModalFocusHarness>,
+    )
+    await expect.element(page.getByRole('textbox', { name: 'Dialog input' })).toHaveFocus()
+    loading.resolve()
+    await vi.waitFor(() =>
+      expect(document.querySelector('[aria-label="Background search"]')).not.toBeNull(),
+    )
+    await userEvent.keyboard('{Escape}')
+    await expect.element(page.getByRole('textbox', { name: 'New action' })).toHaveFocus()
+  })
+})

--- a/apps/desktop/src/lib/request-surface-focus.ts
+++ b/apps/desktop/src/lib/request-surface-focus.ts
@@ -1,0 +1,108 @@
+interface SurfaceFocusOptions extends FocusOptions {
+  selectText?: boolean
+  onFocused?: () => void
+}
+
+const INERT_SELECTOR = '[inert], [data-base-ui-inert], [aria-hidden="true"]'
+const MODAL_SELECTOR = ':is([role="dialog"], [role="alertdialog"]):is([data-open], [data-closed])'
+
+/**
+ * Focus a newly arrived surface, waiting for an already-open modal to finish
+ * closing when necessary. Only blocked requests observe the captured modal's
+ * lifetime; cleanup cancels a request when its route or arrival is superseded.
+ */
+export function requestSurfaceFocus(
+  element: HTMLElement | null,
+  { selectText = false, onFocused, ...focusOptions }: SurfaceFocusOptions = {},
+): () => void {
+  const focus = (): void => {
+    element?.focus(focusOptions)
+    if (
+      selectText &&
+      (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement)
+    ) {
+      element.select()
+    }
+    onFocused?.()
+  }
+  if (element === null) return () => {}
+  const inert = element.closest(INERT_SELECTOR) !== null
+  if (!inert && element.closest(MODAL_SELECTOR) !== null) {
+    focus()
+    return () => {}
+  }
+  // Native inert marks mobile stack layers. Returning to that layer is a new
+  // arrival, not permission to replay a focus gesture from the covered route.
+  if (element.closest('[inert]') !== null) return () => {}
+
+  const document = element.ownerDocument
+  const blockers = [...document.querySelectorAll<HTMLElement>(MODAL_SELECTOR)].filter(
+    (popup) => !popup.hidden && !popup.contains(element),
+  )
+  if (blockers.length === 0) {
+    if (!inert) focus()
+    return () => {}
+  }
+  const portals = blockers.map((popup) => popup.closest('[data-base-ui-portal]') ?? popup)
+  const settled = (): boolean => blockers.every((popup) => !popup.isConnected || popup.hidden)
+  let cancelled = false
+  let frame: number | null = null
+  let restoredFocus: EventTarget | null = null
+
+  const cancel = (): void => {
+    cancelled = true
+    observer.disconnect()
+    if (frame !== null) cancelAnimationFrame(frame)
+    document.removeEventListener('pointerdown', onIntent, { capture: true })
+    document.removeEventListener('keydown', onIntent, { capture: true })
+    document.removeEventListener('focusin', onFocus, { capture: true })
+  }
+  const insideBlocker = (target: EventTarget | null): boolean =>
+    target instanceof Node && portals.some((portal) => portal.contains(target))
+  const onIntent = (event: Event): void => {
+    if (!insideBlocker(event.target)) cancel()
+  }
+  const onFocus = (event: FocusEvent): void => {
+    if (insideBlocker(event.target)) return
+    // Base UI restores the old focus once after unmount. A later focus change
+    // is newer intent and must win over the pending route request.
+    if (!settled() || restoredFocus !== null) {
+      cancel()
+    } else {
+      restoredFocus = event.target
+    }
+  }
+  const observer = new MutationObserver(() => {
+    if (cancelled || frame !== null || !settled()) return
+    observer.disconnect()
+    // Popup removal precedes Base UI's queued return-focus microtask. The next
+    // frame orders the destination focus after that restoration, without
+    // guessing the dialog's animation duration.
+    frame = requestAnimationFrame(() => {
+      if (cancelled) return
+      cancel()
+      if (
+        element.isConnected &&
+        element.closest(INERT_SELECTOR) === null &&
+        ![...document.querySelectorAll<HTMLElement>(MODAL_SELECTOR)].some(
+          (popup) => !popup.hidden && !popup.contains(element),
+        )
+      ) {
+        focus()
+      }
+    })
+  })
+  for (const popup of blockers) {
+    for (
+      let ancestor: HTMLElement | null = popup;
+      ancestor !== null;
+      ancestor = ancestor.parentElement
+    ) {
+      observer.observe(ancestor, { childList: true, attributes: true, attributeFilter: ['hidden'] })
+    }
+  }
+  document.addEventListener('pointerdown', onIntent, { capture: true })
+  document.addEventListener('keydown', onIntent, { capture: true })
+  document.addEventListener('focusin', onFocus, { capture: true })
+  return cancel
+}

--- a/apps/desktop/src/lib/request-surface-focus.ts
+++ b/apps/desktop/src/lib/request-surface-focus.ts
@@ -3,20 +3,24 @@ interface SurfaceFocusOptions extends FocusOptions {
   onFocused?: () => void
 }
 
-const INERT_SELECTOR = '[inert], [data-base-ui-inert], [aria-hidden="true"]'
-const MODAL_SELECTOR = ':is([role="dialog"], [role="alertdialog"]):is([data-open], [data-closed])'
+const INERT_SELECTOR = '[inert], [aria-hidden="true"]'
+const MODAL_SELECTOR = ':is([role="dialog"], [role="alertdialog"])[data-open]'
+const INTENT_EVENTS = ['pointerdown', 'keydown', 'focusin'] as const
 
 /**
- * Focus a newly arrived surface, waiting for an already-open modal to finish
- * closing when necessary. Only blocked requests observe the captured modal's
- * lifetime; cleanup cancels a request when its route or arrival is superseded.
+ * Focuses a newly arrived surface, waiting for any open dialog to close first
+ * and cancelling if the user acts before then. A dialog that is already closing
+ * does not block, because Base UI removes `aria-hidden` from outside elements as
+ * soon as `open` flips false and does not return focus to the trigger when focus
+ * has already moved elsewhere.
  */
 export function requestSurfaceFocus(
   element: HTMLElement | null,
   { selectText = false, onFocused, ...focusOptions }: SurfaceFocusOptions = {},
 ): () => void {
+  if (element === null) return () => {}
   const focus = (): void => {
-    element?.focus(focusOptions)
+    element.focus(focusOptions)
     if (
       selectText &&
       (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement)
@@ -25,7 +29,6 @@ export function requestSurfaceFocus(
     }
     onFocused?.()
   }
-  if (element === null) return () => {}
   const inert = element.closest(INERT_SELECTOR) !== null
   if (!inert && element.closest(MODAL_SELECTOR) !== null) {
     focus()
@@ -36,73 +39,50 @@ export function requestSurfaceFocus(
   if (element.closest('[inert]') !== null) return () => {}
 
   const document = element.ownerDocument
-  const blockers = [...document.querySelectorAll<HTMLElement>(MODAL_SELECTOR)].filter(
-    (popup) => !popup.hidden && !popup.contains(element),
-  )
+  const openDialogs = (): HTMLElement[] =>
+    [...document.querySelectorAll<HTMLElement>(MODAL_SELECTOR)].filter(
+      (popup) => !popup.contains(element),
+    )
+  const blockers = openDialogs()
   if (blockers.length === 0) {
     if (!inert) focus()
     return () => {}
   }
-  const portals = blockers.map((popup) => popup.closest('[data-base-ui-portal]') ?? popup)
-  const settled = (): boolean => blockers.every((popup) => !popup.isConnected || popup.hidden)
-  let cancelled = false
+  const settled = (): boolean =>
+    blockers.every((popup) => !popup.isConnected || !popup.hasAttribute('data-open'))
+  const insideBlocker = (target: EventTarget | null): boolean =>
+    target instanceof Node && blockers.some((popup) => popup.contains(target))
   let frame: number | null = null
-  let restoredFocus: EventTarget | null = null
 
   const cancel = (): void => {
-    cancelled = true
     observer.disconnect()
     if (frame !== null) cancelAnimationFrame(frame)
-    document.removeEventListener('pointerdown', onIntent, { capture: true })
-    document.removeEventListener('keydown', onIntent, { capture: true })
-    document.removeEventListener('focusin', onFocus, { capture: true })
+    for (const type of INTENT_EVENTS) {
+      document.removeEventListener(type, onIntent, { capture: true })
+    }
   }
-  const insideBlocker = (target: EventTarget | null): boolean =>
-    target instanceof Node && portals.some((portal) => portal.contains(target))
   const onIntent = (event: Event): void => {
     if (!insideBlocker(event.target)) cancel()
   }
-  const onFocus = (event: FocusEvent): void => {
-    if (insideBlocker(event.target)) return
-    // Base UI restores the old focus once after unmount. A later focus change
-    // is newer intent and must win over the pending route request.
-    if (!settled() || restoredFocus !== null) {
-      cancel()
-    } else {
-      restoredFocus = event.target
-    }
-  }
   const observer = new MutationObserver(() => {
-    if (cancelled || frame !== null || !settled()) return
-    observer.disconnect()
-    // Popup removal precedes Base UI's queued return-focus microtask. The next
-    // frame orders the destination focus after that restoration, without
-    // guessing the dialog's animation duration.
+    if (!settled()) return
+    cancel()
     frame = requestAnimationFrame(() => {
-      if (cancelled) return
-      cancel()
       if (
         element.isConnected &&
         element.closest(INERT_SELECTOR) === null &&
-        ![...document.querySelectorAll<HTMLElement>(MODAL_SELECTOR)].some(
-          (popup) => !popup.hidden && !popup.contains(element),
-        )
+        openDialogs().length === 0
       ) {
         focus()
       }
     })
   })
   for (const popup of blockers) {
-    for (
-      let ancestor: HTMLElement | null = popup;
-      ancestor !== null;
-      ancestor = ancestor.parentElement
-    ) {
-      observer.observe(ancestor, { childList: true, attributes: true, attributeFilter: ['hidden'] })
+    observer.observe(popup, { attributes: true, attributeFilter: ['data-open'] })
+    for (let ancestor = popup.parentNode; ancestor !== null; ancestor = ancestor.parentNode) {
+      observer.observe(ancestor, { childList: true })
     }
   }
-  document.addEventListener('pointerdown', onIntent, { capture: true })
-  document.addEventListener('keydown', onIntent, { capture: true })
-  document.addEventListener('focusin', onFocus, { capture: true })
+  for (const type of INTENT_EVENTS) document.addEventListener(type, onIntent, { capture: true })
   return cancel
 }

--- a/apps/desktop/src/mobile/use-arrival-focus.test.tsx
+++ b/apps/desktop/src/mobile/use-arrival-focus.test.tsx
@@ -1,19 +1,39 @@
-import { cleanup, renderHook } from 'vitest-browser-react'
+import { useRef, type ReactElement } from 'react'
+import { cleanup, render } from 'vitest-browser-react'
+import { page } from 'vitest/browser'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useArrivalFocus, type ArrivalFocusOptions } from './use-arrival-focus'
 
-async function mountFocus(initial: Omit<ArrivalFocusOptions, 'target'>) {
-  const focus = vi.fn()
-  const target = { current: { focus } as unknown as HTMLElement }
-  const hook = await renderHook(
-    (props: Omit<ArrivalFocusOptions, 'target'> = initial) => useArrivalFocus({ ...props, target }),
-    { initialProps: initial },
-  )
-  return { hook, focus }
+interface ArrivalFocusProbeProps extends Omit<ArrivalFocusOptions, 'target'> {
+  inert?: boolean
+  baseUiInert?: boolean
+  hidden?: boolean
 }
 
-afterEach(() => {
-  cleanup()
+function ArrivalFocusProbe({
+  inert,
+  baseUiInert,
+  hidden,
+  ...options
+}: ArrivalFocusProbeProps): ReactElement {
+  const target = useRef<HTMLInputElement>(null)
+  useArrivalFocus({ ...options, target })
+  return (
+    <div inert={inert} data-base-ui-inert={baseUiInert ? '' : undefined} aria-hidden={hidden}>
+      <input ref={target} aria-label="Arrival target" defaultValue="Existing query" />
+    </div>
+  )
+}
+
+async function mountFocus(initial: ArrivalFocusProbeProps) {
+  const focus = vi.spyOn(HTMLInputElement.prototype, 'focus')
+  const view = await render(<ArrivalFocusProbe {...initial} />)
+  return { view, focus }
+}
+
+afterEach(async () => {
+  await cleanup()
+  vi.restoreAllMocks()
 })
 
 describe('useArrivalFocus', () => {
@@ -27,32 +47,46 @@ describe('useArrivalFocus', () => {
     // committed: the mount already sees the final seq with the focus flag up.
     const { focus } = await mountFocus({ arrivalSeq: 3, arrivalFocusEditor: true })
     expect(focus).toHaveBeenCalledTimes(1)
+    await expect.element(page.getByRole('textbox', { name: 'Arrival target' })).toHaveFocus()
   })
 
   it('focuses on a capture re-arrival (the double-tap while already shown)', async () => {
-    const { hook, focus } = await mountFocus({
+    const { view, focus } = await mountFocus({
       arrivalSeq: 1,
       arrivalFocusEditor: false,
     })
-    await hook.rerender({ arrivalSeq: 2, arrivalFocusEditor: true })
+    await view.rerender(<ArrivalFocusProbe arrivalSeq={2} arrivalFocusEditor />)
     expect(focus).toHaveBeenCalledTimes(1)
   })
 
   it('consumes each arrival once — unrelated re-renders do not re-focus', async () => {
-    const { hook, focus } = await mountFocus({
+    const { view, focus } = await mountFocus({
       arrivalSeq: 2,
       arrivalFocusEditor: true,
     })
-    await hook.rerender({ arrivalSeq: 2, arrivalFocusEditor: true })
+    await view.rerender(<ArrivalFocusProbe arrivalSeq={2} arrivalFocusEditor />)
     expect(focus).toHaveBeenCalledTimes(1)
   })
 
   it('ignores arrivals without the focus flag', async () => {
-    const { hook, focus } = await mountFocus({
+    const { view, focus } = await mountFocus({
       arrivalSeq: 1,
       arrivalFocusEditor: false,
     })
-    await hook.rerender({ arrivalSeq: 2, arrivalFocusEditor: false })
+    await view.rerender(<ArrivalFocusProbe arrivalSeq={2} arrivalFocusEditor={false} />)
+    expect(focus).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { name: 'a native inert container', props: { inert: true } },
+    { name: 'a Base UI inert container', props: { baseUiInert: true } },
+    { name: 'an aria-hidden container', props: { hidden: true } },
+  ])('does not focus an arrival behind $name', async ({ props }) => {
+    const { focus } = await mountFocus({
+      arrivalSeq: 3,
+      arrivalFocusEditor: true,
+      ...props,
+    })
     expect(focus).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/mobile/use-arrival-focus.test.tsx
+++ b/apps/desktop/src/mobile/use-arrival-focus.test.tsx
@@ -6,20 +6,14 @@ import { useArrivalFocus, type ArrivalFocusOptions } from './use-arrival-focus'
 
 interface ArrivalFocusProbeProps extends Omit<ArrivalFocusOptions, 'target'> {
   inert?: boolean
-  baseUiInert?: boolean
   hidden?: boolean
 }
 
-function ArrivalFocusProbe({
-  inert,
-  baseUiInert,
-  hidden,
-  ...options
-}: ArrivalFocusProbeProps): ReactElement {
+function ArrivalFocusProbe({ inert, hidden, ...options }: ArrivalFocusProbeProps): ReactElement {
   const target = useRef<HTMLInputElement>(null)
   useArrivalFocus({ ...options, target })
   return (
-    <div inert={inert} data-base-ui-inert={baseUiInert ? '' : undefined} aria-hidden={hidden}>
+    <div inert={inert} aria-hidden={hidden}>
       <input ref={target} aria-label="Arrival target" defaultValue="Existing query" />
     </div>
   )
@@ -79,7 +73,6 @@ describe('useArrivalFocus', () => {
 
   it.each([
     { name: 'a native inert container', props: { inert: true } },
-    { name: 'a Base UI inert container', props: { baseUiInert: true } },
     { name: 'an aria-hidden container', props: { hidden: true } },
   ])('does not focus an arrival behind $name', async ({ props }) => {
     const { focus } = await mountFocus({

--- a/apps/desktop/src/mobile/use-arrival-focus.ts
+++ b/apps/desktop/src/mobile/use-arrival-focus.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, type RefObject } from 'react'
+import { requestSurfaceFocus } from '@/lib/request-surface-focus'
 
 export interface ArrivalFocusOptions {
   /** The router's navigation counter — bumped on every `navigate`. */
@@ -28,16 +29,14 @@ export function useArrivalFocus({
   const seenSeq = useRef<number | null>(null)
   useEffect(() => {
     const newArrival = seenSeq.current !== arrivalSeq
-    seenSeq.current = arrivalSeq
     if (newArrival && arrivalFocusEditor) {
-      const element = target.current
-      element?.focus()
-      if (
-        selectText &&
-        (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement)
-      ) {
-        element.select()
-      }
+      return requestSurfaceFocus(target.current, {
+        selectText,
+        onFocused: () => {
+          seenSeq.current = arrivalSeq
+        },
+      })
     }
+    seenSeq.current = arrivalSeq
   }, [arrivalSeq, arrivalFocusEditor, selectText, target])
 }


### PR DESCRIPTION
Part of #1216, split out so it can be reviewed and land on its own: Tasks, All Notes, the chat input and the mobile arrival focus request focus through one helper that waits for an open dialog to close instead of stealing focus from it, focuses right away once the dialog starts closing, and cancels if the user acts first. Independent of the other #1216 pieces.