### PR TITLE
refactor: load the AI prompt form on demand

### DIFF
--- a/apps/desktop/src/components/settings-screen.test.tsx
+++ b/apps/desktop/src/components/settings-screen.test.tsx
@@ -1192,6 +1192,7 @@ describe('SettingsScreen', () => {
     await section.getByRole('button', { name: /add prompt/i }).click()
     const dialog = page.getByRole('dialog', { name: /add prompt/i })
     const promptBody = dialog.getByPlaceholder(/Translate the following/)
+    await expect.element(promptBody).toBeInTheDocument()
 
     expect(dialog.element().className).toContain('max-h-[calc(100dvh-2rem)]')
     expect(dialog.element().className).toContain('overflow-y-auto')

--- a/apps/desktop/src/components/settings/ai-prompt-dialog.tsx
+++ b/apps/desktop/src/components/settings/ai-prompt-dialog.tsx
@@ -1,7 +1,5 @@
-import type { ReactElement } from 'react'
-import { useForm, useWatch } from 'react-hook-form'
-import type { AiPrompt, AiPromptMode } from '@reflect/core'
-import { Button } from '@/components/ui/button'
+import { lazy, Suspense, type ReactElement } from 'react'
+import type { AiPrompt } from '@reflect/core'
 import {
   Dialog,
   DialogContent,
@@ -9,16 +7,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import { Textarea } from '@/components/ui/textarea'
 import type { AiPromptDraft } from '@/hooks/use-ai-prompts'
 
 interface AiPromptDialogProps {
@@ -29,7 +17,10 @@ interface AiPromptDialogProps {
   onClose: () => void
 }
 
-const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
+const AiPromptForm = lazy(async () => {
+  const { AiPromptForm } = await import('@/components/settings/ai-prompt-form')
+  return { default: AiPromptForm }
+})
 
 /**
  * The add/edit dialog for a saved AI prompt: a label for the picker, the
@@ -38,20 +29,6 @@ const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
  * or is inserted below it.
  */
 export function AiPromptDialog({ prompt, onSave, onClose }: AiPromptDialogProps): ReactElement {
-  const { register, control, handleSubmit, setValue, formState } = useForm<AiPromptDraft>({
-    defaultValues: {
-      label: prompt?.label ?? '',
-      body: prompt?.body ?? '',
-      mode: prompt?.mode ?? 'replace',
-    },
-  })
-  const mode = useWatch({ control, name: 'mode' })
-
-  const submit = handleSubmit((values) => {
-    onSave({ label: values.label.trim(), body: values.body.trim(), mode: values.mode })
-    onClose()
-  })
-
   return (
     <Dialog
       open
@@ -59,69 +36,23 @@ export function AiPromptDialog({ prompt, onSave, onClose }: AiPromptDialogProps)
         if (!isOpen) onClose()
       }}
     >
-      <DialogContent
-        showCloseButton={false}
-        className="max-h-[calc(100dvh-2rem)] max-w-md overflow-y-auto"
-      >
-        <DialogHeader>
-          <DialogTitle>{prompt === null ? 'Add prompt' : 'Edit prompt'}</DialogTitle>
-          <DialogDescription>
-            The prompt runs on the text you select in a note. Use{' '}
-            <code className="font-mono text-xs">{'{{selectedText}}'}</code> where the selection
-            should appear.
-          </DialogDescription>
-        </DialogHeader>
-        <form
-          className="flex flex-col gap-4"
-          onSubmit={(event) => {
-            void submit(event)
-          }}
+      <Suspense>
+        <DialogContent
+          showCloseButton={false}
+          className="max-h-[calc(100dvh-2rem)] max-w-md overflow-y-auto"
         >
-          <label className="flex flex-col gap-1.5">
-            <span className={FIELD_LABEL_CLASS}>Label</span>
-            <Input
-              {...register('label', { required: true })}
-              aria-invalid={formState.errors.label !== undefined || undefined}
-              placeholder="Translate to French"
-              autoFocus
-            />
-          </label>
-          <label className="flex flex-col gap-1.5">
-            <span className={FIELD_LABEL_CLASS}>Prompt</span>
-            <Textarea
-              {...register('body', { required: true })}
-              aria-invalid={formState.errors.body !== undefined || undefined}
-              className="field-sizing-fixed h-40 max-h-[50dvh] resize-y overflow-y-auto"
-              rows={5}
-              placeholder={'Translate the following text to French.\n\n{{selectedText}}'}
-            />
-          </label>
-          <label className="flex flex-col gap-1.5">
-            <span className={FIELD_LABEL_CLASS}>Result</span>
-            <Select
-              value={mode}
-              items={{ replace: 'Replaces the selection', append: 'Inserted below the selection' }}
-              onValueChange={(value) => setValue('mode', value as AiPromptMode)}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectItem value="replace">Replaces the selection</SelectItem>
-                  <SelectItem value="append">Inserted below the selection</SelectItem>
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-          </label>
-          <div className="flex justify-end gap-2">
-            <Button type="button" variant="ghost" onClick={onClose}>
-              Cancel
-            </Button>
-            <Button type="submit">{prompt === null ? 'Add prompt' : 'Save'}</Button>
-          </div>
-        </form>
-      </DialogContent>
+          <DialogHeader>
+            <DialogTitle>{prompt === null ? 'Add prompt' : 'Edit prompt'}</DialogTitle>
+            <DialogDescription>
+              The prompt runs on the text you select in a note. Use{' '}
+              <code className="font-mono text-xs">{'{{selectedText}}'}</code> where the selection
+              should appear.
+            </DialogDescription>
+          </DialogHeader>
+
+          <AiPromptForm prompt={prompt} onSave={onSave} onClose={onClose} />
+        </DialogContent>
+      </Suspense>
     </Dialog>
   )
 }

--- a/apps/desktop/src/components/settings/ai-prompt-form.tsx
+++ b/apps/desktop/src/components/settings/ai-prompt-form.tsx
@@ -1,0 +1,94 @@
+import type { ReactElement } from 'react'
+import { useForm, useWatch } from 'react-hook-form'
+import type { AiPrompt, AiPromptMode } from '@reflect/core'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import type { AiPromptDraft } from '@/hooks/use-ai-prompts'
+
+interface AiPromptFormProps {
+  /** The prompt being edited, or null when adding a new one. */
+  prompt: AiPrompt | null
+  /** Persists the draft (add or update). */
+  onSave: (draft: AiPromptDraft) => void
+  onClose: () => void
+}
+
+const FIELD_LABEL_CLASS = 'text-xs font-medium text-text-secondary'
+
+export function AiPromptForm({ prompt, onSave, onClose }: AiPromptFormProps): ReactElement {
+  const { register, control, handleSubmit, setValue, formState } = useForm<AiPromptDraft>({
+    defaultValues: {
+      label: prompt?.label ?? '',
+      body: prompt?.body ?? '',
+      mode: prompt?.mode ?? 'replace',
+    },
+  })
+  const mode = useWatch({ control, name: 'mode' })
+
+  const submit = handleSubmit((values) => {
+    onSave({ label: values.label.trim(), body: values.body.trim(), mode: values.mode })
+    onClose()
+  })
+
+  return (
+    <form
+      className="flex flex-col gap-4"
+      onSubmit={(event) => {
+        void submit(event)
+      }}
+    >
+      <label className="flex flex-col gap-1.5">
+        <span className={FIELD_LABEL_CLASS}>Label</span>
+        <Input
+          {...register('label', { required: true })}
+          aria-invalid={formState.errors.label !== undefined || undefined}
+          placeholder="Translate to French"
+          autoFocus
+        />
+      </label>
+      <label className="flex flex-col gap-1.5">
+        <span className={FIELD_LABEL_CLASS}>Prompt</span>
+        <Textarea
+          {...register('body', { required: true })}
+          aria-invalid={formState.errors.body !== undefined || undefined}
+          className="field-sizing-fixed h-40 max-h-[50dvh] resize-y overflow-y-auto"
+          rows={5}
+          placeholder={'Translate the following text to French.\n\n{{selectedText}}'}
+        />
+      </label>
+      <label className="flex flex-col gap-1.5">
+        <span className={FIELD_LABEL_CLASS}>Result</span>
+        <Select
+          value={mode}
+          items={{ replace: 'Replaces the selection', append: 'Inserted below the selection' }}
+          onValueChange={(value) => setValue('mode', value as AiPromptMode)}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectItem value="replace">Replaces the selection</SelectItem>
+              <SelectItem value="append">Inserted below the selection</SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </label>
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button type="submit">{prompt === null ? 'Add prompt' : 'Save'}</Button>
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
Split the form body out of `ai-prompt-dialog.tsx` into `ai-prompt-form.tsx` and load it with `lazy()`, the same pattern as #1238.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a form for creating and editing AI prompts, including label, prompt text, result mode, and save/cancel actions.
  * Prompt labels and text are trimmed before saving.
  * Long prompt text remains scrollable within the dialog viewport.

* **Tests**
  * Added coverage confirming the prompt text area appears when opening the add-prompt dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->