### PR TITLE
fix(mobile): recognize a sandbox install when the app transaction is unavailable

### DIFF
--- a/plugins/tauri-plugin-app-store/ios/Sources/AppStorePlugin.swift
+++ b/plugins/tauri-plugin-app-store/ios/Sources/AppStorePlugin.swift
@@ -1,11 +1,13 @@
+import Foundation
 import StoreKit
 import Tauri
 
 /// The install-channel probe. StoreKit 2's `AppTransaction.environment` is
 /// the official signal: `Production` for the App Store, `Sandbox` for
 /// TestFlight and development installs, `Xcode` for StoreKit-configuration
-/// runs. A probe that cannot reach an answer rejects rather than naming a
-/// channel, so a failure is never mistaken for a verdict.
+/// runs. With no app transaction to read, the receipt path still separates a
+/// sandbox install from an App Store one; short of both, the probe rejects
+/// rather than naming a channel, so a failure is never mistaken for a verdict.
 class AppStorePlugin: Plugin {
   // `async throws` (never throws): Tauri dispatches async commands through
   // the `command:completionHandler:` selector with an `(NSError?) -> Void`
@@ -21,6 +23,15 @@ class AppStorePlugin: Plugin {
         invoke.resolve(["environment": transaction.environment.rawValue])
         return
       }
+    }
+    // Reading an app transaction can need the network and an authenticated
+    // App Store account; the receipt path needs neither, and names a sandbox
+    // install `sandboxReceipt` where an App Store install is `receipt`. The
+    // property is deprecated for Swift in favor of the call above, which is
+    // exactly the call that just failed.
+    if Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" {
+      invoke.resolve(["environment": "Sandbox"])
+      return
     }
     invoke.reject("the app transaction is unavailable")
   }


### PR DESCRIPTION
Falls back to the app receipt path when the app transaction is unavailable, so an offline or unauthenticated TestFlight launch is still recognized as a sandbox install.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved app environment detection when StoreKit cannot provide transaction information.
  - Sandbox receipts are now correctly identified as the Sandbox environment.
  - Receipts from other environments are handled safely without exposing environment details when verification cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->