### PR TITLE
fix(mobile): stop a failed StoreKit probe from reading as an App Store install

### DIFF
--- a/apps/desktop/src/mobile/use-app-store-environment.ts
+++ b/apps/desktop/src/mobile/use-app-store-environment.ts
@@ -10,14 +10,29 @@ import { useGraph } from '@/providers/graph-provider'
 const appStoreEnvironmentSchema = z.enum(['Production', 'Sandbox', 'Xcode']).nullable()
 export type AppStoreEnvironment = z.infer<typeof appStoreEnvironmentSchema>
 
+/**
+ * The channels worth remembering across launches. A remembered `Production`
+ * reads exactly like no seed at all, so storing it can only let one launch's
+ * answer outlive that launch.
+ */
+const rememberedEnvironmentSchema = z.enum(['Sandbox', 'Xcode'])
+
 const APP_STORE_ENVIRONMENT_STORAGE_KEY = 'reflect.app-store.environment'
 
 function readAppStoreEnvironmentSeed(): AppStoreEnvironment | undefined {
-  return getLocalStorageStore(APP_STORE_ENVIRONMENT_STORAGE_KEY).getJson(appStoreEnvironmentSchema)
+  return getLocalStorageStore(APP_STORE_ENVIRONMENT_STORAGE_KEY).getJson(
+    rememberedEnvironmentSchema,
+  )
 }
 
 function writeAppStoreEnvironmentSeed(value: AppStoreEnvironment): void {
-  getLocalStorageStore(APP_STORE_ENVIRONMENT_STORAGE_KEY).setJson(appStoreEnvironmentSchema, value)
+  const store = getLocalStorageStore(APP_STORE_ENVIRONMENT_STORAGE_KEY)
+  const remembered = rememberedEnvironmentSchema.safeParse(value)
+  if (remembered.success) {
+    store.setJson(rememberedEnvironmentSchema, remembered.data)
+  } else {
+    store.set(null)
+  }
 }
 
 async function fetchAppStoreEnvironment(): Promise<AppStoreEnvironment> {

--- a/apps/desktop/src/mobile/use-paywall-gate.test.tsx
+++ b/apps/desktop/src/mobile/use-paywall-gate.test.tsx
@@ -4,6 +4,7 @@ import { renderHook } from 'vitest-browser-react'
 import type { ReactNode } from 'react'
 import { setBridge, type AppPlatform } from '@reflect/core'
 import { usePaywallRequested } from '@/hooks/use-paywall-requested'
+import { resetLocalStorageStores } from '@/lib/local-storage'
 import { queryKeys } from '@/lib/query-client'
 import { SettingsProvider } from '@/providers/settings-provider'
 import { usePaywallGate, type PaywallGate } from './use-paywall-gate'
@@ -118,6 +119,7 @@ beforeEach(() => {
   stored = {}
   emitPurchaseUpdated = null
   localStorage.clear()
+  resetLocalStorageStores()
   sessionStorage.clear()
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Infinity } },
@@ -413,6 +415,30 @@ describe('usePaywallGate', () => {
       expect(result.current).toBe('hide')
       probe.settle('Production')
       await vi.waitFor(() => expect(result.current).toBe('show'))
+    })
+
+    it('does not answer from a channel an older build remembered as Production', async () => {
+      // Written by hand: this build never remembers `Production`, because a
+      // remembered `Production` reads exactly like no seed at all.
+      localStorage.setItem('reflect.app-store.environment', JSON.stringify('Production'))
+      resetLocalStorageStores()
+      environment = never
+
+      await renderHook(() => usePaywallGate(), { wrapper })
+
+      expect(queryClient.getQueryData(queryKeys.appStore.environment)).toBeUndefined()
+    })
+
+    it('forgets a remembered channel once the probe answers Production', async () => {
+      environment = () => Promise.resolve('Sandbox')
+      await runLaunch('hide')
+      environment = () => Promise.resolve('Production')
+      await runLaunch('show')
+
+      environment = never
+      await renderHook(() => usePaywallGate(), { wrapper })
+
+      expect(queryClient.getQueryData(queryKeys.appStore.environment)).toBeUndefined()
     })
   })
 })

