### PR TITLE
feat(capture): save new X bookmarks with public text

### DIFF
--- a/apps/desktop/src-tauri/src/capture.rs
+++ b/apps/desktop/src-tauri/src/capture.rs
@@ -534,22 +534,15 @@ pub async fn capture_meta_fetch(url: String) -> AppResult<String> {
     Ok(String::from_utf8_lossy(&response.body).into_owned())
 }
 
-// ---- oEmbed fetch ---------------------------------------------------------------
+// ---- JSON fetch -----------------------------------------------------------------
 
-/// oEmbed answers are ~1 KB of JSON; anything past this cap is not an oEmbed
-/// answer, and a truncated one would be unparseable, so oversize is an error
-/// rather than a cut.
-const OEMBED_FETCH_MAX_BYTES: usize = 64 * 1024;
+/// JSON responses exceeding the byte cap are rejected rather than truncated.
+const CAPTURE_JSON_MAX_BYTES: usize = 64 * 1024;
 
-/// Fetch an oEmbed endpoint's JSON answer for the capture meta scrape. Which
-/// URLs are oEmbed endpoints is policy and lives in `@reflect/core`
-/// (`actions/oembed`), behind the same privacy gate as `capture_meta_fetch`;
-/// this side only bounds the transport, strictly tighter than the HTML
-/// fetch: https only, JSON only, a small byte cap, and no redirects (oEmbed
-/// endpoints answer directly, so a redirect is a failure).
+/// Fetch bounded HTTPS JSON without following redirects.
 #[tauri::command]
-pub async fn capture_oembed_fetch(url: String) -> AppResult<String> {
-    let response = fetch_capture_json(&url, OEMBED_FETCH_MAX_BYTES).await?;
+pub async fn capture_json_fetch(url: String) -> AppResult<String> {
+    let response = fetch_capture_json(&url, CAPTURE_JSON_MAX_BYTES).await?;
     String::from_utf8(response.body)
         .map_err(|err| AppError::parse(format!("{url} answered non-UTF-8: {err}")))
 }
@@ -573,7 +566,11 @@ mod tests {
         ));
         assert!(matches!(
             classify_fetch_status(url, StatusCode::NOT_FOUND),
-            Some(AppError::Io { .. })
+            Some(AppError::NotFound { .. })
+        ));
+        assert!(matches!(
+            classify_fetch_status(url, StatusCode::GONE),
+            Some(AppError::NotFound { .. })
         ));
         assert!(matches!(
             classify_fetch_status(url, StatusCode::FORBIDDEN),

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -374,7 +374,7 @@ pub fn run() {
             capture::capture_screenshot_promote,
             capture::capture_link_preview,
             capture::capture_meta_fetch,
-            capture::capture_oembed_fetch,
+            capture::capture_json_fetch,
             editor_link_preview::link_preview_fetch_html,
             editor_link_preview::link_preview_fetch_icon,
             git::git_status,

--- a/apps/desktop/src-tauri/src/web_fetch.rs
+++ b/apps/desktop/src-tauri/src/web_fetch.rs
@@ -87,6 +87,9 @@ pub(crate) fn classify_fetch_status(url: &str, status: StatusCode) -> Option<App
         return None;
     }
     let message = format!("{url} answered {status}");
+    if status == StatusCode::NOT_FOUND || status == StatusCode::GONE {
+        return Some(AppError::NotFound { message });
+    }
     if status.is_server_error() || status == StatusCode::TOO_MANY_REQUESTS {
         return Some(AppError::Network { message });
     }

--- a/apps/desktop/src/lib/capture-controller.ts
+++ b/apps/desktop/src/lib/capture-controller.ts
@@ -98,7 +98,11 @@ export function createCaptureController(options: CaptureControllerOptions): Capt
       }
     }
     const isNoteDirty = (path: string): boolean => openSession(path)?.isDirty() === true
