### PR TITLE
refactor: load the new template form on demand

### DIFF
--- a/apps/desktop/src/components/templates/template-create-dialog.tsx
+++ b/apps/desktop/src/components/templates/template-create-dialog.tsx
@@ -1,7 +1,3 @@
-import { useState, type ReactElement } from 'react'
-import { useForm } from 'react-hook-form'
-import { errorMessage } from '@reflect/core'
-import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
@@ -9,11 +5,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import { InlineAlert } from '@/components/inline-alert'
 import type { CommandContext } from '@/lib/commands/types'
-import { createTemplate } from '@/lib/note-templates'
 import { useNoteTemplates } from '@/providers/note-templates-provider'
+import { once } from '@ocavue/utils'
+import { lazy, Suspense, useState, type ReactElement } from 'react'
 
 /**
  * The "New template" dialog (docs/porting/note-templates.md): name it, and the
@@ -27,31 +22,20 @@ interface TemplateCreateDialogProps {
   context: CommandContext
 }
 
-interface TemplateCreateForm {
-  name: string
-}
+const loadTemplateCreateForm = once(async () => {
+  const { TemplateCreateForm } = await import('@/components/templates/template-create-form')
+  return { default: TemplateCreateForm }
+})
+
+const TemplateCreateForm = lazy(loadTemplateCreateForm)
 
 export function TemplateCreateDialog({ context }: TemplateCreateDialogProps): ReactElement {
   const { createOpen, closeTemplateCreate } = useNoteTemplates()
-  const { register, handleSubmit, formState, reset } = useForm<TemplateCreateForm>({
-    defaultValues: { name: '' },
-  })
-  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [showForm, setShowForm] = useState(createOpen)
 
-  const submit = handleSubmit(async (values) => {
-    setSubmitError(null)
-    const generation = context.generation()
-    if (generation === null) {
-      return
-    }
-    try {
-      const path = await createTemplate(values.name, generation)
-      closeTemplateCreate()
-      context.navigate({ kind: 'note', path })
-    } catch (cause: unknown) {
-      setSubmitError(errorMessage(cause))
-    }
-  })
+  if (createOpen && !showForm) {
+    setShowForm(true)
+  }
 
   return (
     <Dialog
@@ -63,51 +47,22 @@ export function TemplateCreateDialog({ context }: TemplateCreateDialogProps): Re
       }}
       onOpenChangeComplete={(isOpen) => {
         if (!isOpen) {
-          reset()
-          setSubmitError(null)
+          setShowForm(false)
         }
       }}
     >
-      <DialogContent showCloseButton={false} className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>New template</DialogTitle>
-          <DialogDescription>
-            A markdown file in your graph's <code>templates/</code> folder.
-          </DialogDescription>
-        </DialogHeader>
-        <form
-          className="flex flex-col gap-3"
-          onSubmit={(event) => {
-            void submit(event)
-          }}
-        >
-          <Input
-            autoFocus
-            placeholder="Template name"
-            autoComplete="off"
-            spellCheck={false}
-            {...register('name', {
-              validate: (value) => value.trim().length > 0 || 'Enter a name.',
-            })}
-          />
-          {formState.errors.name ? (
-            <span role="alert" className="text-xs text-red-600 dark:text-red-400">
-              {formState.errors.name.message}
-            </span>
-          ) : null}
+      <Suspense>
+        <DialogContent showCloseButton={false} className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>New template</DialogTitle>
+            <DialogDescription>
+              A markdown file in your graph's <code>templates/</code> folder.
+            </DialogDescription>
+          </DialogHeader>
 
-          {submitError !== null ? <InlineAlert tone="error">{submitError}</InlineAlert> : null}
-
-          <div className="flex justify-end gap-2">
-            <Button type="button" variant="outline" size="sm" onClick={closeTemplateCreate}>
-              Cancel
-            </Button>
-            <Button type="submit" size="sm" disabled={formState.isSubmitting}>
-              Create
-            </Button>
-          </div>
-        </form>
-      </DialogContent>
+          {showForm ? <TemplateCreateForm onClose={closeTemplateCreate} context={context} /> : null}
+        </DialogContent>
+      </Suspense>
     </Dialog>
   )
 }

--- a/apps/desktop/src/components/templates/template-create-dialog.tsx
+++ b/apps/desktop/src/components/templates/template-create-dialog.tsx
@@ -7,7 +7,6 @@ import {
 } from '@/components/ui/dialog'
 import type { CommandContext } from '@/lib/commands/types'
 import { useNoteTemplates } from '@/providers/note-templates-provider'
-import { once } from '@ocavue/utils'
 import { lazy, Suspense, useState, type ReactElement } from 'react'
 
 /**
@@ -22,12 +21,10 @@ interface TemplateCreateDialogProps {
   context: CommandContext
 }
 
-const loadTemplateCreateForm = once(async () => {
+const TemplateCreateForm = lazy(async () => {
   const { TemplateCreateForm } = await import('@/components/templates/template-create-form')
   return { default: TemplateCreateForm }
 })
-
-const TemplateCreateForm = lazy(loadTemplateCreateForm)
 
 export function TemplateCreateDialog({ context }: TemplateCreateDialogProps): ReactElement {
   const { createOpen, closeTemplateCreate } = useNoteTemplates()

--- a/apps/desktop/src/components/templates/template-create-form.tsx
+++ b/apps/desktop/src/components/templates/template-create-form.tsx
@@ -1,0 +1,74 @@
+import { useState, type ReactElement } from 'react'
+import { useForm } from 'react-hook-form'
+import { errorMessage } from '@reflect/core'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { InlineAlert } from '@/components/inline-alert'
+import type { CommandContext } from '@/lib/commands/types'
+import { createTemplate } from '@/lib/note-templates'
+
+interface TemplateCreateFormProps {
+  context: CommandContext
+  onClose: () => void
+}
+
+interface TemplateCreateValues {
+  name: string
+}
+
+export function TemplateCreateForm({ context, onClose }: TemplateCreateFormProps): ReactElement {
+  const { register, handleSubmit, formState } = useForm<TemplateCreateValues>({
+    defaultValues: { name: '' },
+  })
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const submit = handleSubmit(async (values) => {
+    setSubmitError(null)
+    const generation = context.generation()
+    if (generation === null) {
+      return
+    }
+    try {
+      const path = await createTemplate(values.name, generation)
+      onClose()
+      context.navigate({ kind: 'note', path })
+    } catch (cause: unknown) {
+      setSubmitError(errorMessage(cause))
+    }
+  })
+
+  return (
+    <form
+      className="flex flex-col gap-3"
+      onSubmit={(event) => {
+        void submit(event)
+      }}
+    >
+      <Input
+        autoFocus
+        placeholder="Template name"
+        autoComplete="off"
+        spellCheck={false}
+        {...register('name', {
+          validate: (value) => value.trim().length > 0 || 'Enter a name.',
+        })}
+      />
+      {formState.errors.name ? (
+        <span role="alert" className="text-xs text-red-600 dark:text-red-400">
+          {formState.errors.name.message}
+        </span>
+      ) : null}
+
+      {submitError !== null ? <InlineAlert tone="error">{submitError}</InlineAlert> : null}
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button type="submit" size="sm" disabled={formState.isSubmitting}>
+          Create
+        </Button>
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
part of https://github.com/team-reflect/reflect-open/pull/1216 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a template creation form with name validation.
  - Users can cancel or submit while receiving clear submitting-state feedback.
  - After creation, users are taken directly to the new template note.
  - Submission errors are displayed within the form.

- **Performance**
  - Template creation content now loads when needed, improving initial dialog loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->