--- a/packages/core/src/ipc/app-store-plugin.ts
+++ b/packages/core/src/ipc/app-store-plugin.ts
@@ -18,9 +18,8 @@ const getEnvironmentCommand = definePluginCommand<Record<string, never>, { envir
  * Which channel installed this build, per StoreKit 2's
  * `AppTransaction.environment`: `'Production'` (App Store), `'Sandbox'`
  * (TestFlight or a development install), or `'Xcode'` (a
- * StoreKit-configuration run). Fail-closed: probe errors and non-iOS
- * platforms answer `'Production'`, and callers must treat unknown values
- * the same way, so a failure can never misclassify a paying customer.
+ * StoreKit-configuration run). Rejects when the probe cannot answer, so an
+ * unanswered probe stays distinguishable from a named channel.
  */
 export async function getAppStoreEnvironment(): Promise<string> {
   return (await getEnvironmentCommand({})).environment

--- a/plugins/tauri-plugin-app-store/ios/Sources/AppStorePlugin.swift
+++ b/plugins/tauri-plugin-app-store/ios/Sources/AppStorePlugin.swift
@@ -4,23 +4,25 @@ import Tauri
 /// The install-channel probe. StoreKit 2's `AppTransaction.environment` is
 /// the official signal: `Production` for the App Store, `Sandbox` for
 /// TestFlight and development installs, `Xcode` for StoreKit-configuration
-/// runs. Anything short of a verified answer resolves as `Production`, so a
-/// failure can never misclassify a paying App Store customer as a tester.
+/// runs. A probe that cannot reach an answer rejects rather than naming a
+/// channel, so a failure is never mistaken for a verdict.
 class AppStorePlugin: Plugin {
   // `async throws` (never throws): Tauri dispatches async commands through
   // the `command:completionHandler:` selector with an `(NSError?) -> Void`
   // block, the bridge only a throwing async method generates; a plain
   // `async` method would take a zero-argument block and mismatch that ABI.
   @objc public func getEnvironment(_ invoke: Invoke) async throws {
-    if #available(iOS 16.0, *) {
-      if let result = try? await AppTransaction.shared,
-        case .verified(let transaction) = result
-      {
+    if #available(iOS 16.0, *), let result = try? await AppTransaction.shared {
+      // An unverified payload names the same environment as a verified one:
+      // StoreKit lists it beside a thrown error as a case for
+      // `AppTransaction.refresh()`, not as a wrong answer.
+      switch result {
+      case .verified(let transaction), .unverified(let transaction, _):
         invoke.resolve(["environment": transaction.environment.rawValue])
         return
       }
     }
-    invoke.resolve(["environment": "Production"])
+    invoke.reject("the app transaction is unavailable")
   }
 }
 

--- a/plugins/tauri-plugin-app-store/src/models.rs
+++ b/plugins/tauri-plugin-app-store/src/models.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 /// Which channel installed this build, as StoreKit 2's
 /// `AppTransaction.environment` reports it: `Production` (App Store),
 /// `Sandbox` (TestFlight or a development install), or `Xcode` (a
-/// StoreKit-configuration run). Consumers must treat unknown values as
-/// `Production`, the fail-closed answer.
+/// StoreKit-configuration run). A probe that cannot answer returns an error
+/// instead of a channel.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AppStoreEnvironment {
     pub environment: String,


### PR DESCRIPTION
A TestFlight build whose `AppTransaction` lookup fails no longer reports itself as an App Store install: the probe rejects instead of answering `Production`, so a transient StoreKit failure can no longer show the paywall to a tester or overwrite a correctly remembered `Sandbox`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved App Store environment detection by distinguishing probe failures from the Production environment.
  * Prevented invalid or unsupported environment values from being persisted.
  * Legacy remembered Production values are now ignored and cleared when a live check confirms Production.

* **Documentation**
  * Clarified that unavailable or failed environment checks return an error instead of defaulting to Production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->