### PR TITLE
feat: change graph colors from each graph menu row

### DIFF
--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -1,26 +1,17 @@
 import { useRef, useState, type ReactElement } from 'react'
 import type { GraphInfo } from '@reflect/core'
 import { revealItemInDir } from '@tauri-apps/plugin-opener'
-import {
-  Check,
-  FolderOpen,
-  GraduationCap,
-  LocateFixed,
-  PanelsTopLeft,
-  Settings,
-} from 'lucide-react'
+import { FolderOpen, GraduationCap, LocateFixed, PanelsTopLeft, Settings } from 'lucide-react'
 import { GraphSwatch } from '@/components/graph-swatch'
 import { ReflectAppsDialog } from '@/components/reflect-apps-dialog'
 import { ShortcutKeys } from '@/components/shortcut-keys'
+import { GraphMenuItem } from '@/components/sidebar/graph-menu-item'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -28,7 +19,6 @@ import { useGraphColors } from '@/hooks/use-graph-colors'
 import { keybindingFor } from '@/lib/commands/app-commands'
 import { runCommand } from '@/lib/commands/registry'
 import type { CommandContext } from '@/lib/commands/types'
-import { DEFAULT_GRAPH_COLOR, GRAPH_COLOR_OPTIONS } from '@/lib/graph-colors'
 import { openUrlSync } from '@/lib/open-url'
 import { cn } from '@/lib/utils'
 import { isMainWindow } from '@/lib/windows/window-role'
@@ -79,8 +69,7 @@ export function GraphFooter({ graph, context }: GraphFooterProps): ReactElement 
   const [appsOpen, setAppsOpen] = useState(false)
   const graphTriggerRef = useRef<HTMLButtonElement>(null)
   const { recents, indexing, openRecent, chooseGraph } = useGraph()
-  const { colorFor, setColor } = useGraphColors()
-  const currentColor = colorFor(graph.root) ?? DEFAULT_GRAPH_COLOR
+  const { colorFor } = useGraphColors()
   const { backup } = useSync()
   const { route } = useRouter()
   const dot = backupDot(backup)
@@ -132,58 +121,20 @@ export function GraphFooter({ graph, context }: GraphFooterProps): ReactElement 
           <TooltipContent>{graph.root}</TooltipContent>
         </Tooltip>
         <DropdownMenuContent aria-label="Switch graph" side="top" sideOffset={6}>