-    const drained = await drainCaptureInbox({ generation: options.generation, isStale, isNoteDirty })
+    const drained = await drainCaptureInbox({
+      generation: options.generation,
+      isStale,
+      isNoteDirty,
+    })
     surfaceStop('Saving link capture', drained.stopped)
     if (isStale()) {
       return

--- a/apps/desktop/src/lib/capture-controller.ts
+++ b/apps/desktop/src/lib/capture-controller.ts
@@ -13,6 +13,7 @@ import {
 import { createBackgroundReconciler } from '@/lib/background-reconciler'
 import { startOperation } from '@/lib/operations'
 import { providerFetch } from '@/lib/provider-fetch'
+import { openSession } from '@/editor/open-documents'
 
 /**
  * The link-capture lifecycle for one graph session. Built on
@@ -96,7 +97,8 @@ export function createCaptureController(options: CaptureControllerOptions): Capt
         return
       }
     }
-    const drained = await drainCaptureInbox({ generation: options.generation, isStale })
+    const isNoteDirty = (path: string): boolean => openSession(path)?.isDirty() === true
+    const drained = await drainCaptureInbox({ generation: options.generation, isStale, isNoteDirty })
     surfaceStop('Saving link capture', drained.stopped)
     if (isStale()) {
       return
@@ -106,6 +108,7 @@ export function createCaptureController(options: CaptureControllerOptions): Capt
       generation: options.generation,
       fetchFn: providerFetch,
       isStale,
+      isNoteDirty,
     })
     surfaceStop('Enriching link capture', enriched.stopped)
   }

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -25,6 +25,37 @@ cannot observe the desktop drain.
 
 ## Develop
 
+### Save new X bookmarks
+
+Upgrade the Reflect desktop app, then open **Settings** from the capture popup
+and enable **Save new X bookmarks to Reflect**. This optional permission observes
+new `CreateBookmark` requests on X/Twitter. It saves bookmark intent, including
+requests X later rejects, without reading cookies or request headers. Turning it
+off revokes those host permissions; captures already queued still finish.
+
+Each new capture UUID creates a separate note linked from its capture-day Daily.
+Replaying the same UUID only repairs its backlink and cleanup. The desktop saves
+the URL first, then appends available public text. Long posts may be previews;
+protected/unavailable posts may only have a link. There is no automatic like
+capture, historical import, media download, quote expansion or DOM extraction.
+Manual X captures keep annotations, selection and screenshots; supplied page text
+is saved directly without another text fetch. Private notes and private Daily
+notes block external enrichment, and edited notes stop automatic appends.
+
+The shared extension queue holds 50 captures and drops the oldest when full.
+New captures can evict earlier manual captures during a long offline period.
+An old native host can transport the unchanged v1 envelope, but an old desktop
+still applies its old link-capture behavior. Upgrade desktop before opting in.
+
+For browser acceptance, use an unpacked build and verify button/menu/shortcut
+bookmarks, cancellation, permission denial/revocation, and service worker wake
+after suspension. Only record the operation and post ID, never a full request.
+Then close Reflect, queue a bookmark, reopen it, and verify the note and Daily
+link. These live checks complement the request fixtures; they are not proven by
+offline tests.
+
+### Build and run
+
 ```bash
 pnpm --filter @reflect/extension dev     # wxt dev server (auto-reloads in Chrome)
 pnpm --filter @reflect/extension build   # production build → .output/chrome-mv3
@@ -61,8 +92,8 @@ allowlisted by) the native-messaging host. Check, in order:
    ("Open Reflect and pick a graph first") means the host ran but has no active
    graph to spool into.
 
-The capture is never lost while held — it stays queued and retries automatically
-once the host is reachable.
+Held captures retry automatically once the host is reachable, subject to the
+50-entry queue limit described above.
 
 ## The unpacked ID is pinned — and the store ID is not the same
 

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -7,6 +7,7 @@ import { readIncludePageTextPreference } from '@/lib/popup-preferences'
 import { saveCapture } from '@/lib/save-capture'
 import { snapshotTab } from '@/lib/snapshot-active-tab'
 import { tryExtractPageText } from './popup/extract-page-text'
+import { installXBookmarkListener } from '@/lib/x-bookmarks'
 
 /**
  * The MV3 service worker owns retries and the shortcut fast path. Every
@@ -42,6 +43,7 @@ async function saveTabWithDefaults(tab: Parameters<typeof snapshotTab>[0]): Prom
 }
 
 export default defineBackground(() => {
+  installXBookmarkListener()
   browser.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     if (isFlushRequest(message)) {
       flushQueue().then(sendResponse, (cause: unknown) => {

--- a/apps/extension/entrypoints/options/app.tsx
+++ b/apps/extension/entrypoints/options/app.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState, type ReactElement } from 'react'
+import { browser } from 'wxt/browser'
+import { hasXPermission, setXPermission } from '@/lib/x-permissions'
+
+/** The X bookmark opt-in follows the browser's actual host grants. */
+export function CaptureOptions(): ReactElement {
+  const [enabled, setEnabled] = useState(false)
+  const [busy, setBusy] = useState(true)
+  const [error, setError] = useState('')
+  useEffect(() => {
+    let disposed = false
+    const refresh = (): void => {
+      void hasXPermission().then((granted) => {
+        if (!disposed) setEnabled(granted)
+      }).catch(() => {
+        if (!disposed) setError('Could not read X permissions. Reopen settings to retry.')
+      }).finally(() => {
+        if (!disposed) setBusy(false)
+      })
+    }
+    browser.permissions.onAdded.addListener(refresh)
+    browser.permissions.onRemoved.addListener(refresh)
+    refresh()
+    return () => {
+      disposed = true
+      browser.permissions.onAdded.removeListener(refresh)
+      browser.permissions.onRemoved.removeListener(refresh)
+    }
+  }, [])
+
+  async function toggle(checked: boolean): Promise<void> {
+    setBusy(true)
+    setError('')
+    try {
+      setEnabled(await setXPermission(checked))
+    } catch {
+      setError('Could not change X permissions. Please try again.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <main className="mx-auto flex max-w-lg flex-col gap-4 p-6 text-sm">
+      <h1 className="text-lg font-medium">Reflect Capture</h1>
+      <label className="flex items-center gap-2">
+        <input type="checkbox" checked={enabled} disabled={busy}
+          onChange={(event) => { void toggle(event.target.checked) }}
+          className="size-4 accent-accent focus:ring-focus-ring" />
+        Save new X bookmarks to Reflect
+      </label>
+      <p className="text-text-secondary">
+        Upgrade Reflect before enabling. New bookmark actions save a link to your Daily note,
+        even if X later rejects the action. Reflect adds available public text; long posts may
+        only include a preview. Images and private posts are not downloaded.
+      </p>
+      <p className="text-text-secondary">
+        Each action creates a separate note. Turning this off stops new captures and keeps
+        captures already queued. The shared queue holds 50 captures; older entries are dropped
+        when full.
+      </p>
+      {error ? <p role="alert" className="text-destructive">{error}</p> : null}
+    </main>
+  )
+}

--- a/apps/extension/entrypoints/options/app.tsx
+++ b/apps/extension/entrypoints/options/app.tsx
@@ -10,13 +10,16 @@ export function CaptureOptions(): ReactElement {
   useEffect(() => {
     let disposed = false
     const refresh = (): void => {
-      void hasXPermission().then((granted) => {
-        if (!disposed) setEnabled(granted)
-      }).catch(() => {
-        if (!disposed) setError('Could not read X permissions. Reopen settings to retry.')
-      }).finally(() => {
-        if (!disposed) setBusy(false)
-      })
+      void hasXPermission()
+        .then((granted) => {
+          if (!disposed) setEnabled(granted)
+        })
+        .catch(() => {
+          if (!disposed) setError('Could not read X permissions. Reopen settings to retry.')
+        })
+        .finally(() => {
+          if (!disposed) setBusy(false)
+        })
     }
     browser.permissions.onAdded.addListener(refresh)
     browser.permissions.onRemoved.addListener(refresh)
@@ -44,22 +47,31 @@ export function CaptureOptions(): ReactElement {
     <main className="mx-auto flex max-w-lg flex-col gap-4 p-6 text-sm">
       <h1 className="text-lg font-medium">Reflect Capture</h1>
       <label className="flex items-center gap-2">
-        <input type="checkbox" checked={enabled} disabled={busy}
-          onChange={(event) => { void toggle(event.target.checked) }}
-          className="size-4 accent-accent focus:ring-focus-ring" />
+        <input
+          type="checkbox"
+          checked={enabled}
+          disabled={busy}
+          onChange={(event) => {
+            void toggle(event.target.checked)
+          }}
+          className="size-4 accent-accent focus:ring-focus-ring"
+        />
         Save new X bookmarks to Reflect
       </label>
       <p className="text-text-secondary">
-        Upgrade Reflect before enabling. New bookmark actions save a link to your Daily note,
-        even if X later rejects the action. Reflect adds available public text; long posts may
-        only include a preview. Images and private posts are not downloaded.
+        Upgrade Reflect before enabling. New bookmark actions save a link to your Daily note, even
+        if X later rejects the action. Reflect adds available public text; long posts may only
+        include a preview. Images and private posts are not downloaded.
       </p>
       <p className="text-text-secondary">
-        Each action creates a separate note. Turning this off stops new captures and keeps
-        captures already queued. The shared queue holds 50 captures; older entries are dropped
-        when full.
+        Each action creates a separate note. Turning this off stops new captures and keeps captures
+        already queued. The shared queue holds 50 captures; older entries are dropped when full.
       </p>
-      {error ? <p role="alert" className="text-destructive">{error}</p> : null}
+      {error ? (
+        <p role="alert" className="text-destructive">
+          {error}
+        </p>
+      ) : null}
     </main>
   )
 }

--- a/apps/extension/entrypoints/options/index.html
+++ b/apps/extension/entrypoints/options/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Reflect Capture settings</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/extension/entrypoints/options/main.tsx
+++ b/apps/extension/entrypoints/options/main.tsx
@@ -8,4 +8,8 @@ if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
 }
 const root = document.getElementById('root')
 if (!root) throw new Error('options root element missing')
-createRoot(root).render(<StrictMode><CaptureOptions /></StrictMode>)
+createRoot(root).render(
+  <StrictMode>
+    <CaptureOptions />
+  </StrictMode>,
+)

--- a/apps/extension/entrypoints/options/main.tsx
+++ b/apps/extension/entrypoints/options/main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { CaptureOptions } from './app'
+import './style.css'
+
+if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+  document.documentElement.classList.add('dark')
+}
+const root = document.getElementById('root')
+if (!root) throw new Error('options root element missing')
+createRoot(root).render(<StrictMode><CaptureOptions /></StrictMode>)

--- a/apps/extension/entrypoints/options/style.css
+++ b/apps/extension/entrypoints/options/style.css
@@ -1,0 +1,5 @@
+@import '../popup/style.css';
+
+body {
+  width: auto;
+}

--- a/apps/extension/entrypoints/popup/app.tsx
+++ b/apps/extension/entrypoints/popup/app.tsx
@@ -131,8 +131,14 @@ export function CapturePopup(): ReactElement {
 
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-3 p-3">
-      <a href={browser.runtime.getURL('/options.html')} target="_blank" rel="noreferrer"
-        className="self-end text-xs text-text-muted underline">Settings</a>
+      <a
+        href={browser.runtime.getURL('/options.html')}
+        target="_blank"
+        rel="noreferrer"
+        className="self-end text-xs text-text-muted underline"
+      >
+        Settings
+      </a>
       {page.screenshotDataUrl ? (
         <img
           src={page.screenshotDataUrl}

--- a/apps/extension/entrypoints/popup/app.tsx
+++ b/apps/extension/entrypoints/popup/app.tsx
@@ -131,6 +131,8 @@ export function CapturePopup(): ReactElement {
 
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-3 p-3">
+      <a href={browser.runtime.getURL('/options.html')} target="_blank" rel="noreferrer"
+        className="self-end text-xs text-text-muted underline">Settings</a>
       {page.screenshotDataUrl ? (
         <img
           src={page.screenshotDataUrl}

--- a/apps/extension/lib/x-bookmarks.test.ts
+++ b/apps/extension/lib/x-bookmarks.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Browser } from 'wxt/browser'
+import { captureWireMessageSchema } from '@reflect/core/capture-envelope'
+import { bookmarkId, captureXBookmark, installXBookmarkListener } from './x-bookmarks'
+import { hasXPermission, setXPermission, X_ORIGINS } from './x-permissions'
+
+const mocks = vi.hoisted(() => ({
+  contains: vi.fn(), request: vi.fn(), remove: vi.fn(), addListener: vi.fn(),
+  enqueue: vi.fn(), flush: vi.fn(),
+}))
+vi.mock('wxt/browser', () => ({ browser: {
+  permissions: { contains: mocks.contains, request: mocks.request, remove: mocks.remove },
+  webRequest: { onBeforeRequest: { addListener: mocks.addListener } },
+} }))
+vi.mock('./flush', () => ({ enqueueCapture: mocks.enqueue, flushQueue: mocks.flush }))
+
+const REQUEST: Browser.webRequest.OnBeforeRequestDetails = {
+  url: 'https://x.com/i/api/graphql/operation-hash/CreateBookmark',
+  method: 'POST', initiator: 'https://x.com', requestId: 'request-1', frameId: 0,
+  parentFrameId: -1, tabId: -1, timeStamp: 0, type: 'xmlhttprequest',
+  requestBody: { raw: [{ bytes: new TextEncoder().encode('{"variables":{"tweet_id":"1234567890123456789"}}').buffer }] },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.contains.mockResolvedValue(true)
+  mocks.enqueue.mockResolvedValue(undefined)
+  mocks.flush.mockResolvedValue(undefined)
+})
+
+describe('bookmark request capture', () => {
+  it('registers synchronously without a permission read or blocking listener', () => {
+    installXBookmarkListener()
+    expect(mocks.addListener).toHaveBeenCalledWith(expect.any(Function), { urls: [
+      'https://x.com/i/api/graphql/*/CreateBookmark',
+      'https://twitter.com/i/api/graphql/*/CreateBookmark',
+    ] }, ['requestBody'])
+    expect(mocks.contains).not.toHaveBeenCalled()
+  })
+
+  it('persists a plain v1 envelope before flushing, including requests with no tab', async () => {
+    await captureXBookmark(REQUEST)
+    const wire = captureWireMessageSchema.parse(mocks.enqueue.mock.calls[0]?.[0])
+    expect(wire.envelope).toMatchObject({ version: 1, url: 'https://x.com/i/status/1234567890123456789', source: 'extension' })
+    expect(Object.keys(wire.envelope).sort()).toEqual(['capturedAt', 'id', 'source', 'title', 'url', 'version'])
+    expect(mocks.enqueue.mock.invocationCallOrder[0]).toBeLessThan(mocks.flush.mock.invocationCallOrder[0] ?? 0)
+  })
+
+  it('keeps distinct request observations independent', async () => {
+    await captureXBookmark(REQUEST)
+    await captureXBookmark(REQUEST)
+    const first = captureWireMessageSchema.parse(mocks.enqueue.mock.calls[0]?.[0])
+    const second = captureWireMessageSchema.parse(mocks.enqueue.mock.calls[1]?.[0])
+    expect(first.envelope.id).not.toBe(second.envelope.id)
+  })
+
+  it.each([
+    { method: 'GET' }, { initiator: 'https://example.com' }, { initiator: 'null' },
+    { url: REQUEST.url.replace('CreateBookmark', 'DeleteBookmark') },
+    { url: REQUEST.url.replace('CreateBookmark', 'FavoriteTweet') },
+    { url: REQUEST.url.replace('x.com', 'x.com.evil.com') },
+  ])('ignores unrelated request %j', async (overrides) => {
+    await captureXBookmark({ ...REQUEST, ...overrides })
+    expect(mocks.enqueue).not.toHaveBeenCalled()
+  })
+
+  it('does not enqueue after revocation or partial permission grants', async () => {
+    mocks.contains.mockResolvedValue(false)
+    await captureXBookmark(REQUEST)
+    expect(mocks.enqueue).not.toHaveBeenCalled()
+  })
+
+  it('does not flush a failed durable enqueue', async () => {
+    mocks.enqueue.mockRejectedValueOnce(new Error('storage full'))
+    await expect(captureXBookmark(REQUEST)).rejects.toThrow('storage full')
+    expect(mocks.flush).not.toHaveBeenCalled()
+  })
+
+  it('joins raw chunks before decoding split UTF-8', () => {
+    const bytes = new TextEncoder().encode('{"label":"😀","variables":{"tweet_id":"123"}}')
+    const start = bytes.indexOf(0xf0) + 2
+    expect(bookmarkId({ raw: [{ bytes: bytes.slice(0, start).buffer }, { bytes: bytes.slice(start).buffer }] })).toBe('123')
+  })
+
+  it.each([
+    undefined, { error: 'unavailable' }, { raw: [{ file: '' }] },
+    { raw: [{ bytes: new ArrayBuffer(65 * 1024) }] },
+    { raw: [{ bytes: new Uint8Array([0xff]).buffer }] },
+    { raw: [{ bytes: new TextEncoder().encode('{"variables":{"tweet_id":123}}').buffer }] },
+  ])('ignores unavailable or invalid raw bodies', (body) => {
+    expect(bookmarkId(body)).toBeNull()
+  })
+})
+
+describe('X permission opt-in', () => {
+  it('requests from the gesture before any asynchronous permission lookup', async () => {
+    mocks.request.mockResolvedValue(false)
+    mocks.contains.mockResolvedValue(false)
+    const toggled = setXPermission(true)
+    expect(mocks.request).toHaveBeenCalledWith({ origins: X_ORIGINS })
+    expect(mocks.contains).not.toHaveBeenCalled()
+    expect(await toggled).toBe(false)
+  })
+  it('revokes both origins and reads the resulting grant', async () => {
+    mocks.remove.mockResolvedValue(true)
+    mocks.contains.mockResolvedValue(false)
+    expect(await setXPermission(false)).toBe(false)
+    expect(mocks.remove).toHaveBeenCalledWith({ origins: X_ORIGINS })
+    expect(await hasXPermission()).toBe(false)
+  })
+})

--- a/apps/extension/lib/x-bookmarks.test.ts
+++ b/apps/extension/lib/x-bookmarks.test.ts
@@ -5,20 +5,38 @@ import { bookmarkId, captureXBookmark, installXBookmarkListener } from './x-book
 import { hasXPermission, setXPermission, X_ORIGINS } from './x-permissions'
 
 const mocks = vi.hoisted(() => ({
-  contains: vi.fn(), request: vi.fn(), remove: vi.fn(), addListener: vi.fn(),
-  enqueue: vi.fn(), flush: vi.fn(),
+  contains: vi.fn(),
+  request: vi.fn(),
+  remove: vi.fn(),
+  addListener: vi.fn(),
+  enqueue: vi.fn(),
+  flush: vi.fn(),
 }))
-vi.mock('wxt/browser', () => ({ browser: {
-  permissions: { contains: mocks.contains, request: mocks.request, remove: mocks.remove },
-  webRequest: { onBeforeRequest: { addListener: mocks.addListener } },
-} }))
+vi.mock('wxt/browser', () => ({
+  browser: {
+    permissions: { contains: mocks.contains, request: mocks.request, remove: mocks.remove },
+    webRequest: { onBeforeRequest: { addListener: mocks.addListener } },
+  },
+}))
 vi.mock('./flush', () => ({ enqueueCapture: mocks.enqueue, flushQueue: mocks.flush }))
 
 const REQUEST: Browser.webRequest.OnBeforeRequestDetails = {
   url: 'https://x.com/i/api/graphql/operation-hash/CreateBookmark',
-  method: 'POST', initiator: 'https://x.com', requestId: 'request-1', frameId: 0,
-  parentFrameId: -1, tabId: -1, timeStamp: 0, type: 'xmlhttprequest',
-  requestBody: { raw: [{ bytes: new TextEncoder().encode('{"variables":{"tweet_id":"1234567890123456789"}}').buffer }] },
+  method: 'POST',
+  initiator: 'https://x.com',
+  requestId: 'request-1',
+  frameId: 0,
+  parentFrameId: -1,
+  tabId: -1,
+  timeStamp: 0,
+  type: 'xmlhttprequest',
+  requestBody: {
+    raw: [
+      {
+        bytes: new TextEncoder().encode('{"variables":{"tweet_id":"1234567890123456789"}}').buffer,
+      },
+    ],
+  },
 }
 
 beforeEach(() => {
@@ -31,19 +49,38 @@ beforeEach(() => {
 describe('bookmark request capture', () => {
   it('registers synchronously without a permission read or blocking listener', () => {
     installXBookmarkListener()
-    expect(mocks.addListener).toHaveBeenCalledWith(expect.any(Function), { urls: [
-      'https://x.com/i/api/graphql/*/CreateBookmark',
-      'https://twitter.com/i/api/graphql/*/CreateBookmark',
-    ] }, ['requestBody'])
+    expect(mocks.addListener).toHaveBeenCalledWith(
+      expect.any(Function),
+      {
+        urls: [
+          'https://x.com/i/api/graphql/*/CreateBookmark',
+          'https://twitter.com/i/api/graphql/*/CreateBookmark',
+        ],
+      },
+      ['requestBody'],
+    )
     expect(mocks.contains).not.toHaveBeenCalled()
   })
 
   it('persists a plain v1 envelope before flushing, including requests with no tab', async () => {
     await captureXBookmark(REQUEST)
     const wire = captureWireMessageSchema.parse(mocks.enqueue.mock.calls[0]?.[0])
-    expect(wire.envelope).toMatchObject({ version: 1, url: 'https://x.com/i/status/1234567890123456789', source: 'extension' })
-    expect(Object.keys(wire.envelope).sort()).toEqual(['capturedAt', 'id', 'source', 'title', 'url', 'version'])
-    expect(mocks.enqueue.mock.invocationCallOrder[0]).toBeLessThan(mocks.flush.mock.invocationCallOrder[0] ?? 0)
+    expect(wire.envelope).toMatchObject({
+      version: 1,
+      url: 'https://x.com/i/status/1234567890123456789',
+      source: 'extension',
+    })
+    expect(Object.keys(wire.envelope).sort()).toEqual([
+      'capturedAt',
+      'id',
+      'source',
+      'title',
+      'url',
+      'version',
+    ])
+    expect(mocks.enqueue.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.flush.mock.invocationCallOrder[0] ?? 0,
+    )
   })
 
   it('keeps distinct request observations independent', async () => {
@@ -55,7 +92,9 @@ describe('bookmark request capture', () => {
   })
 
   it.each([
-    { method: 'GET' }, { initiator: 'https://example.com' }, { initiator: 'null' },
+    { method: 'GET' },
+    { initiator: 'https://example.com' },
+    { initiator: 'null' },
     { url: REQUEST.url.replace('CreateBookmark', 'DeleteBookmark') },
     { url: REQUEST.url.replace('CreateBookmark', 'FavoriteTweet') },
     { url: REQUEST.url.replace('x.com', 'x.com.evil.com') },
@@ -79,11 +118,17 @@ describe('bookmark request capture', () => {
   it('joins raw chunks before decoding split UTF-8', () => {
     const bytes = new TextEncoder().encode('{"label":"😀","variables":{"tweet_id":"123"}}')
     const start = bytes.indexOf(0xf0) + 2
-    expect(bookmarkId({ raw: [{ bytes: bytes.slice(0, start).buffer }, { bytes: bytes.slice(start).buffer }] })).toBe('123')
+    expect(
+      bookmarkId({
+        raw: [{ bytes: bytes.slice(0, start).buffer }, { bytes: bytes.slice(start).buffer }],
+      }),
+    ).toBe('123')
   })
 
   it.each([
-    undefined, { error: 'unavailable' }, { raw: [{ file: '' }] },
+    undefined,
+    { error: 'unavailable' },
+    { raw: [{ file: '' }] },
     { raw: [{ bytes: new ArrayBuffer(65 * 1024) }] },
     { raw: [{ bytes: new Uint8Array([0xff]).buffer }] },
     { raw: [{ bytes: new TextEncoder().encode('{"variables":{"tweet_id":123}}').buffer }] },

--- a/apps/extension/lib/x-bookmarks.ts
+++ b/apps/extension/lib/x-bookmarks.ts
@@ -9,7 +9,9 @@ const bookmarkBody = z.object({ variables: z.object({ tweet_id: z.string().regex
 const BOOKMARK_PATH = /^\/i\/api\/graphql\/[^/]+\/CreateBookmark$/
 
 /** Extract the bookmark ID from bounded raw request chunks. */
-export function bookmarkId(body: Browser.webRequest.OnBeforeRequestDetails['requestBody']): string | null {
+export function bookmarkId(
+  body: Browser.webRequest.OnBeforeRequestDetails['requestBody'],
+): string | null {
   if (!body || body.error || !body.raw?.length) return null
   const chunks: Uint8Array[] = []
   let size = 0
@@ -35,18 +37,28 @@ export function bookmarkId(body: Browser.webRequest.OnBeforeRequestDetails['requ
 }
 
 /** Enqueue bookmark intent using the existing v1 capture protocol. */
-export async function captureXBookmark(details: Browser.webRequest.OnBeforeRequestDetails): Promise<void> {
+export async function captureXBookmark(
+  details: Browser.webRequest.OnBeforeRequestDetails,
+): Promise<void> {
   if (details.method !== 'POST') return
   const url = new URL(details.url)
-  if (!['https://x.com', 'https://twitter.com'].includes(url.origin)
-    || !BOOKMARK_PATH.test(url.pathname)
-    || !details.initiator || !['https://x.com', 'https://twitter.com'].includes(details.initiator)) return
+  if (
+    !['https://x.com', 'https://twitter.com'].includes(url.origin) ||
+    !BOOKMARK_PATH.test(url.pathname) ||
+    !details.initiator ||
+    !['https://x.com', 'https://twitter.com'].includes(details.initiator)
+  )
+    return
   const postId = bookmarkId(details.requestBody)
   if (postId === null) return
   const wire: CaptureWireMessage = {
     envelope: {
-      version: 1, id: crypto.randomUUID(), url: xPostURL(postId),
-      title: `X post ${postId}`, capturedAt: new Date().toISOString(), source: 'extension',
+      version: 1,
+      id: crypto.randomUUID(),
+      url: xPostURL(postId),
+      title: `X post ${postId}`,
+      capturedAt: new Date().toISOString(),
+      source: 'extension',
     },
   }
   if (!(await hasXPermission())) return
@@ -60,10 +72,12 @@ export function installXBookmarkListener(): void {
     (details) => {
       void captureXBookmark(details).catch(() => console.error('X bookmark capture failed'))
     },
-    { urls: [
-      'https://x.com/i/api/graphql/*/CreateBookmark',
-      'https://twitter.com/i/api/graphql/*/CreateBookmark',
-    ] },
+    {
+      urls: [
+        'https://x.com/i/api/graphql/*/CreateBookmark',
+        'https://twitter.com/i/api/graphql/*/CreateBookmark',
+      ],
+    },
     ['requestBody'],
   )
 }

--- a/apps/extension/lib/x-bookmarks.ts
+++ b/apps/extension/lib/x-bookmarks.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod'
+import { browser, type Browser } from 'wxt/browser'
+import { X_POST_ID, xPostURL } from '@reflect/core/x-post'
+import type { CaptureWireMessage } from '@reflect/core/capture-envelope'
+import { enqueueCapture, flushQueue } from './flush'
+import { hasXPermission } from './x-permissions'
+
+const bookmarkBody = z.object({ variables: z.object({ tweet_id: z.string().regex(X_POST_ID) }) })
+const BOOKMARK_PATH = /^\/i\/api\/graphql\/[^/]+\/CreateBookmark$/
+
+/** Extract the bookmark ID from bounded raw request chunks. */
+export function bookmarkId(body: Browser.webRequest.OnBeforeRequestDetails['requestBody']): string | null {
+  if (!body || body.error || !body.raw?.length) return null
+  const chunks: Uint8Array[] = []
+  let size = 0
+  for (const part of body.raw) {
+    if (part.file !== undefined || !part.bytes) return null
+    size += part.bytes.byteLength
+    if (size > 64 * 1024) return null
+    chunks.push(new Uint8Array(part.bytes))
+  }
+  const bytes = new Uint8Array(size)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.length
+  }
+  try {
+    const json: unknown = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes))
+    const parsed = bookmarkBody.safeParse(json)
+    return parsed.success ? parsed.data.variables.tweet_id : null
+  } catch {
+    return null
+  }
+}
+
+/** Enqueue bookmark intent using the existing v1 capture protocol. */
+export async function captureXBookmark(details: Browser.webRequest.OnBeforeRequestDetails): Promise<void> {
+  if (details.method !== 'POST') return
+  const url = new URL(details.url)
+  if (!['https://x.com', 'https://twitter.com'].includes(url.origin)
+    || !BOOKMARK_PATH.test(url.pathname)
+    || !details.initiator || !['https://x.com', 'https://twitter.com'].includes(details.initiator)) return
+  const postId = bookmarkId(details.requestBody)
+  if (postId === null) return
+  const wire: CaptureWireMessage = {
+    envelope: {
+      version: 1, id: crypto.randomUUID(), url: xPostURL(postId),
+      title: `X post ${postId}`, capturedAt: new Date().toISOString(), source: 'extension',
+    },
+  }
+  if (!(await hasXPermission())) return
+  await enqueueCapture(wire)
+  await flushQueue()
+}
+
+/** Register synchronously so a suspended worker can wake for the next request. */
+export function installXBookmarkListener(): void {
+  browser.webRequest.onBeforeRequest.addListener(
+    (details) => {
+      void captureXBookmark(details).catch(() => console.error('X bookmark capture failed'))
+    },
+    { urls: [
+      'https://x.com/i/api/graphql/*/CreateBookmark',
+      'https://twitter.com/i/api/graphql/*/CreateBookmark',
+    ] },
+    ['requestBody'],
+  )
+}

--- a/apps/extension/lib/x-permissions.ts
+++ b/apps/extension/lib/x-permissions.ts
@@ -1,0 +1,16 @@
+import { browser } from 'wxt/browser'
+
+/** X host grants are the bookmark capture opt-in. */
+export const X_ORIGINS = ['https://x.com/*', 'https://twitter.com/*']
+
+/** Both origins are required so partial grants never silently enable capture. */
+export function hasXPermission(): Promise<boolean> {
+  return browser.permissions.contains({ origins: X_ORIGINS })
+}
+
+/** Change the host grant directly from a user gesture. */
+export async function setXPermission(enabled: boolean): Promise<boolean> {
+  if (enabled) await browser.permissions.request({ origins: X_ORIGINS })
+  else await browser.permissions.remove({ origins: X_ORIGINS })
+  return hasXPermission()
+}

--- a/apps/extension/lib/x-permissions.ts
+++ b/apps/extension/lib/x-permissions.ts
@@ -12,5 +12,5 @@ export function hasXPermission(): Promise<boolean> {
 export async function setXPermission(enabled: boolean): Promise<boolean> {
   if (enabled) await browser.permissions.request({ origins: X_ORIGINS })
   else await browser.permissions.remove({ origins: X_ORIGINS })
-  return hasXPermission()
+  return await hasXPermission()
 }

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -44,7 +44,9 @@ export default defineConfig({
       'storage',
       'unlimitedStorage',
       'alarms',
+      'webRequest',
     ],
+    optional_host_permissions: ['https://x.com/*', 'https://twitter.com/*'],
     commands: {
       [SAVE_CURRENT_PAGE_COMMAND]: {
         suggested_key: { default: 'Ctrl+Shift+K', mac: 'Command+Shift+K' },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,8 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./capture-envelope": "./src/actions/capture-envelope.ts"
+    "./capture-envelope": "./src/actions/capture-envelope.ts",
+    "./x-post": "./src/actions/x-post.ts"
   },
   "scripts": {
     "test": "vitest run --config ../../vitest.config.ts --project core-browser --project core-node"

--- a/packages/core/src/actions/capture-drain.ts
+++ b/packages/core/src/actions/capture-drain.ts
@@ -22,6 +22,8 @@ import { sectionEnd, topLevelHeadings } from '../markdown/heading-blocks'
 import { parseFrontmatter, splitFrontmatter } from '../markdown/frontmatter'
 import type { ReconcileStop } from './audio-memo'
 import { ensureBacklinkTarget } from './backlink-target'
+import { drainXCapture } from './x-capture'
+import { xPostId } from './x-post'
 import {
   captureFromPath,
   captureIdentity,
@@ -54,6 +56,8 @@ const SCREENSHOT_MAX_DIM = 1600
 const ORPHAN_SPOOL_MAX_AGE_MS = 60 * 60 * 1000
 
 export interface DrainCaptureInboxInput {
+  /** Defer capture writes while an editor holds unsaved changes. */
+  isNoteDirty?: (path: string) => boolean
   /** `GraphInfo.generation` — pins every read and write to the issuing graph. */
   generation: number
   /** Abort gate, checked between spool files (graph switch / unmount). */
@@ -196,6 +200,11 @@ export async function drainCaptureInbox(
         await drainTextCapture(envelope, input.generation)
         await captureInboxRemove(name, input.generation)
         drained += 1
+        continue
+      }
+      const postId = xPostId(envelope.url)
+      if (postId !== null) {
+        if ((await drainXCapture(envelope, name, postId, input)) === 'saved') drained += 1
         continue
       }
       const fresh = captureIdentity(new Date(envelope.capturedAt), envelope.id)

--- a/packages/core/src/actions/capture-enrichment-write.ts
+++ b/packages/core/src/actions/capture-enrichment-write.ts
@@ -6,6 +6,7 @@ import { parseNote } from '../markdown/extract'
 import { parseFrontmatter, splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
 import type { AiProviderConfig } from '../settings/schema'
 import type { CaptureIdentity } from './capture-identity'
+import { isXCapturePath, xCaptureFrontmatter, xCaptureMeta, type XCaptureMeta } from './x-capture-note'
 import {
   captureNoteMeta,
   notePrivate,
@@ -31,6 +32,8 @@ export interface PendingCaptureSnapshot {
 }
 
 interface PersistCaptureEnrichmentInput {
+  expectedCapture?: Pick<XCaptureMeta, 'captureKind' | 'captureDay' | 'captureUrl'>
+  canWrite?: () => boolean
   identity: CaptureIdentity
   expectedHash: string
   body: string
@@ -62,8 +65,9 @@ export async function readPendingCaptureSnapshot(
     throw cause
   }
   const split = splitFrontmatter(source)
-  const frontmatter = parseFrontmatter(split.raw).data
-  const meta = captureNoteMeta(frontmatter)
+  const isX = isXCapturePath(identity.notePath)
+  const frontmatter = isX ? xCaptureFrontmatter(source) : parseFrontmatter(split.raw).data
+  const meta = isX ? xCaptureMeta(source) : captureNoteMeta(frontmatter)
   if (meta === null || meta.captureStatus !== 'pending') {
     return null
   }
@@ -166,6 +170,12 @@ export async function persistCaptureEnrichment(
   const captureHash = await hashContent(input.body)
   const snapshot = await readPendingCaptureSnapshot(input.identity, input.generation)
   const dailySource = await noteSource(dailyPath(input.identity.date), input.generation)
+  const expected = input.expectedCapture
+  if (expected && (xCaptureFrontmatter(dailySource).private
+    || snapshot?.meta.captureKind !== expected.captureKind
+    || snapshot.meta.captureDay !== expected.captureDay
+    || snapshot.meta.captureUrl !== expected.captureUrl
+    || input.identity.date !== expected.captureDay)) return null
   if (
     snapshot === null ||
     snapshot.title !== input.fromTitle ||
@@ -177,6 +187,7 @@ export async function persistCaptureEnrichment(
   }
   const reassembled = snapshot.source.slice(0, snapshot.bodyOffset) + input.body
   const titleChanged = input.toTitle !== input.fromTitle
+  if (input.canWrite?.() === false) return null
   await writeNote(
     input.identity.notePath,
     upsertFrontmatter(reassembled, {

--- a/packages/core/src/actions/capture-enrichment-write.ts
+++ b/packages/core/src/actions/capture-enrichment-write.ts
@@ -6,7 +6,12 @@ import { parseNote } from '../markdown/extract'
 import { parseFrontmatter, splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
 import type { AiProviderConfig } from '../settings/schema'
 import type { CaptureIdentity } from './capture-identity'
-import { isXCapturePath, xCaptureFrontmatter, xCaptureMeta, type XCaptureMeta } from './x-capture-note'
+import {
+  isXCapturePath,
+  xCaptureFrontmatter,
+  xCaptureMeta,
+  type XCaptureMeta,
+} from './x-capture-note'
 import {
   captureNoteMeta,
   notePrivate,
@@ -171,11 +176,15 @@ export async function persistCaptureEnrichment(
   const snapshot = await readPendingCaptureSnapshot(input.identity, input.generation)
   const dailySource = await noteSource(dailyPath(input.identity.date), input.generation)
   const expected = input.expectedCapture
-  if (expected && (xCaptureFrontmatter(dailySource).private
-    || snapshot?.meta.captureKind !== expected.captureKind
-    || snapshot.meta.captureDay !== expected.captureDay
-    || snapshot.meta.captureUrl !== expected.captureUrl
-    || input.identity.date !== expected.captureDay)) return null
+  if (
+    expected &&
+    (xCaptureFrontmatter(dailySource).private ||
+      snapshot?.meta.captureKind !== expected.captureKind ||
+      snapshot.meta.captureDay !== expected.captureDay ||
+      snapshot.meta.captureUrl !== expected.captureUrl ||
+      input.identity.date !== expected.captureDay)
+  )
+    return null
   if (
     snapshot === null ||
     snapshot.title !== input.fromTitle ||

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -65,11 +65,16 @@ export async function listPendingCaptures(generation: number): Promise<CaptureId
       if (isAppError(cause) && cause.kind === 'notFound') continue
       throw cause
     }
-    const meta = isX ? xCaptureMeta(source) : captureNoteMeta(parseFrontmatter(splitFrontmatter(source).raw).data)
+    const meta = isX
+      ? xCaptureMeta(source)
+      : captureNoteMeta(parseFrontmatter(splitFrontmatter(source).raw).data)
     const identity = isX ? xCaptureFromSource(file.path, source) : legacy
     if (identity && meta?.captureStatus === 'pending') pending.push(identity)
   }
-  pending.sort((first, second) => first.date.localeCompare(second.date) || first.base.localeCompare(second.base))
+  pending.sort(
+    (first, second) =>
+      first.date.localeCompare(second.date) || first.base.localeCompare(second.base),
+  )
   return pending
 }
 

--- a/packages/core/src/actions/capture-enrichment.ts
+++ b/packages/core/src/actions/capture-enrichment.ts
@@ -44,6 +44,8 @@ import {
 } from './capture-note'
 import type { PageMeta } from '../link-preview/metadata'
 import { scrapePageMeta } from './meta-scrape'
+import { enrichXCapture } from './x-capture'
+import { isXCapturePath, xCaptureFromSource, xCaptureMeta } from './x-capture-note'
 
 /**
  * Capture notes still awaiting enrichment, oldest first: well-formed capture
@@ -51,30 +53,29 @@ import { scrapePageMeta } from './meta-scrape'
  */
 export async function listPendingCaptures(generation: number): Promise<CaptureIdentity[]> {
   const files = await listFiles(generation)
-  const candidates = files
-    .map((file) => captureFromPath(file.path))
-    .filter((identity): identity is CaptureIdentity => identity !== null)
-    .sort((first, second) => first.base.localeCompare(second.base))
   const pending: CaptureIdentity[] = []
-  for (const identity of candidates) {
+  for (const file of files) {
+    const isX = isXCapturePath(file.path)
+    const legacy = captureFromPath(file.path)
+    if (!isX && legacy === null) continue
     let source: string
     try {
-      source = await readNote(identity.notePath, generation)
+      source = await readNote(file.path, generation)
     } catch (cause) {
-      if (isAppError(cause) && cause.kind === 'notFound') {
-        continue
-      }
+      if (isAppError(cause) && cause.kind === 'notFound') continue
       throw cause
     }
-    const meta = captureNoteMeta(parseFrontmatter(splitFrontmatter(source).raw).data)
-    if (meta?.captureStatus === 'pending') {
-      pending.push(identity)
-    }
+    const meta = isX ? xCaptureMeta(source) : captureNoteMeta(parseFrontmatter(splitFrontmatter(source).raw).data)
+    const identity = isX ? xCaptureFromSource(file.path, source) : legacy
+    if (identity && meta?.captureStatus === 'pending') pending.push(identity)
   }
+  pending.sort((first, second) => first.date.localeCompare(second.date) || first.base.localeCompare(second.base))
   return pending
 }
 
 export interface ReconcileCaptureEnrichmentInput {
+  /** Defer capture writes while an editor holds unsaved changes. */
+  isNoteDirty?: (path: string) => boolean
   /** The configured-providers state — decides the provider and keychain entry. */
   providers: AiProvidersState
   /** `GraphInfo.generation` — pins every read and write to the issuing graph. */
@@ -196,17 +197,22 @@ export async function reconcileCaptureEnrichment(
   const config = defaultAiProvider(input.providers)
   let apiKey: string | null = null
   let providerStop: ReconcileStop | null = null
-  if (config !== null) {
-    try {
-      apiKey = await aiApiKeyForConfig(config)
-    } catch (cause) {
-      const error = toAppError(cause)
-      providerStop = { reason: error.kind, message: error.message }
-    }
-    if (apiKey === null && providerStop === null) {
-      providerStop = {
-        reason: 'config',
-        message: `The API key for the configured ${config.provider} model is missing from the keychain.`,
+  let providerLoaded = false
+  async function loadProvider(): Promise<void> {
+    if (providerLoaded) return
+    providerLoaded = true
+    if (config !== null) {
+      try {
+        apiKey = await aiApiKeyForConfig(config)
+      } catch (cause) {
+        const error = toAppError(cause)
+        providerStop = { reason: error.kind, message: error.message }
+      }
+      if (apiKey === null && providerStop === null) {
+        providerStop = {
+          reason: 'config',
+          message: `The API key for the configured ${config.provider} model is missing from the keychain.`,
+        }
       }
     }
   }
@@ -266,6 +272,13 @@ export async function reconcileCaptureEnrichment(
       return outcome({ reason: 'stale', message: 'the graph session ended mid-pass' })
     }
     try {
+      if (isXCapturePath(identity.notePath)) {
+        const result = await enrichXCapture(identity, input)
+        if (result === 'enriched') enriched += 1
+        if (result === 'skipped') skipped += 1
+        continue
+      }
+      await loadProvider()
       let snapshot = await currentCapture(identity)
       if (snapshot === null) {
         continue

--- a/packages/core/src/actions/capture-note.ts
+++ b/packages/core/src/actions/capture-note.ts
@@ -21,6 +21,8 @@ export { notePrivate } from '../privacy/checkers'
 export type CaptureStatus = 'pending' | 'done' | 'skipped'
 
 const captureNoteMetaSchema = z.object({
+  captureKind: z.literal('x-text').optional(),
+  captureDay: z.iso.date().optional(),
   captureUrl: z.string(),
   captureStatus: z.enum(['pending', 'done', 'skipped']),
   /** The metadata attempt completed, including a permanently unsuitable page. */

--- a/packages/core/src/actions/meta-scrape-routing.test.ts
+++ b/packages/core/src/actions/meta-scrape-routing.test.ts
@@ -1,14 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ReflectError } from '../errors'
-import { captureMetaFetch, captureOEmbedFetch } from '../graph/commands'
+import { captureMetaFetch, captureJsonFetch } from '../graph/commands'
 import { scrapePageMeta } from './meta-scrape'
 
 vi.mock('../graph/commands', () => ({
   captureMetaFetch: vi.fn(),
-  captureOEmbedFetch: vi.fn(),
+  captureJsonFetch: vi.fn(),
 }))
 
-const oembedFetchMock = vi.mocked(captureOEmbedFetch)
+const oembedFetchMock = vi.mocked(captureJsonFetch)
 const metaFetchMock = vi.mocked(captureMetaFetch)
 
 const VIDEO_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'

--- a/packages/core/src/actions/meta-scrape.ts
+++ b/packages/core/src/actions/meta-scrape.ts
@@ -1,5 +1,5 @@
 import { toAppError } from '../errors'
-import { captureMetaFetch, captureOEmbedFetch } from '../graph/commands'
+import { captureMetaFetch, captureJsonFetch } from '../graph/commands'
 import { normalizePageMetaValue, parsePageMeta, type PageMeta } from '../link-preview/metadata'
 import { oembedRequestURL, parseOEmbedAnswer } from './oembed'
 
@@ -14,7 +14,7 @@ import { oembedRequestURL, parseOEmbedAnswer } from './oembed'
 async function scrapeOEmbed(requestURL: string): Promise<PageMeta | null> {
   let json: string
   try {
-    json = await captureOEmbedFetch(requestURL)
+    json = await captureJsonFetch(requestURL)
   } catch (cause) {
     const kind = toAppError(cause).kind
     if (kind === 'network' || kind === 'auth') {

--- a/packages/core/src/actions/oembed.ts
+++ b/packages/core/src/actions/oembed.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 /**
  * oEmbed policy for link capture: which capture URLs have an oEmbed answer
  * worth asking for, where to ask, and what a valid answer looks like. The
- * Rust `capture_oembed_fetch` primitive only bounds the transport (https,
+ * Rust `capture_json_fetch` primitive only bounds the transport (https,
  * JSON, a small byte cap, no redirects); everything provider-shaped lives
  * here, so supporting another provider is a TypeScript-only change: one more
  * entry in `OEMBED_PROVIDERS`.

--- a/packages/core/src/actions/x-capture-note.ts
+++ b/packages/core/src/actions/x-capture-note.ts
@@ -10,7 +10,8 @@ import { captureNoteMeta, metadataValue, type CaptureNoteMeta } from './capture-
 import { xPostId, xPostURL } from './x-post'
 import type { XText } from './x-syndication'
 
-const X_PATH = /^notes\/capture-x-text-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.md$/
+const X_PATH =
+  /^notes\/capture-x-text-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.md$/
 
 /** Recognize the reserved filename family, including damaged identities. */
 export function isXCapturePath(path: string): boolean {
@@ -42,8 +43,13 @@ export interface XCaptureMeta extends CaptureNoteMeta {
 /** Validate the persisted X lifecycle without interpreting its Markdown body. */
 export function xCaptureMeta(source: string): XCaptureMeta {
   const meta = captureNoteMeta(xCaptureFrontmatter(source))
-  if (!meta || meta.captureKind !== 'x-text' || !meta.captureDay
-    || !z.iso.date().safeParse(meta.captureDay).success || xPostId(meta.captureUrl) === null) {
+  if (
+    !meta ||
+    meta.captureKind !== 'x-text' ||
+    !meta.captureDay ||
+    !z.iso.date().safeParse(meta.captureDay).success ||
+    xPostId(meta.captureUrl) === null
+  ) {
     throw new ReflectError('parse', 'The X capture metadata is missing or invalid.')
   }
   return { ...meta, captureKind: 'x-text', captureDay: meta.captureDay }
@@ -58,7 +64,10 @@ export function xCaptureFromSource(path: string, source: string): CaptureIdentit
 
 /** Quote external plain text without activating Markdown images, HTML or links. */
 export function xPlainMarkdown(text: string): string {
-  return text.replace(/[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]/g, '\\$&')
+  return text.replaceAll(
+    /[\u{21}-\u{2F}\u{3A}-\u{40}\u{5B}-\u{60}\u{7B}-\u{7E}]/gu,
+    String.raw`\$&`,
+  )
 }
 
 /** Render the raw, durable capture once, preserving the user's annotation. */
@@ -78,8 +87,10 @@ export async function xCaptureSource(
     parts.push(`- Description: ${xPlainMarkdown(metadataValue(envelope.metaDescription))}`)
   }
   if (envelope.note?.trim()) parts.push(`## Note\n\n${envelope.note}`)
-  if (envelope.selection?.trim()) parts.push(`## Selection\n\n${xPlainMarkdown(envelope.selection)}`)
-  if (envelope.contentText?.trim()) parts.push(`## Page Text\n\n${xPlainMarkdown(envelope.contentText)}`)
+  if (envelope.selection?.trim())
+    parts.push(`## Selection\n\n${xPlainMarkdown(envelope.selection)}`)
+  if (envelope.contentText?.trim())
+    parts.push(`## Page Text\n\n${xPlainMarkdown(envelope.contentText)}`)
   if (screenshot === 'saved') parts.push(`## Screenshot\n\n![Screenshot](${identity.assetPath})`)
   if (screenshot === 'missing') parts.push('The captured screenshot was unavailable.')
   const body = `${parts.join('\n\n')}\n`
@@ -104,9 +115,13 @@ export function appendXText(body: string, post: XText | null): string {
   if (post === null) {
     parts.push('No public text was available. Open the original post using the URL above.')
   } else {
-    if (post.author) parts.push(`Author: ${xPlainMarkdown(post.author.name)} (@${xPlainMarkdown(post.author.handle)})`)
+    if (post.author)
+      parts.push(
+        `Author: ${xPlainMarkdown(post.author.name)} (@${xPlainMarkdown(post.author.handle)})`,
+      )
     parts.push(xPlainMarkdown(post.text))
-    if (post.truncated) parts.push('Only a preview was available. Open the original post for the full text.')
+    if (post.truncated)
+      parts.push('Only a preview was available. Open the original post for the full text.')
   }
   return body + (body.endsWith('\n') ? '\n' : '\n\n') + parts.join('\n\n') + '\n'
 }

--- a/packages/core/src/actions/x-capture-note.ts
+++ b/packages/core/src/actions/x-capture-note.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod'
+import { ReflectError } from '../errors'
+import { assetPath, dailyPath, notePath } from '../graph/paths'
+import { hashContent } from '../indexing/hash'
+import { parseFrontmatter, splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
+import type { Frontmatter } from '../markdown/model'
+import type { CaptureEnvelope } from './capture-envelope'
+import type { CaptureIdentity } from './capture-identity'
+import { captureNoteMeta, metadataValue, type CaptureNoteMeta } from './capture-note'
+import { xPostId, xPostURL } from './x-post'
+import type { XText } from './x-syndication'
+
+const X_PATH = /^notes\/capture-x-text-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.md$/
+
+/** Recognize the reserved filename family, including damaged identities. */
+export function isXCapturePath(path: string): boolean {
+  return path.startsWith('notes/capture-x-text-') && path.endsWith('.md')
+}
+
+/** X delivery identity is independent of the machine's current timezone. */
+export function xCaptureIdentity(id: string, day: string): CaptureIdentity {
+  const base = `capture-x-text-${z.guid().parse(id).toLowerCase()}`
+  dailyPath(day)
+  return { base, date: day, notePath: notePath(base), assetPath: assetPath(`${base}.jpg`) }
+}
+
+/** Broken frontmatter cannot establish permission to enrich a capture. */
+export function xCaptureFrontmatter(source: string): Frontmatter {
+  const split = splitFrontmatter(source)
+  const parsed = parseFrontmatter(split.raw)
+  if (parsed.warning || (split.raw === null && /^---[ \t]*(?:\r?\n|$)/.test(source))) {
+    throw new ReflectError('parse', 'Fix the invalid capture or Daily frontmatter before retrying.')
+  }
+  return parsed.data
+}
+
+export interface XCaptureMeta extends CaptureNoteMeta {
+  captureKind: 'x-text'
+  captureDay: string
+}
+
+/** Validate the persisted X lifecycle without interpreting its Markdown body. */
+export function xCaptureMeta(source: string): XCaptureMeta {
+  const meta = captureNoteMeta(xCaptureFrontmatter(source))
+  if (!meta || meta.captureKind !== 'x-text' || !meta.captureDay
+    || !z.iso.date().safeParse(meta.captureDay).success || xPostId(meta.captureUrl) === null) {
+    throw new ReflectError('parse', 'The X capture metadata is missing or invalid.')
+  }
+  return { ...meta, captureKind: 'x-text', captureDay: meta.captureDay }
+}
+
+/** Recover the first writer's day from an existing UUID note. */
+export function xCaptureFromSource(path: string, source: string): CaptureIdentity {
+  const id = X_PATH.exec(path)?.[1]
+  if (!id) throw new ReflectError('parse', `Invalid X capture filename: ${path}`)
+  return xCaptureIdentity(id, xCaptureMeta(source).captureDay)
+}
+
+/** Quote external plain text without activating Markdown images, HTML or links. */
+export function xPlainMarkdown(text: string): string {
+  return text.replace(/[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]/g, '\\$&')
+}
+
+/** Render the raw, durable capture once, preserving the user's annotation. */
+export async function xCaptureSource(
+  envelope: CaptureEnvelope,
+  identity: CaptureIdentity,
+  postId: string,
+  screenshot: 'none' | 'saved' | 'missing',
+  dailySource: string,
+): Promise<string> {
+  const title = `X post ${postId}`
+  const parts = [`# ${title}`, `- URL: ${xPostURL(postId)}\n- Type: #link`]
+  if (envelope.title.trim() && envelope.title !== title) {
+    parts.push(`- Page title: ${xPlainMarkdown(metadataValue(envelope.title))}`)
+  }
+  if (envelope.metaDescription?.trim()) {
+    parts.push(`- Description: ${xPlainMarkdown(metadataValue(envelope.metaDescription))}`)
+  }
+  if (envelope.note?.trim()) parts.push(`## Note\n\n${envelope.note}`)
+  if (envelope.selection?.trim()) parts.push(`## Selection\n\n${xPlainMarkdown(envelope.selection)}`)
+  if (envelope.contentText?.trim()) parts.push(`## Page Text\n\n${xPlainMarkdown(envelope.contentText)}`)
+  if (screenshot === 'saved') parts.push(`## Screenshot\n\n![Screenshot](${identity.assetPath})`)
+  if (screenshot === 'missing') parts.push('The captured screenshot was unavailable.')
+  const body = `${parts.join('\n\n')}\n`
+  const isPrivate = xCaptureFrontmatter(dailySource).private
+  return upsertFrontmatter(body, {
+    aliases: [identity.base],
+    private: isPrivate ? true : undefined,
+    captureKind: 'x-text',
+    captureDay: identity.date,
+    captureUrl: xPostURL(postId),
+    capturedAt: envelope.capturedAt,
+    captureSource: envelope.source,
+    captureStatus: isPrivate ? 'skipped' : envelope.contentText?.trim() ? 'done' : 'pending',
+    captureHash: await hashContent(body),
+    captureScreenshot: screenshot === 'saved' ? identity.assetPath : undefined,
+  })
+}
+
+/** Append one plain-text result without reconstructing earlier sections. */
+export function appendXText(body: string, post: XText | null): string {
+  const parts = ['## X post text']
+  if (post === null) {
+    parts.push('No public text was available. Open the original post using the URL above.')
+  } else {
+    if (post.author) parts.push(`Author: ${xPlainMarkdown(post.author.name)} (@${xPlainMarkdown(post.author.handle)})`)
+    parts.push(xPlainMarkdown(post.text))
+    if (post.truncated) parts.push('Only a preview was available. Open the original post for the full text.')
+  }
+  return body + (body.endsWith('\n') ? '\n' : '\n\n') + parts.join('\n\n') + '\n'
+}

--- a/packages/core/src/actions/x-capture.test.ts
+++ b/packages/core/src/actions/x-capture.test.ts
@@ -4,21 +4,51 @@ import { captureJsonFetch, createNoteIfAbsent } from '../graph/commands'
 import { dailyPath } from '../graph/paths'
 import { parseNote } from '../markdown/extract'
 import { splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
-import { addSpool, DAILY, describeMock, drain, envelope, files, getSecretMock, inboxRemoveMock, linkPreviewMock, NO_PROVIDERS, promoteMock, readNoteMock, reconcile, scrapeMock, spool, wireCaptureMocks, writeNoteMock } from './capture-harness'
+import {
+  addSpool,
+  DAILY,
+  describeMock,
+  drain,
+  envelope,
+  files,
+  getSecretMock,
+  inboxRemoveMock,
+  linkPreviewMock,
+  NO_PROVIDERS,
+  promoteMock,
+  readNoteMock,
+  reconcile,
+  scrapeMock,
+  spool,
+  wireCaptureMocks,
+  writeNoteMock,
+} from './capture-harness'
 import { listPendingCaptures } from './capture-enrichment'
 import { persistCaptureEnrichment } from './capture-enrichment-write'
+import { captureIdentity } from './capture-identity'
+import { captureNoteSource } from './capture-note'
 import { xCaptureIdentity, xCaptureMeta } from './x-capture-note'
 import { xPostURL } from './x-post'
 
 vi.mock('../graph/commands', () => ({
-  captureInboxList: vi.fn(), captureInboxRead: vi.fn(), captureInboxReject: vi.fn(),
-  captureInboxRemove: vi.fn(), captureLinkPreview: vi.fn(), captureJsonFetch: vi.fn(),
-  createNoteIfAbsent: vi.fn(), listFiles: vi.fn(), promoteCaptureScreenshot: vi.fn(),
-  readAsset: vi.fn(), readNote: vi.fn(), writeAsset: vi.fn(), writeNote: vi.fn(),
+  captureInboxList: vi.fn(),
+  captureInboxRead: vi.fn(),
+  captureInboxReject: vi.fn(),
+  captureInboxRemove: vi.fn(),
+  captureLinkPreview: vi.fn(),
+  captureJsonFetch: vi.fn(),
+  createNoteIfAbsent: vi.fn(),
+  listFiles: vi.fn(),
+  promoteCaptureScreenshot: vi.fn(),
+  readAsset: vi.fn(),
+  readNote: vi.fn(),
+  writeAsset: vi.fn(),
+  writeNote: vi.fn(),
 }))
 vi.mock('./meta-scrape', () => ({ scrapePageMeta: vi.fn() }))
 vi.mock('../ai/describe-page', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../ai/describe-page')>()), describePage: vi.fn(),
+  ...(await importOriginal<typeof import('../ai/describe-page')>()),
+  describePage: vi.fn(),
 }))
 vi.mock('../secrets/keychain', () => ({ getSecret: vi.fn() }))
 vi.mock('./backlink-target', () => ({ ensureBacklinkTarget: vi.fn(async () => 'Links') }))
@@ -28,7 +58,11 @@ const CAPTURE = envelope({ url: xPostURL(POST_ID), title: `X post ${POST_ID}` })
 const IDENTITY = xCaptureIdentity(CAPTURE.id, '2026-06-11')
 const fetchMock = vi.mocked(captureJsonFetch)
 const createMock = vi.mocked(createNoteIfAbsent)
-const ANSWER = JSON.stringify({ id_str: POST_ID, text: 'Public post text.', user: { name: 'Example', screen_name: 'example' } })
+const ANSWER = JSON.stringify({
+  id_str: POST_ID,
+  text: 'Public post text.',
+  user: { name: 'Example', screen_name: 'example' },
+})
 
 function source(): string {
   const value = files.get(IDENTITY.notePath)
@@ -53,13 +87,17 @@ beforeEach(() => {
 describe('X capture create and replay', () => {
   it('preserves manual input and skips all enrichment when page text is supplied', async () => {
     const annotation = '## Page Text\n\n<!-- reflect-capture-page-text:end -->\n\n[[My note]]'
-    const external = '![remote](https://example.com/image.png) <img src="https://example.com/x"> [[external]]'
+    const external =
+      '![remote](https://example.com/image.png) <img src="https://example.com/x"> [[external]]'
     addSpool({ ...CAPTURE, note: annotation, selection: external, contentText: external })
     expect((await drain()).drained).toBe(1)
     expect(source()).toContain(annotation)
     const parsed = parseNote({ path: IDENTITY.notePath, source: source() })
     expect(parsed.wikiLinks.map((link) => link.target)).toEqual(['My note'])
-    expect(parsed.assets.map((asset) => asset.path)).toEqual([IDENTITY.assetPath])
+    expect(parsed.assets.map((asset) => asset.path)).toEqual([
+      `notes/${IDENTITY.assetPath}`,
+      IDENTITY.assetPath,
+    ])
     expect(parsed.links.map((link) => link.href)).not.toContain('https://example.com/image.png')
     expect(xCaptureMeta(source()).captureStatus).toBe('done')
     await reconcile()
@@ -79,12 +117,19 @@ describe('X capture create and replay', () => {
     expect(createMock).toHaveBeenCalledTimes(1)
     expect(promoteMock).toHaveBeenCalledTimes(1)
     expect(spool.size).toBe(0)
-    expect(parseNote({ path: DAILY, source: files.get(DAILY) ?? '' }).wikiLinks.filter((link) => link.target === IDENTITY.base)).toHaveLength(1)
+    expect(
+      parseNote({ path: DAILY, source: files.get(DAILY) ?? '' }).wikiLinks.filter(
+        (link) => link.target === IDENTITY.base,
+      ),
+    ).toHaveLength(1)
   })
 
   it('replays after screenshot cleanup without needing the deleted screenshot', async () => {
     addSpool(CAPTURE)
-    inboxRemoveMock.mockImplementationOnce(async (name) => { spool.delete(name) })
+    inboxRemoveMock
+      .mockImplementationOnce(async (name) => {
+        spool.delete(name)
+      })
       .mockRejectedValueOnce(new ReflectError('io', 'cannot remove JSON'))
     expect((await drain()).stopped?.reason).toBe('io')
     const saved = source()
@@ -109,7 +154,9 @@ describe('X capture create and replay', () => {
     addSpool(CAPTURE, { screenshot: false })
     addSpool({ ...CAPTURE, id: '7c9e6679-7425-40de-944b-e07fc1f90ae8' }, { screenshot: false })
     expect((await drain()).drained).toBe(2)
-    expect([...files.keys()].filter((path) => path.startsWith('notes/capture-x-text-'))).toHaveLength(2)
+    expect(
+      [...files.keys()].filter((path) => path.startsWith('notes/capture-x-text-')),
+    ).toHaveLength(2)
   })
 
   it('keeps the spool when an unrelated file occupies the UUID path', async () => {
@@ -151,13 +198,29 @@ describe('X text enrichment', () => {
     writeNoteMock.mockClear()
   })
 
+  it('keeps older X link notes on their original enrichment path', async () => {
+    files.clear()
+    const legacy = captureIdentity(new Date(CAPTURE.capturedAt), CAPTURE.id)
+    files.set(
+      legacy.notePath,
+      await captureNoteSource(CAPTURE, legacy, {
+        hasScreenshot: false,
+        status: 'pending',
+      }),
+    )
+    expect((await reconcile()).enriched).toBe(1)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(scrapeMock).toHaveBeenCalledWith(CAPTURE.url)
+    expect(describeMock).toHaveBeenCalledTimes(1)
+  })
+
   it('commits the appended text and terminal status once, without AI or retitle', async () => {
     const raw = body()
     const daily = files.get(DAILY)
     files.set(IDENTITY.notePath, upsertFrontmatter(source(), { custom: 'preserved' }))
     expect((await reconcile({ providers: NO_PROVIDERS })).enriched).toBe(1)
     expect(body().startsWith(raw)).toBe(true)
-    expect(body()).toContain('Public post text\\.')
+    expect(body()).toContain(String.raw`Public post text\.`)
     expect(source()).toContain('custom: preserved')
     expect(xCaptureMeta(source()).captureStatus).toBe('done')
     expect(writeNoteMock).toHaveBeenCalledTimes(1)
@@ -196,30 +259,44 @@ describe('X text enrichment', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
-  it.each(['body', 'url', 'day', 'note-private', 'daily-private', 'note-dirty', 'daily-dirty', 'stale'] as const)(
-    'does not append when %s changes during fetch', async (change) => {
-      const response = Promise.withResolvers<string>()
-      const started = Promise.withResolvers<void>()
-      fetchMock.mockImplementationOnce(() => { started.resolve(); return response.promise })
-      let dirty = ''
-      let stale = false
-      const raw = body()
-      const running = reconcile({ isNoteDirty: (path) => path === dirty, isStale: () => stale })
-      await started.promise
-      if (change === 'body') files.set(IDENTITY.notePath, source() + '\nKeep edit\n')
-      if (change === 'url') files.set(IDENTITY.notePath, upsertFrontmatter(source(), { captureUrl: xPostURL('42') }))
-      if (change === 'day') files.set(IDENTITY.notePath, upsertFrontmatter(source(), { captureDay: '2026-06-10' }))
-      if (change === 'note-private') files.set(IDENTITY.notePath, upsertFrontmatter(source(), { private: true }))
-      if (change === 'daily-private') files.set(DAILY, upsertFrontmatter(files.get(DAILY) ?? '', { private: true }))
-      if (change === 'note-dirty') dirty = IDENTITY.notePath
-      if (change === 'daily-dirty') dirty = DAILY
-      if (change === 'stale') stale = true
-      response.resolve(ANSWER)
-      await running
-      expect(body()).toBe(change === 'body' ? raw + '\nKeep edit\n' : raw)
-      expect(xCaptureMeta(source()).captureStatus).toBe(dirty || stale ? 'pending' : 'skipped')
-    },
-  )
+  it.each([
+    'body',
+    'url',
+    'day',
+    'note-private',
+    'daily-private',
+    'note-dirty',
+    'daily-dirty',
+    'stale',
+  ] as const)('does not append when %s changes during fetch', async (change) => {
+    const response = Promise.withResolvers<string>()
+    const started = Promise.withResolvers<void>()
+    fetchMock.mockImplementationOnce(() => {
+      started.resolve()
+      return response.promise
+    })
+    let dirty = ''
+    let stale = false
+    const raw = body()
+    const running = reconcile({ isNoteDirty: (path) => path === dirty, isStale: () => stale })
+    await started.promise
+    if (change === 'body') files.set(IDENTITY.notePath, source() + '\nKeep edit\n')
+    if (change === 'url')
+      files.set(IDENTITY.notePath, upsertFrontmatter(source(), { captureUrl: xPostURL('42') }))
+    if (change === 'day')
+      files.set(IDENTITY.notePath, upsertFrontmatter(source(), { captureDay: '2026-06-10' }))
+    if (change === 'note-private')
+      files.set(IDENTITY.notePath, upsertFrontmatter(source(), { private: true }))
+    if (change === 'daily-private')
+      files.set(DAILY, upsertFrontmatter(files.get(DAILY) ?? '', { private: true }))
+    if (change === 'note-dirty') dirty = IDENTITY.notePath
+    if (change === 'daily-dirty') dirty = DAILY
+    if (change === 'stale') stale = true
+    response.resolve(ANSWER)
+    await running
+    expect(body()).toBe(change === 'body' ? raw + '\nKeep edit\n' : raw)
+    expect(xCaptureMeta(source()).captureStatus).toBe(dirty || stale ? 'pending' : 'skipped')
+  })
 
   it('checks dirty again in the final writer', async () => {
     let dirty = false
@@ -232,17 +309,27 @@ describe('X text enrichment', () => {
     })
     const meta = xCaptureMeta(source())
     const title = `X post ${POST_ID}`
-    expect(await persistCaptureEnrichment({
-      identity: IDENTITY, expectedHash: meta.captureHash, expectedCapture: meta,
-      body: body() + '\nDo not append\n', fromTitle: title, toTitle: title,
-      status: 'done', provider: null, generation: 3, canWrite: () => !dirty,
-    })).toBeNull()
+    expect(
+      await persistCaptureEnrichment({
+        identity: IDENTITY,
+        expectedHash: meta.captureHash,
+        expectedCapture: meta,
+        body: body() + '\nDo not append\n',
+        fromTitle: title,
+        toTitle: title,
+        status: 'done',
+        provider: null,
+        generation: 3,
+        canWrite: () => !dirty,
+      }),
+    ).toBeNull()
     expect(writeNoteMock).not.toHaveBeenCalled()
     expect(xCaptureMeta(source()).captureStatus).toBe('pending')
   })
 
   it.each(['---\nprivate: [\n---\n', '---\nprivate: true\n'])(
-    'refuses malformed Daily frontmatter before fetching', async (daily) => {
+    'refuses malformed Daily frontmatter before fetching',
+    async (daily) => {
       files.set(DAILY, daily)
       expect((await reconcile()).stopped?.reason).toBe('parse')
       expect(fetchMock).not.toHaveBeenCalled()

--- a/packages/core/src/actions/x-capture.test.ts
+++ b/packages/core/src/actions/x-capture.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ReflectError } from '../errors'
+import { captureJsonFetch, createNoteIfAbsent } from '../graph/commands'
+import { dailyPath } from '../graph/paths'
+import { parseNote } from '../markdown/extract'
+import { splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
+import { addSpool, DAILY, describeMock, drain, envelope, files, getSecretMock, inboxRemoveMock, linkPreviewMock, NO_PROVIDERS, promoteMock, readNoteMock, reconcile, scrapeMock, spool, wireCaptureMocks, writeNoteMock } from './capture-harness'
+import { listPendingCaptures } from './capture-enrichment'
+import { persistCaptureEnrichment } from './capture-enrichment-write'
+import { xCaptureIdentity, xCaptureMeta } from './x-capture-note'
+import { xPostURL } from './x-post'
+
+vi.mock('../graph/commands', () => ({
+  captureInboxList: vi.fn(), captureInboxRead: vi.fn(), captureInboxReject: vi.fn(),
+  captureInboxRemove: vi.fn(), captureLinkPreview: vi.fn(), captureJsonFetch: vi.fn(),
+  createNoteIfAbsent: vi.fn(), listFiles: vi.fn(), promoteCaptureScreenshot: vi.fn(),
+  readAsset: vi.fn(), readNote: vi.fn(), writeAsset: vi.fn(), writeNote: vi.fn(),
+}))
+vi.mock('./meta-scrape', () => ({ scrapePageMeta: vi.fn() }))
+vi.mock('../ai/describe-page', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../ai/describe-page')>()), describePage: vi.fn(),
+}))
+vi.mock('../secrets/keychain', () => ({ getSecret: vi.fn() }))
+vi.mock('./backlink-target', () => ({ ensureBacklinkTarget: vi.fn(async () => 'Links') }))
+
+const POST_ID = '1234567890123456789'
+const CAPTURE = envelope({ url: xPostURL(POST_ID), title: `X post ${POST_ID}` })
+const IDENTITY = xCaptureIdentity(CAPTURE.id, '2026-06-11')
+const fetchMock = vi.mocked(captureJsonFetch)
+const createMock = vi.mocked(createNoteIfAbsent)
+const ANSWER = JSON.stringify({ id_str: POST_ID, text: 'Public post text.', user: { name: 'Example', screen_name: 'example' } })
+
+function source(): string {
+  const value = files.get(IDENTITY.notePath)
+  if (value === undefined) throw new Error('capture was not saved')
+  return value
+}
+
+function body(): string {
+  return splitFrontmatter(source()).body
+}
+
+beforeEach(() => {
+  wireCaptureMocks()
+  fetchMock.mockReset().mockResolvedValue(ANSWER)
+  createMock.mockReset().mockImplementation(async (path, contents) => {
+    if (files.has(path)) return { kind: 'collision' }
+    files.set(path, contents)
+    return { kind: 'created', modifiedMs: 0 }
+  })
+})
+
+describe('X capture create and replay', () => {
+  it('preserves manual input and skips all enrichment when page text is supplied', async () => {
+    const annotation = '## Page Text\n\n<!-- reflect-capture-page-text:end -->\n\n[[My note]]'
+    const external = '![remote](https://example.com/image.png) <img src="https://example.com/x"> [[external]]'
+    addSpool({ ...CAPTURE, note: annotation, selection: external, contentText: external })
+    expect((await drain()).drained).toBe(1)
+    expect(source()).toContain(annotation)
+    const parsed = parseNote({ path: IDENTITY.notePath, source: source() })
+    expect(parsed.wikiLinks.map((link) => link.target)).toEqual(['My note'])
+    expect(parsed.assets.map((asset) => asset.path)).toEqual([IDENTITY.assetPath])
+    expect(parsed.links.map((link) => link.href)).not.toContain('https://example.com/image.png')
+    expect(xCaptureMeta(source()).captureStatus).toBe('done')
+    await reconcile()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(scrapeMock).not.toHaveBeenCalled()
+    expect(getSecretMock).not.toHaveBeenCalled()
+  })
+
+  it('repairs the Daily after failure without rebuilding the edited winner', async () => {
+    addSpool({ ...CAPTURE, note: 'First annotation' })
+    writeNoteMock.mockRejectedValueOnce(new ReflectError('io', 'disk full'))
+    expect((await drain()).stopped?.reason).toBe('io')
+    const edited = source() + '\n## User section\n\nKeep me.\n'
+    files.set(IDENTITY.notePath, edited)
+    expect((await drain()).drained).toBe(1)
+    expect(source()).toBe(edited)
+    expect(createMock).toHaveBeenCalledTimes(1)
+    expect(promoteMock).toHaveBeenCalledTimes(1)
+    expect(spool.size).toBe(0)
+    expect(parseNote({ path: DAILY, source: files.get(DAILY) ?? '' }).wikiLinks.filter((link) => link.target === IDENTITY.base)).toHaveLength(1)
+  })
+
+  it('replays after screenshot cleanup without needing the deleted screenshot', async () => {
+    addSpool(CAPTURE)
+    inboxRemoveMock.mockImplementationOnce(async (name) => { spool.delete(name) })
+      .mockRejectedValueOnce(new ReflectError('io', 'cannot remove JSON'))
+    expect((await drain()).stopped?.reason).toBe('io')
+    const saved = source()
+    expect(spool.has(`${CAPTURE.id}.jpg`)).toBe(false)
+    expect((await drain()).drained).toBe(1)
+    expect(source()).toBe(saved)
+    expect(promoteMock).toHaveBeenCalledTimes(1)
+    expect(spool.size).toBe(0)
+  })
+
+  it('uses the persisted day on replay and pending discovery', async () => {
+    addSpool(CAPTURE, { screenshot: false })
+    await drain()
+    files.set(IDENTITY.notePath, upsertFrontmatter(source(), { captureDay: '2026-06-10' }))
+    addSpool({ ...CAPTURE, capturedAt: '2026-06-12T23:59:59-10:00' }, { screenshot: false })
+    expect((await drain()).drained).toBe(1)
+    expect(files.get(dailyPath('2026-06-10'))).toContain(IDENTITY.base)
+    expect((await listPendingCaptures(3))[0]?.date).toBe('2026-06-10')
+  })
+
+  it('creates separate notes for distinct UUIDs of the same URL', async () => {
+    addSpool(CAPTURE, { screenshot: false })
+    addSpool({ ...CAPTURE, id: '7c9e6679-7425-40de-944b-e07fc1f90ae8' }, { screenshot: false })
+    expect((await drain()).drained).toBe(2)
+    expect([...files.keys()].filter((path) => path.startsWith('notes/capture-x-text-'))).toHaveLength(2)
+  })
+
+  it('keeps the spool when an unrelated file occupies the UUID path', async () => {
+    files.set(IDENTITY.notePath, '# My existing note\n')
+    addSpool(CAPTURE)
+    expect((await drain()).stopped?.reason).toBe('parse')
+    expect(source()).toBe('# My existing note\n')
+    expect(spool.size).toBe(2)
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('adopts an atomic create winner rather than overwriting it', async () => {
+    addSpool(CAPTURE, { screenshot: false })
+    createMock.mockImplementationOnce(async (path, contents) => {
+      files.set(path, contents + '\nWinner annotation\n')
+      return { kind: 'collision' }
+    })
+    expect((await drain()).drained).toBe(1)
+    expect(source()).toContain('Winner annotation')
+  })
+
+  it('defers a dirty Daily and inherits private on initial creation', async () => {
+    addSpool(CAPTURE, { screenshot: false })
+    expect((await drain({ isNoteDirty: (path) => path === DAILY })).drained).toBe(0)
+    expect(createMock).not.toHaveBeenCalled()
+    files.set(DAILY, '---\nprivate: true\n---\n# Daily\n')
+    await drain()
+    expect(source()).toContain('private: true')
+    expect(xCaptureMeta(source()).captureStatus).toBe('skipped')
+    await reconcile()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('X text enrichment', () => {
+  beforeEach(async () => {
+    addSpool(CAPTURE, { screenshot: false })
+    expect((await drain()).stopped).toBeNull()
+    writeNoteMock.mockClear()
+  })
+
+  it('commits the appended text and terminal status once, without AI or retitle', async () => {
+    const raw = body()
+    const daily = files.get(DAILY)
+    files.set(IDENTITY.notePath, upsertFrontmatter(source(), { custom: 'preserved' }))
+    expect((await reconcile({ providers: NO_PROVIDERS })).enriched).toBe(1)
+    expect(body().startsWith(raw)).toBe(true)
+    expect(body()).toContain('Public post text\\.')
+    expect(source()).toContain('custom: preserved')
+    expect(xCaptureMeta(source()).captureStatus).toBe('done')
+    expect(writeNoteMock).toHaveBeenCalledTimes(1)
+    expect(files.get(DAILY)).toBe(daily)
+    const done = source()
+    await reconcile()
+    expect(source()).toBe(done)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(getSecretMock).not.toHaveBeenCalled()
+    expect(describeMock).not.toHaveBeenCalled()
+    expect(linkPreviewMock).not.toHaveBeenCalled()
+    expect(scrapeMock).not.toHaveBeenCalled()
+  })
+
+  it.each(['notFound', 'parse'] as const)('finishes unavailable %s responses', async (kind) => {
+    fetchMock.mockRejectedValueOnce(new ReflectError(kind, 'unavailable'))
+    expect((await reconcile()).enriched).toBe(1)
+    expect(body()).toContain('No public text was available.')
+    expect(xCaptureMeta(source()).captureStatus).toBe('done')
+  })
+
+  it.each(['network', 'io'] as const)('keeps %s errors pending', async (kind) => {
+    const raw = source()
+    fetchMock.mockRejectedValueOnce(new ReflectError(kind, 'failed'))
+    expect((await reconcile()).stopped?.reason).toBe(kind)
+    expect(source()).toBe(raw)
+    expect((await reconcile()).enriched).toBe(1)
+  })
+
+  it('does not mistake a disk failure for unavailable text', async () => {
+    const raw = source()
+    writeNoteMock.mockRejectedValueOnce(new ReflectError('io', 'disk full'))
+    expect((await reconcile()).stopped?.reason).toBe('io')
+    expect(source()).toBe(raw)
+    expect((await reconcile()).enriched).toBe(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it.each(['body', 'url', 'day', 'note-private', 'daily-private', 'note-dirty', 'daily-dirty', 'stale'] as const)(
+    'does not append when %s changes during fetch', async (change) => {
+      const response = Promise.withResolvers<string>()
+      const started = Promise.withResolvers<void>()
+      fetchMock.mockImplementationOnce(() => { started.resolve(); return response.promise })
+      let dirty = ''
+      let stale = false
+      const raw = body()
+      const running = reconcile({ isNoteDirty: (path) => path === dirty, isStale: () => stale })
+      await started.promise
+      if (change === 'body') files.set(IDENTITY.notePath, source() + '\nKeep edit\n')
+      if (change === 'url') files.set(IDENTITY.notePath, upsertFrontmatter(source(), { captureUrl: xPostURL('42') }))
+      if (change === 'day') files.set(IDENTITY.notePath, upsertFrontmatter(source(), { captureDay: '2026-06-10' }))
+      if (change === 'note-private') files.set(IDENTITY.notePath, upsertFrontmatter(source(), { private: true }))
+      if (change === 'daily-private') files.set(DAILY, upsertFrontmatter(files.get(DAILY) ?? '', { private: true }))
+      if (change === 'note-dirty') dirty = IDENTITY.notePath
+      if (change === 'daily-dirty') dirty = DAILY
+      if (change === 'stale') stale = true
+      response.resolve(ANSWER)
+      await running
+      expect(body()).toBe(change === 'body' ? raw + '\nKeep edit\n' : raw)
+      expect(xCaptureMeta(source()).captureStatus).toBe(dirty || stale ? 'pending' : 'skipped')
+    },
+  )
+
+  it('checks dirty again in the final writer', async () => {
+    let dirty = false
+    const original = readNoteMock.getMockImplementation()
+    if (!original) throw new Error('read mock not initialized')
+    readNoteMock.mockImplementation(async (path, generation) => {
+      const contents = await original(path, generation)
+      if (path === DAILY) dirty = true
+      return contents
+    })
+    const meta = xCaptureMeta(source())
+    const title = `X post ${POST_ID}`
+    expect(await persistCaptureEnrichment({
+      identity: IDENTITY, expectedHash: meta.captureHash, expectedCapture: meta,
+      body: body() + '\nDo not append\n', fromTitle: title, toTitle: title,
+      status: 'done', provider: null, generation: 3, canWrite: () => !dirty,
+    })).toBeNull()
+    expect(writeNoteMock).not.toHaveBeenCalled()
+    expect(xCaptureMeta(source()).captureStatus).toBe('pending')
+  })
+
+  it.each(['---\nprivate: [\n---\n', '---\nprivate: true\n'])(
+    'refuses malformed Daily frontmatter before fetching', async (daily) => {
+      files.set(DAILY, daily)
+      expect((await reconcile()).stopped?.reason).toBe('parse')
+      expect(fetchMock).not.toHaveBeenCalled()
+    },
+  )
+})

--- a/packages/core/src/actions/x-capture.ts
+++ b/packages/core/src/actions/x-capture.ts
@@ -1,8 +1,18 @@
 import { isAppError, ReflectError } from '../errors'
-import { captureInboxRemove, createNoteIfAbsent, promoteCaptureScreenshot, readNote, writeNote } from '../graph/commands'
+import {
+  captureInboxRemove,
+  createNoteIfAbsent,
+  promoteCaptureScreenshot,
+  readNote,
+  writeNote,
+} from '../graph/commands'
 import { dailyPath } from '../graph/paths'
 import { hashContent } from '../indexing/hash'
-import { appendListItemUnderBacklinkedHeading, upgradeSectionHeadingBacklink, wikiLinkSafe } from '../markdown/edit'
+import {
+  appendListItemUnderBacklinkedHeading,
+  upgradeSectionHeadingBacklink,
+  wikiLinkSafe,
+} from '../markdown/edit'
 import { parseNote } from '../markdown/extract'
 import { splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
 import { ensureBacklinkTarget } from './backlink-target'
@@ -10,7 +20,15 @@ import type { CaptureEnvelope } from './capture-envelope'
 import { persistCaptureEnrichment } from './capture-enrichment-write'
 import { captureLocalDate, type CaptureIdentity } from './capture-identity'
 import { noteSource } from './capture-note'
-import { appendXText, xCaptureFromSource, xCaptureFrontmatter, xCaptureIdentity, xCaptureMeta, xCaptureSource, type XCaptureMeta } from './x-capture-note'
+import {
+  appendXText,
+  xCaptureFromSource,
+  xCaptureFrontmatter,
+  xCaptureIdentity,
+  xCaptureMeta,
+  xCaptureSource,
+  type XCaptureMeta,
+} from './x-capture-note'
 import { xPostId } from './x-post'
 import { fetchXText } from './x-syndication'
 
@@ -29,8 +47,11 @@ interface XCapture {
 }
 
 function canTouch(identity: CaptureIdentity, input: XCaptureInput): boolean {
-  return !input.isStale?.() && !input.isNoteDirty?.(identity.notePath)
-    && !input.isNoteDirty?.(dailyPath(identity.date))
+  return (
+    !input.isStale?.() &&
+    !input.isNoteDirty?.(identity.notePath) &&
+    !input.isNoteDirty?.(dailyPath(identity.date))
+  )
 }
 
 async function readXCapture(path: string, generation: number): Promise<XCapture | null> {
@@ -42,8 +63,11 @@ async function readXCapture(path: string, generation: number): Promise<XCapture 
     throw cause
   }
   return {
-    source, identity: xCaptureFromSource(path, source), meta: xCaptureMeta(source),
-    body: splitFrontmatter(source).body, title: parseNote({ path, source }).title,
+    source,
+    identity: xCaptureFromSource(path, source),
+    meta: xCaptureMeta(source),
+    body: splitFrontmatter(source).body,
+    title: parseNote({ path, source }).title,
   }
 }
 
@@ -76,7 +100,12 @@ export async function drainXCapture(
     let screenshot: 'none' | 'saved' | 'missing' = 'none'
     if (envelope.screenshotRef) {
       try {
-        await promoteCaptureScreenshot(envelope.screenshotRef, identity.assetPath, 1600, input.generation)
+        await promoteCaptureScreenshot(
+          envelope.screenshotRef,
+          identity.assetPath,
+          1600,
+          input.generation,
+        )
         screenshot = 'saved'
       } catch (cause) {
         if (!isAppError(cause) || (cause.kind !== 'notFound' && cause.kind !== 'parse')) throw cause
@@ -99,7 +128,9 @@ export async function drainXCapture(
   if (!parseNote({ path, source }).wikiLinks.some((link) => link.target === identity.base)) {
     const updated = appendListItemUnderBacklinkedHeading(
       upgradeSectionHeadingBacklink(source, linksTitle, ['Links']),
-      linksTitle, `[[${identity.base}|${wikiLinkSafe(winner.title)}]]`, ['Links'],
+      linksTitle,
+      `[[${identity.base}|${wikiLinkSafe(winner.title)}]]`,
+      ['Links'],
     )
     if (!canTouch(identity, input)) return 'deferred'
     await writeNote(path, updated, input.generation)
@@ -123,13 +154,26 @@ export async function enrichXCapture(
     const daily = await readDaily(snapshot.identity, input.generation)
     const hash = await hashContent(snapshot.body)
     if (!canTouch(identity, input) || !canTouch(snapshot.identity, input)) return null
-    if (xCaptureFrontmatter(snapshot.source).private || xCaptureFrontmatter(daily).private
-      || snapshot.identity.date !== identity.date || hash !== snapshot.meta.captureHash
-      || (expected && (hash !== expected.meta.captureHash
-        || snapshot.meta.captureUrl !== expected.meta.captureUrl))) {
+    if (
+      xCaptureFrontmatter(snapshot.source).private ||
+      xCaptureFrontmatter(daily).private ||
+      snapshot.identity.date !== identity.date ||
+      hash !== snapshot.meta.captureHash ||
+      (expected &&
+        (hash !== expected.meta.captureHash ||
+          snapshot.meta.captureUrl !== expected.meta.captureUrl))
+    ) {
       const latest = await readXCapture(identity.notePath, input.generation)
-      if (latest?.meta.captureStatus === 'pending' && canTouch(identity, input) && canTouch(latest.identity, input)) {
-        await writeNote(identity.notePath, upsertFrontmatter(latest.source, { captureStatus: 'skipped' }), input.generation)
+      if (
+        latest?.meta.captureStatus === 'pending' &&
+        canTouch(identity, input) &&
+        canTouch(latest.identity, input)
+      ) {
+        await writeNote(
+          identity.notePath,
+          upsertFrontmatter(latest.source, { captureStatus: 'skipped' }),
+          input.generation,
+        )
         skipped = true
       }
       return null
@@ -144,9 +188,15 @@ export async function enrichXCapture(
     const snapshot = await current(before)
     if (snapshot) {
       const hash = await persistCaptureEnrichment({
-        identity, expectedHash: before.meta.captureHash, expectedCapture: before.meta,
-        body: appendXText(snapshot.body, post), fromTitle: snapshot.title, toTitle: snapshot.title,
-        status: 'done', provider: null, generation: input.generation,
+        identity,
+        expectedHash: before.meta.captureHash,
+        expectedCapture: before.meta,
+        body: appendXText(snapshot.body, post),
+        fromTitle: snapshot.title,
+        toTitle: snapshot.title,
+        status: 'done',
+        provider: null,
+        generation: input.generation,
         canWrite: () => canTouch(identity, input),
       })
       if (hash !== null) return 'enriched'

--- a/packages/core/src/actions/x-capture.ts
+++ b/packages/core/src/actions/x-capture.ts
@@ -1,0 +1,156 @@
+import { isAppError, ReflectError } from '../errors'
+import { captureInboxRemove, createNoteIfAbsent, promoteCaptureScreenshot, readNote, writeNote } from '../graph/commands'
+import { dailyPath } from '../graph/paths'
+import { hashContent } from '../indexing/hash'
+import { appendListItemUnderBacklinkedHeading, upgradeSectionHeadingBacklink, wikiLinkSafe } from '../markdown/edit'
+import { parseNote } from '../markdown/extract'
+import { splitFrontmatter, upsertFrontmatter } from '../markdown/frontmatter'
+import { ensureBacklinkTarget } from './backlink-target'
+import type { CaptureEnvelope } from './capture-envelope'
+import { persistCaptureEnrichment } from './capture-enrichment-write'
+import { captureLocalDate, type CaptureIdentity } from './capture-identity'
+import { noteSource } from './capture-note'
+import { appendXText, xCaptureFromSource, xCaptureFrontmatter, xCaptureIdentity, xCaptureMeta, xCaptureSource, type XCaptureMeta } from './x-capture-note'
+import { xPostId } from './x-post'
+import { fetchXText } from './x-syndication'
+
+interface XCaptureInput {
+  generation: number
+  isStale?: (() => boolean) | undefined
+  isNoteDirty?: ((path: string) => boolean) | undefined
+}
+
+interface XCapture {
+  identity: CaptureIdentity
+  source: string
+  body: string
+  title: string
+  meta: XCaptureMeta
+}
+
+function canTouch(identity: CaptureIdentity, input: XCaptureInput): boolean {
+  return !input.isStale?.() && !input.isNoteDirty?.(identity.notePath)
+    && !input.isNoteDirty?.(dailyPath(identity.date))
+}
+
+async function readXCapture(path: string, generation: number): Promise<XCapture | null> {
+  let source: string
+  try {
+    source = await readNote(path, generation)
+  } catch (cause) {
+    if (isAppError(cause) && cause.kind === 'notFound') return null
+    throw cause
+  }
+  return {
+    source, identity: xCaptureFromSource(path, source), meta: xCaptureMeta(source),
+    body: splitFrontmatter(source).body, title: parseNote({ path, source }).title,
+  }
+}
+
+async function readDaily(identity: CaptureIdentity, generation: number): Promise<string> {
+  const source = await noteSource(dailyPath(identity.date), generation)
+  xCaptureFrontmatter(source)
+  return source
+}
+
+function checkPost(capture: XCapture, postId: string): void {
+  if (xPostId(capture.meta.captureUrl) !== postId) {
+    throw new ReflectError('io', `A different capture occupies ${capture.identity.notePath}.`)
+  }
+}
+
+/** Save one UUID delivery and finish its Daily backlink before removing the spool. */
+export async function drainXCapture(
+  envelope: CaptureEnvelope,
+  spoolName: string,
+  postId: string,
+  input: XCaptureInput,
+): Promise<'saved' | 'deferred'> {
+  const proposed = xCaptureIdentity(envelope.id, captureLocalDate(new Date(envelope.capturedAt)))
+  let winner = await readXCapture(proposed.notePath, input.generation)
+  if (winner) checkPost(winner, postId)
+  let identity = winner?.identity ?? proposed
+  if (!canTouch(identity, input)) return 'deferred'
+  if (winner === null) {
+    await readDaily(identity, input.generation)
+    let screenshot: 'none' | 'saved' | 'missing' = 'none'
+    if (envelope.screenshotRef) {
+      try {
+        await promoteCaptureScreenshot(envelope.screenshotRef, identity.assetPath, 1600, input.generation)
+        screenshot = 'saved'
+      } catch (cause) {
+        if (!isAppError(cause) || (cause.kind !== 'notFound' && cause.kind !== 'parse')) throw cause
+        screenshot = 'missing'
+      }
+    }
+    const daily = await readDaily(identity, input.generation)
+    const source = await xCaptureSource(envelope, identity, postId, screenshot, daily)
+    if (!canTouch(identity, input)) return 'deferred'
+    await createNoteIfAbsent(identity.notePath, source, input.generation)
+  }
+  const linksTitle = await ensureBacklinkTarget('Links', input.generation)
+  winner = await readXCapture(identity.notePath, input.generation)
+  if (!winner) throw new ReflectError('notFound', 'The saved X capture disappeared before linking.')
+  checkPost(winner, postId)
+  identity = winner.identity
+  const path = dailyPath(identity.date)
+  const source = await readDaily(identity, input.generation)
+  if (!canTouch(identity, input)) return 'deferred'
+  if (!parseNote({ path, source }).wikiLinks.some((link) => link.target === identity.base)) {
+    const updated = appendListItemUnderBacklinkedHeading(
+      upgradeSectionHeadingBacklink(source, linksTitle, ['Links']),
+      linksTitle, `[[${identity.base}|${wikiLinkSafe(winner.title)}]]`, ['Links'],
+    )
+    if (!canTouch(identity, input)) return 'deferred'
+    await writeNote(path, updated, input.generation)
+  }
+  if (!canTouch(identity, input)) return 'deferred'
+  if (envelope.screenshotRef) await captureInboxRemove(envelope.screenshotRef, input.generation)
+  await captureInboxRemove(spoolName, input.generation)
+  return 'saved'
+}
+
+/** Append public text only while the original raw body and capture identity remain owned. */
+export async function enrichXCapture(
+  identity: CaptureIdentity,
+  input: XCaptureInput,
+): Promise<'enriched' | 'skipped' | 'deferred'> {
+  let skipped = false
+  async function current(expected?: XCapture): Promise<XCapture | null> {
+    if (!canTouch(identity, input)) return null
+    const snapshot = await readXCapture(identity.notePath, input.generation)
+    if (!snapshot || snapshot.meta.captureStatus !== 'pending') return null
+    const daily = await readDaily(snapshot.identity, input.generation)
+    const hash = await hashContent(snapshot.body)
+    if (!canTouch(identity, input) || !canTouch(snapshot.identity, input)) return null
+    if (xCaptureFrontmatter(snapshot.source).private || xCaptureFrontmatter(daily).private
+      || snapshot.identity.date !== identity.date || hash !== snapshot.meta.captureHash
+      || (expected && (hash !== expected.meta.captureHash
+        || snapshot.meta.captureUrl !== expected.meta.captureUrl))) {
+      const latest = await readXCapture(identity.notePath, input.generation)
+      if (latest?.meta.captureStatus === 'pending' && canTouch(identity, input) && canTouch(latest.identity, input)) {
+        await writeNote(identity.notePath, upsertFrontmatter(latest.source, { captureStatus: 'skipped' }), input.generation)
+        skipped = true
+      }
+      return null
+    }
+    return snapshot
+  }
+  const before = await current()
+  if (before && canTouch(identity, input)) {
+    const postId = xPostId(before.meta.captureUrl)
+    if (postId === null) throw new ReflectError('parse', 'Invalid X capture URL.')
+    const post = await fetchXText(postId)
+    const snapshot = await current(before)
+    if (snapshot) {
+      const hash = await persistCaptureEnrichment({
+        identity, expectedHash: before.meta.captureHash, expectedCapture: before.meta,
+        body: appendXText(snapshot.body, post), fromTitle: snapshot.title, toTitle: snapshot.title,
+        status: 'done', provider: null, generation: input.generation,
+        canWrite: () => canTouch(identity, input),
+      })
+      if (hash !== null) return 'enriched'
+    }
+  }
+  return skipped ? 'skipped' : 'deferred'
+}

--- a/packages/core/src/actions/x-post.ts
+++ b/packages/core/src/actions/x-post.ts
@@ -1,11 +1,16 @@
 /** Decimal post IDs remain strings to preserve their precision. */
-export const X_POST_ID = /^[1-9][0-9]{0,19}$/
+export const X_POST_ID = /^[1-9]\d{0,19}$/
 
 const X_HOSTS = new Set([
-  'x.com', 'www.x.com', 'mobile.x.com',
-  'twitter.com', 'www.twitter.com', 'mobile.twitter.com',
+  'x.com',
+  'www.x.com',
+  'mobile.x.com',
+  'twitter.com',
+  'www.twitter.com',
+  'mobile.twitter.com',
 ])
-const POST_PATH = /^\/(?:i(?:\/web)?|[A-Za-z0-9_]{1,15})\/status\/([1-9][0-9]{0,19})(?:\/(?:photo|video)\/[1-9][0-9]*)?\/?$/
+const POST_PATH =
+  /^\/(?:i(?:\/web)?|\w{1,15})\/status\/([1-9]\d{0,19})(?:\/(?:photo|video)\/[1-9]\d*)?\/?$/
 
 /** Read the ID of an X permalink, including legacy Twitter spellings. */
 export function xPostId(value: string): string | null {

--- a/packages/core/src/actions/x-post.ts
+++ b/packages/core/src/actions/x-post.ts
@@ -1,0 +1,27 @@
+/** Decimal post IDs remain strings to preserve their precision. */
+export const X_POST_ID = /^[1-9][0-9]{0,19}$/
+
+const X_HOSTS = new Set([
+  'x.com', 'www.x.com', 'mobile.x.com',
+  'twitter.com', 'www.twitter.com', 'mobile.twitter.com',
+])
+const POST_PATH = /^\/(?:i(?:\/web)?|[A-Za-z0-9_]{1,15})\/status\/([1-9][0-9]{0,19})(?:\/(?:photo|video)\/[1-9][0-9]*)?\/?$/
+
+/** Read the ID of an X permalink, including legacy Twitter spellings. */
+export function xPostId(value: string): string | null {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    return null
+  }
+  if (!['http:', 'https:'].includes(url.protocol) || !X_HOSTS.has(url.hostname)) return null
+  if (url.username || url.password || url.port) return null
+  return POST_PATH.exec(url.pathname)?.[1] ?? null
+}
+
+/** The stable, account-independent permalink for a post. */
+export function xPostURL(id: string): string {
+  if (!X_POST_ID.test(id)) throw new Error('invalid X post ID')
+  return `https://x.com/i/status/${id}`
+}

--- a/packages/core/src/actions/x-syndication.test.ts
+++ b/packages/core/src/actions/x-syndication.test.ts
@@ -12,25 +12,54 @@ describe('X post text', () => {
     expect(xPostId(url)).toBe('123')
     expect(xPostURL('123')).toBe('https://x.com/i/status/123')
   })
-  it.each(['https://x.com/home', 'https://x.com.evil.com/i/status/123', 'https://evil.com/x.com/i/status/123', 'https://x.com/i/status/0', 'https://x.com/i/status/123/other', 'https://user@x.com/i/status/123', 'file://x.com/i/status/123'])(
-    'rejects %s', (url) => expect(xPostId(url)).toBeNull(),
-  )
+  it.each([
+    'https://x.com/home',
+    'https://x.com.evil.com/i/status/123',
+    'https://evil.com/x.com/i/status/123',
+    'https://x.com/i/status/0',
+    'https://x.com/i/status/123/other',
+    'https://user@x.com/i/status/123',
+    'file://x.com/i/status/123',
+  ])('rejects %s', (url) => expect(xPostId(url)).toBeNull())
   it('uses code-point ranges before expanding URLs and decoding entities', () => {
-    expect(parseXText({
-      id_str: '123', text: 'A😀 &amp; https://t.co/abcZ', display_text_range: [1, 25],
-      entities: { urls: [{ url: 'https://t.co/abc', expanded_url: 'https://example.com/$&' }] },
-    }, '123')).toMatchObject({ text: '😀 & https://example.com/$&', truncated: false })
+    expect(
+      parseXText(
+        {
+          id_str: '123',
+          text: 'A😀 &amp; https://t.co/abcZ',
+          display_text_range: [1, 25],
+          entities: { urls: [{ url: 'https://t.co/abc', expanded_url: 'https://example.com/$&' }] },
+        },
+        '123',
+      ),
+    ).toMatchObject({ text: '😀 & https://example.com/$&', truncated: false })
   })
   it('marks long posts as previews and ignores nested media and quotes', () => {
-    expect(parseXText({ id_str: '123', text: 'Preview', note_tweet: {}, quoted_tweet: { text: 'Quote' }, mediaDetails: [{ media_url_https: 'https://example.com/image' }] }, '123'))
-      .toEqual({ text: 'Preview', truncated: true })
+    expect(
+      parseXText(
+        {
+          id_str: '123',
+          text: 'Preview',
+          note_tweet: {},
+          quoted_tweet: { text: 'Quote' },
+          mediaDetails: [{ media_url_https: 'https://example.com/image' }],
+        },
+        '123',
+      ),
+    ).toEqual({ text: 'Preview', truncated: true })
   })
   it('limits by code point and marks invalid ranges as previews', () => {
-    const post = parseXText({ id_str: '123', text: '😀'.repeat(20_001), display_text_range: [3, 1] }, '123')
+    const post = parseXText(
+      { id_str: '123', text: '😀'.repeat(20_001), display_text_range: [3, 1] },
+      '123',
+    )
     expect(post?.text).toBe('😀'.repeat(20_000))
     expect(post?.truncated).toBe(true)
   })
-  it.each([{}, { id_str: '123', text: '' }, { id_str: '456', text: 'wrong post' }])('has no public text for %j', (value) => {
-    expect(parseXText(value, '123')).toBeNull()
-  })
+  it.each([{}, { id_str: '123', text: '' }, { id_str: '456', text: 'wrong post' }])(
+    'has no public text for %j',
+    (value) => {
+      expect(parseXText(value, '123')).toBeNull()
+    },
+  )
 })

--- a/packages/core/src/actions/x-syndication.test.ts
+++ b/packages/core/src/actions/x-syndication.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { parseXText } from './x-syndication'
+import { xPostId, xPostURL } from './x-post'
+
+describe('X post text', () => {
+  it.each([
+    'https://x.com/example/status/123?ref=timeline',
+    'https://twitter.com/i/web/status/123',
+    'https://mobile.twitter.com/example/status/123/photo/1',
+    'https://www.x.com/i/status/123/video/2',
+  ])('canonicalizes %s', (url) => {
+    expect(xPostId(url)).toBe('123')
+    expect(xPostURL('123')).toBe('https://x.com/i/status/123')
+  })
+  it.each(['https://x.com/home', 'https://x.com.evil.com/i/status/123', 'https://evil.com/x.com/i/status/123', 'https://x.com/i/status/0', 'https://x.com/i/status/123/other', 'https://user@x.com/i/status/123', 'file://x.com/i/status/123'])(
+    'rejects %s', (url) => expect(xPostId(url)).toBeNull(),
+  )
+  it('uses code-point ranges before expanding URLs and decoding entities', () => {
+    expect(parseXText({
+      id_str: '123', text: 'A😀 &amp; https://t.co/abcZ', display_text_range: [1, 25],
+      entities: { urls: [{ url: 'https://t.co/abc', expanded_url: 'https://example.com/$&' }] },
+    }, '123')).toMatchObject({ text: '😀 & https://example.com/$&', truncated: false })
+  })
+  it('marks long posts as previews and ignores nested media and quotes', () => {
+    expect(parseXText({ id_str: '123', text: 'Preview', note_tweet: {}, quoted_tweet: { text: 'Quote' }, mediaDetails: [{ media_url_https: 'https://example.com/image' }] }, '123'))
+      .toEqual({ text: 'Preview', truncated: true })
+  })
+  it('limits by code point and marks invalid ranges as previews', () => {
+    const post = parseXText({ id_str: '123', text: '😀'.repeat(20_001), display_text_range: [3, 1] }, '123')
+    expect(post?.text).toBe('😀'.repeat(20_000))
+    expect(post?.truncated).toBe(true)
+  })
+  it.each([{}, { id_str: '123', text: '' }, { id_str: '456', text: 'wrong post' }])('has no public text for %j', (value) => {
+    expect(parseXText(value, '123')).toBeNull()
+  })
+})

--- a/packages/core/src/actions/x-syndication.ts
+++ b/packages/core/src/actions/x-syndication.ts
@@ -12,13 +12,25 @@ export interface XText {
 const tweetSchema = z.object({
   id_str: z.string(),
   text: z.string(),
-  display_text_range: z.tuple([z.number().int().nonnegative(), z.number().int().nonnegative()]).optional(),
+  display_text_range: z
+    .tuple([z.number().int().nonnegative(), z.number().int().nonnegative()])
+    .optional(),
   user: z.object({ name: z.string(), screen_name: z.string() }).optional(),
-  entities: z.object({ urls: z.array(z.object({ url: z.string().min(1), expanded_url: z.string() })).optional() }).optional(),
+  entities: z
+    .object({
+      urls: z.array(z.object({ url: z.string().min(1), expanded_url: z.string() })).optional(),
+    })
+    .optional(),
   truncated: z.boolean().optional(),
   note_tweet: z.unknown().optional(),
 })
-const ENTITIES: Record<string, string> = { '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#39;': "'" }
+const ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+}
 
 /** Read only public post text from the bounded syndication response. */
 export function parseXText(value: unknown, id: string): XText | null {
@@ -33,16 +45,21 @@ export function parseXText(value: unknown, id: string): XText | null {
     if (start <= end && end <= points.length) text = points.slice(start, end).join('')
     else truncated = true
   }
-  for (const entity of tweet.entities?.urls ?? []) text = text.replaceAll(entity.url, () => entity.expanded_url)
-  text = text.replace(/&(?:amp|lt|gt|quot|#39);/g, (entity) => ENTITIES[entity] ?? entity).trim()
+  for (const entity of tweet.entities?.urls ?? [])
+    text = text.replaceAll(entity.url, () => entity.expanded_url)
+  text = text.replaceAll(/&(?:amp|lt|gt|quot|#39);/g, (entity) => ENTITIES[entity] ?? entity).trim()
   if (!text) return null
   const limited = Array.from(text)
   return {
     text: limited.slice(0, 20_000).join(''),
-    ...(tweet.user ? { author: {
-      name: Array.from(tweet.user.name).slice(0, 200).join(''),
-      handle: Array.from(tweet.user.screen_name).slice(0, 100).join(''),
-    } } : {}),
+    ...(tweet.user
+      ? {
+          author: {
+            name: Array.from(tweet.user.name).slice(0, 200).join(''),
+            handle: Array.from(tweet.user.screen_name).slice(0, 100).join(''),
+          },
+        }
+      : {}),
     truncated: truncated || limited.length > 20_000,
   }
 }
@@ -51,7 +68,7 @@ export function parseXText(value: unknown, id: string): XText | null {
 export async function fetchXText(id: string): Promise<XText | null> {
   if (!X_POST_ID.test(id)) throw new Error('invalid X post ID')
   // Matches react-tweet's public syndication token algorithm.
-  const token = ((Number(id) / 1e15) * Math.PI).toString(36).replace(/0+|\./g, '')
+  const token = ((Number(id) / 1e15) * Math.PI).toString(36).replaceAll(/0+|\./g, '')
   const url = new URL('https://cdn.syndication.twimg.com/tweet-result')
   url.search = new URLSearchParams({ id, lang: 'en', token }).toString()
   let raw: string

--- a/packages/core/src/actions/x-syndication.ts
+++ b/packages/core/src/actions/x-syndication.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod'
+import { isAppError } from '../errors'
+import { captureJsonFetch } from '../graph/commands'
+import { X_POST_ID } from './x-post'
+
+export interface XText {
+  text: string
+  author?: { name: string; handle: string }
+  truncated: boolean
+}
+
+const tweetSchema = z.object({
+  id_str: z.string(),
+  text: z.string(),
+  display_text_range: z.tuple([z.number().int().nonnegative(), z.number().int().nonnegative()]).optional(),
+  user: z.object({ name: z.string(), screen_name: z.string() }).optional(),
+  entities: z.object({ urls: z.array(z.object({ url: z.string().min(1), expanded_url: z.string() })).optional() }).optional(),
+  truncated: z.boolean().optional(),
+  note_tweet: z.unknown().optional(),
+})
+const ENTITIES: Record<string, string> = { '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#39;': "'" }
+
+/** Read only public post text from the bounded syndication response. */
+export function parseXText(value: unknown, id: string): XText | null {
+  const parsed = tweetSchema.safeParse(value)
+  if (!parsed.success || parsed.data.id_str !== id) return null
+  const tweet = parsed.data
+  let truncated = tweet.truncated === true || tweet.note_tweet != null
+  const points = Array.from(tweet.text)
+  let text = tweet.text
+  if (tweet.display_text_range) {
+    const [start, end] = tweet.display_text_range
+    if (start <= end && end <= points.length) text = points.slice(start, end).join('')
+    else truncated = true
+  }
+  for (const entity of tweet.entities?.urls ?? []) text = text.replaceAll(entity.url, () => entity.expanded_url)
+  text = text.replace(/&(?:amp|lt|gt|quot|#39);/g, (entity) => ENTITIES[entity] ?? entity).trim()
+  if (!text) return null
+  const limited = Array.from(text)
+  return {
+    text: limited.slice(0, 20_000).join(''),
+    ...(tweet.user ? { author: {
+      name: Array.from(tweet.user.name).slice(0, 200).join(''),
+      handle: Array.from(tweet.user.screen_name).slice(0, 100).join(''),
+    } } : {}),
+    truncated: truncated || limited.length > 20_000,
+  }
+}
+
+/** Fetch a single text source; transient transport failures remain retryable. */
+export async function fetchXText(id: string): Promise<XText | null> {
+  if (!X_POST_ID.test(id)) throw new Error('invalid X post ID')
+  // Matches react-tweet's public syndication token algorithm.
+  const token = ((Number(id) / 1e15) * Math.PI).toString(36).replace(/0+|\./g, '')
+  const url = new URL('https://cdn.syndication.twimg.com/tweet-result')
+  url.search = new URLSearchParams({ id, lang: 'en', token }).toString()
+  let raw: string
+  try {
+    raw = await captureJsonFetch(url.href)
+  } catch (cause) {
+    if (isAppError(cause) && (cause.kind === 'notFound' || cause.kind === 'parse')) return null
+    throw cause
+  }
+  let value: unknown
+  try {
+    value = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  return parseXText(value, id)
+}

--- a/packages/core/src/graph/commands.ts
+++ b/packages/core/src/graph/commands.ts
@@ -426,13 +426,13 @@ export async function captureMetaFetch(url: string): Promise<string> {
 }
 
 /**
- * Fetch an oEmbed endpoint's JSON answer as text. The Rust side only bounds
+ * Fetch an endpoint's JSON answer as text. The Rust side only bounds
  * the transport (https only, JSON only, a small byte cap, no redirects);
- * which URLs are oEmbed endpoints is policy in `actions/oembed`. The privacy
+ * endpoint selection belongs to the action requesting it. The privacy
  * gate runs before any call here, exactly as for {@link captureMetaFetch}.
  */
-export async function captureOEmbedFetch(url: string): Promise<string> {
-  return await call('capture_oembed_fetch', { url }, z.string())
+export async function captureJsonFetch(url: string): Promise<string> {
+  return await call('capture_json_fetch', { url }, z.string())
 }
 
 /** The recently-opened graphs, newest first. */


### PR DESCRIPTION
Save new X bookmark actions into Reflect after an optional browser host-permission grant. The extension observes `CreateBookmark` requests and sends ordinary v1 link envelopes through the existing queue and native host.

New X captures create independent UUID notes and repair their Daily backlink on replay without rebuilding saved content. Reflect saves the URL and manual input first, then appends available public text through the existing bounded JSON transport. Private, dirty, edited, or changed captures stop automatic writes. Supplied page text completes the capture directly; X captures do not run AI, link previews, or automatic retitling.

Scope: bookmark intent only, including requests X later rejects. No DOM extraction, likes, historical import, quote expansion, or media download. Long posts may be previews. The existing 50-entry queue limit still applies. Upgrade desktop before opting in; the unchanged wire format does not change old desktop behavior.

Validation:
- Added request/permission, Unicode/text normalization, create/replay, cleanup failure, privacy/edit-race, and terminal-write tests.
- After the initial CI failure, all 154 targeted tests, TypeScript, changed-file lint, and the Chrome MV3 production build passed locally. Full CI is running on the updated head.
- Read-only live syndication probes for three public IDs returned matching IDs within the existing 64 KiB response cap, including an empty display-text range.
- Draft remains open for live signed-in X button/menu/shortcut, worker wake/revocation, and app-closed capture acceptance. Offline fixtures do not establish those live contracts.

Change size relative to master: production files +778/-51 (net +727), tests net +559, documentation net +31, configuration net +3. Production counts include comments, whitespace, and inline Rust tests. No new dependency or wire schema was added.