-          {recents.map((recent, index) => {
-            const current = recent.root === graph.root
-            const binding = graphSwitchBindingFor(index)
-            return (
-              <Tooltip key={recent.root}>
-                <TooltipTrigger
-                  delay={700}
-                  render={
-                    <DropdownMenuItem
-                      onClick={() => {
-                        if (!current) {
-                          void openRecent(recent.root)
-                        }
-                      }}
-                      className={MENU_ITEM_CLASS}
-                    >
-                      <GraphSwatch color={colorFor(recent.root)} className="size-3.5 rounded" />
-                      <span className="min-w-0 flex-1 truncate">{recent.name}</span>
-                      {current ? (
-                        <Check aria-hidden className="size-3.5 shrink-0 text-accent" />
-                      ) : binding !== null ? (
-                        <ShortcutKeys binding={binding} className="text-[10px]" />
-                      ) : null}
-                    </DropdownMenuItem>
-                  }
-                />
-                <TooltipContent side="right">{recent.root}</TooltipContent>
-              </Tooltip>
-            )
-          })}
+          {recents.map((recent, index) => (
+            <GraphMenuItem
+              key={recent.root}
+              graph={recent}
+              current={recent.root === graph.root}
+              binding={graphSwitchBindingFor(index)}
+              onSelect={() => {
+                if (recent.root !== graph.root) {
+                  void openRecent(recent.root)
+                }
+              }}
+            />
+          ))}
           {recents.length > 0 ? <DropdownMenuSeparator /> : null}
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger className={MENU_ITEM_CLASS}>
-              <GraphSwatch color={currentColor} className="size-3.5 rounded" />
-              <span className="min-w-0 flex-1 truncate">Graph color</span>
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent aria-label="Graph color">
-              {GRAPH_COLOR_OPTIONS.map((option) => (
-                <DropdownMenuItem
-                  key={option.id}
-                  onClick={() => setColor(graph.root, option.id)}
-                  className={MENU_ITEM_CLASS}
-                >
-                  <GraphSwatch color={option.id} className="size-3.5 rounded" />
-                  <span className="min-w-0 flex-1">{option.label}</span>
-                  {option.id === currentColor ? (
-                    <Check aria-hidden className="size-3.5 shrink-0 text-accent" />
-                  ) : null}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
           <DropdownMenuItem
             onClick={() => {
               void revealItemInDir(graph.root).catch((cause: unknown) => {

--- a/apps/desktop/src/components/sidebar/graph-menu-item.tsx
+++ b/apps/desktop/src/components/sidebar/graph-menu-item.tsx
@@ -1,0 +1,85 @@
+import type { ReactElement } from 'react'
+import type { RecentGraph } from '@reflect/core'
+import { Check } from 'lucide-react'
+import { GraphSwatch } from '@/components/graph-swatch'
+import { ShortcutKeys } from '@/components/shortcut-keys'
+import {
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useGraphColors } from '@/hooks/use-graph-colors'
+import { DEFAULT_GRAPH_COLOR, GRAPH_COLOR_OPTIONS } from '@/lib/graph-colors'
+
+interface GraphMenuItemProps {
+  graph: RecentGraph
+  current: boolean
+  binding: string | null
+  onSelect: () => void
+}
+
+/** A recent graph with separate color and switch actions in the same row. */
+export function GraphMenuItem({
+  graph,
+  current,
+  binding,
+  onSelect,
+}: GraphMenuItemProps): ReactElement {
+  const { colorFor, setColor } = useGraphColors()
+  const color = colorFor(graph.root) ?? DEFAULT_GRAPH_COLOR
+
+  return (
+    <div className="flex h-8 items-stretch">
+      <DropdownMenuSub>
+        <DropdownMenuSubTrigger
+          aria-label={`Change color for ${graph.name}`}
+          label={`Change color for ${graph.name}`}
+          openOnHover={false}
+          showChevron={false}
+          className="shrink-0 justify-center px-2 py-0"
+        >
+          <GraphSwatch color={color} className="size-3.5 rounded" />
+        </DropdownMenuSubTrigger>
+        <DropdownMenuSubContent aria-label={`Color for ${graph.name}`}>
+          <DropdownMenuRadioGroup value={color}>
+            {GRAPH_COLOR_OPTIONS.map((option) => (
+              <DropdownMenuRadioItem
+                key={option.id}
+                value={option.id}
+                closeOnClick
+                onClick={() => setColor(graph.root, option.id)}
+                className="h-8 gap-2 py-0 pl-2 text-[13px] text-text-secondary"
+              >
+                <GraphSwatch color={option.id} className="size-3.5 rounded" />
+                {option.label}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuSubContent>
+      </DropdownMenuSub>
+      <Tooltip>
+        <TooltipTrigger
+          delay={700}
+          render={
+            <DropdownMenuItem
+              onClick={onSelect}
+              className="min-w-0 flex-1 gap-2 py-0 pr-2 pl-0 text-[13px] text-text-secondary"
+            >
+              <span className="min-w-0 flex-1 truncate">{graph.name}</span>
+              {current ? (
+                <Check aria-hidden className="size-3.5 shrink-0 text-accent" />
+              ) : binding !== null ? (
+                <ShortcutKeys binding={binding} className="text-[10px]" />
+              ) : null}
+            </DropdownMenuItem>
+          }
+        />
+        <TooltipContent side="right">{graph.root}</TooltipContent>
+      </Tooltip>
+    </div>
+  )
+}

--- a/apps/desktop/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/components/sidebar/sidebar.test.tsx
@@ -125,6 +125,7 @@ beforeEach(() => {
   openRecent.mockClear()
   pickAndOpen.mockClear()
   chooseGraph.mockClear()
+  updateSettingsWith.mockClear()
   openNativeContextMenu.mockClear()
   unpinNote.mockClear()
 })
@@ -392,7 +393,7 @@ describe('Sidebar', () => {
     const { view } = await renderSidebar()
 
     await view.getByRole('button', { name: /Notes/ }).click()
-    const work = page.getByRole('menuitem', { name: 'Work' })
+    const work = page.getByRole('menuitem', { name: 'Work', exact: true })
     await expect.element(work).toBeVisible()
     expect(
       [...work.element().querySelectorAll('kbd')].map((keycap) => keycap.textContent),
@@ -470,17 +471,53 @@ describe('Sidebar', () => {
     expect(revealItemInDir).toHaveBeenCalledWith('/notes')
   })
 
-  it('the graph footer recolors the current graph', async () => {
+  it.each([
+    { name: 'Notes', root: '/notes' },
+    { name: 'Work', root: '/work' },
+  ])('recolors $name from its swatch without switching graphs', async ({ name, root }) => {
     const { view } = await renderSidebar()
 
     await view.getByRole('button', { name: /Notes/ }).click()
-    await page.getByRole('menuitem', { name: 'Graph color' }).click()
-    await page.getByRole('menuitem', { name: 'Teal' }).click()
-    await vi.waitFor(() => expect(updateSettingsWith).toHaveBeenCalled())
+    await expect
+      .element(page.getByRole('menuitem', { name: 'Graph color', exact: true }))
+      .not.toBeInTheDocument()
+    await page.getByRole('menuitem', { name: `Change color for ${name}` }).click()
+    await expect
+      .element(page.getByRole('menuitemradio', { name: 'Indigo' }))
+      .toHaveAttribute('aria-checked', 'true')
+    await page.getByRole('menuitemradio', { name: 'Teal' }).click()
+    await expect.element(page.getByRole('menuitemradio', { name: 'Teal' })).not.toBeInTheDocument()
+    expect(updateSettingsWith).toHaveBeenCalledTimes(1)
+    expect(openRecent).not.toHaveBeenCalled()
 
-    // The patch composes over the latest settings at apply time — feed the
-    // updater a document and check the record it builds.
     const updater = updateSettingsWith.mock.lastCall?.[0]
-    expect(updater?.(DEFAULT_SETTINGS)).toEqual({ graphColors: { '/notes': 'teal' } })
+    expect(updater?.({ ...DEFAULT_SETTINGS, graphColors: { '/other': 'red' } })).toEqual({
+      graphColors: { '/other': 'red', [root]: 'teal' },
+    })
+  })
+
+  it('opens and dismisses a graph color menu from the keyboard', async () => {
+    const { view } = await renderSidebar()
+    view.getByRole('button', { name: /Notes/ }).element().focus()
+    await userEvent.keyboard('{ArrowDown}')
+    const swatch = page.getByRole('menuitem', { name: 'Change color for Notes' })
+    await expect.element(swatch).toHaveFocus()
+    await userEvent.keyboard('{ArrowRight}')
+    await expect.element(page.getByRole('menuitemradio', { name: 'Indigo' })).toHaveFocus()
+    await userEvent.keyboard('{Escape}')
+    await expect.element(swatch).toHaveFocus()
+    await expect.element(swatch).toBeVisible()
+    expect(updateSettingsWith).not.toHaveBeenCalled()
+
+    await userEvent.keyboard('{ArrowRight}')
+    await expect.element(page.getByRole('menuitemradio', { name: 'Indigo' })).toHaveFocus()
+    await userEvent.keyboard('{ArrowDown}')
+    await expect.element(page.getByRole('menuitemradio', { name: 'Blue' })).toHaveFocus()
+    await userEvent.keyboard('{Enter}')
+    await vi.waitFor(() => expect(updateSettingsWith).toHaveBeenCalledTimes(1))
+    expect(updateSettingsWith.mock.lastCall?.[0](DEFAULT_SETTINGS)).toEqual({
+      graphColors: { '/notes': 'blue' },
+    })
+    expect(openRecent).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -99,11 +99,14 @@ function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
 }
 
 function DropdownMenuSubTrigger({
+  showChevron = true,
   className,
   inset,
   children,
   ...props
 }: MenuPrimitive.SubmenuTrigger.Props & {
+  /** Hide the trailing arrow for compact, icon-only submenu triggers. */
+  showChevron?: boolean
   inset?: boolean
 }) {
   return (
@@ -117,7 +120,7 @@ function DropdownMenuSubTrigger({
       {...props}
     >
       {children}
-      <ChevronRightIcon className="ml-auto" />
+      {showChevron ? <ChevronRightIcon className="ml-auto" /> : null}
     </MenuPrimitive.SubmenuTrigger>
   )
 }


### PR DESCRIPTION
Graph colors currently live behind a separate menu item that only edits the active graph. This moves the picker into each recent graph row: click its swatch to recolor that graph without opening it, or click its name to switch graphs.

The standalone “Graph color” item is removed. Each swatch has a named, keyboard-accessible submenu with the selected color exposed as a radio option. Selecting a color closes the menus; Escape returns focus to the swatch. The existing per-graph settings storage is reused.

Verification:
- `pnpm check`
- `pnpm build`
- `pnpm test --run apps/desktop/src/components/sidebar/sidebar.test.tsx` — 24 tests passed in Chromium.
- The same sidebar suite with `REFLECT_TEST_BROWSER=webkit` — 24 tests passed.
- Local browser inspection of the picker, color updates, menu dismissal, and row spacing.

Tests cover active and inactive graph recoloring, preservation of other graph colors, graph switching, selected-color semantics, and keyboard selection/dismissal. No settings migration is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Recent graphs now appear in a consistent menu layout with dedicated actions for selecting a graph and changing its color.
  - Graph colors are preserved across interactions and can be updated directly from the recent graphs menu.
  - Keyboard navigation and focus behavior for graph selection are improved.
  - Compact submenu triggers can now display without a trailing chevron.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->