### PR TITLE
fix(mobile): align the All and Tasks search bars

### DIFF
--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -259,13 +259,6 @@ function visibleLayer(view: BrowserView): HTMLElement {
   return visible
 }
 
-/** Where a tab puts its search field, for comparing one tab's row with another's. */
-async function searchFieldTop(view: BrowserView, name: string): Promise<number> {
-  const box = view.getByRole('searchbox', { name })
-  await expect.element(box).toBeVisible()
-  return box.element().getBoundingClientRect().top
-}
-
 /**
  * Dispatch a pointer event the gesture hook can read.
  */
@@ -648,28 +641,6 @@ describe('MobileShell', () => {
         .getAttribute('aria-current'),
     ).not.toBe('date')
     expect(editorProbe.focusCalls).toBe(0)
-  })
-
-  it('keeps the search field on one row across the All and Tasks tabs', async () => {
-    const user = userEvent
-    const view = await mount({ kind: 'today' })
-
-    await user.click(view.getByRole('button', { name: 'All' }))
-    const all = await searchFieldTop(view, 'Search notes')
-
-    await user.click(view.getByRole('button', { name: 'Tasks' }))
-    expect(await searchFieldTop(view, 'Search tasks')).toBe(all)
-  })
-
-  it('keeps the search field on that row when the All tab shows a tag back button', async () => {
-    const user = userEvent
-    const view = await mount({ kind: 'allNotes', tag: 'book' })
-
-    await expect.element(view.getByRole('button', { name: 'Back' })).toBeVisible()
-    const tagged = await searchFieldTop(view, 'Search notes')
-
-    await user.click(view.getByRole('button', { name: 'Tasks' }))
-    expect(await searchFieldTop(view, 'Search tasks')).toBe(tagged)
   })
 
   it('switches to the Tasks tab, which renders the grouped task list', async () => {

--- a/apps/desktop/src/mobile/mobile-screen.test.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.test.tsx
@@ -259,6 +259,13 @@ function visibleLayer(view: BrowserView): HTMLElement {
   return visible
 }
 
+/** Where a tab puts its search field, for comparing one tab's row with another's. */
+async function searchFieldTop(view: BrowserView, name: string): Promise<number> {
+  const box = view.getByRole('searchbox', { name })
+  await expect.element(box).toBeVisible()
+  return box.element().getBoundingClientRect().top
+}
+
 /**
  * Dispatch a pointer event the gesture hook can read.
  */
@@ -641,6 +648,28 @@ describe('MobileShell', () => {
         .getAttribute('aria-current'),
     ).not.toBe('date')
     expect(editorProbe.focusCalls).toBe(0)
+  })
+
+  it('keeps the search field on one row across the All and Tasks tabs', async () => {
+    const user = userEvent
+    const view = await mount({ kind: 'today' })
+
+    await user.click(view.getByRole('button', { name: 'All' }))
+    const all = await searchFieldTop(view, 'Search notes')
+
+    await user.click(view.getByRole('button', { name: 'Tasks' }))
+    expect(await searchFieldTop(view, 'Search tasks')).toBe(all)
+  })
+
+  it('keeps the search field on that row when the All tab shows a tag back button', async () => {
+    const user = userEvent
+    const view = await mount({ kind: 'allNotes', tag: 'book' })
+
+    await expect.element(view.getByRole('button', { name: 'Back' })).toBeVisible()
+    const tagged = await searchFieldTop(view, 'Search notes')
+
+    await user.click(view.getByRole('button', { name: 'Tasks' }))
+    expect(await searchFieldTop(view, 'Search tasks')).toBe(tagged)
   })
 
   it('switches to the Tasks tab, which renders the grouped task list', async () => {

--- a/apps/desktop/src/mobile/screens/all-notes.tsx
+++ b/apps/desktop/src/mobile/screens/all-notes.tsx
@@ -21,6 +21,7 @@ import {
   type AllNotesFilters,
 } from '@/mobile/search-filters/filter-state'
 import { NoteRowList } from '@/mobile/note-row-list'
+import { MobileSearchHeader } from '@/mobile/search-header'
 import { SearchInput } from '@/mobile/search-input'
 import type { NoteRowModel } from '@/mobile/swipeable-note-row'
 import { useArrivalFocus } from '@/mobile/use-arrival-focus'
@@ -142,42 +143,43 @@ export function MobileAllNotes({
       className="flex h-full w-screen flex-col"
       style={{ paddingTop: 'env(safe-area-inset-top)' }}
     >
-      <header className="shrink-0 space-y-2 border-b border-border px-4 pb-2 pt-1">
-        <div className="flex items-center gap-1">
-          {tag !== null && (
-            <Button
-              variant="ghost"
-              size="icon"
-              className="-ml-2 size-9 shrink-0"
-              aria-label="Back"
-              onClick={back}
-            >
-              <ChevronLeft />
-            </Button>
-          )}
-          <SearchInput
-            ref={searchInputRef}
-            placeholder="Search anything…"
-            aria-label="Search notes"
-            value={query}
-            onValueChange={onQueryChange}
-          />
-        </div>
-        {pending !== null ? (
-          <TagSuggestions
-            facets={matchingTagFacets(facets ?? [], pending.partial)}
-            onPick={addPendingTag}
-          />
-        ) : (
-          <FilterBar
-            filters={filters}
-            onFiltersChange={onFiltersChange}
-            facets={facets ?? []}
-            routeTag={tag}
-            onClearRouteTag={() => navigate({ kind: 'allNotes', tag: null })}
-          />
+      <MobileSearchHeader
+        below={
+          pending !== null ? (
+            <TagSuggestions
+              facets={matchingTagFacets(facets ?? [], pending.partial)}
+              onPick={addPendingTag}
+            />
+          ) : (
+            <FilterBar
+              filters={filters}
+              onFiltersChange={onFiltersChange}
+              facets={facets ?? []}
+              routeTag={tag}
+              onClearRouteTag={() => navigate({ kind: 'allNotes', tag: null })}
+            />
+          )
+        }
+      >
+        {tag !== null && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="-ml-2 size-10 shrink-0"
+            aria-label="Back"
+            onClick={back}
+          >
+            <ChevronLeft />
+          </Button>
         )}
-      </header>
+        <SearchInput
+          ref={searchInputRef}
+          placeholder="Search anything…"
+          aria-label="Search notes"
+          value={query}
+          onValueChange={onQueryChange}
+        />
+      </MobileSearchHeader>
       {/* Undefined hits mean "still fetching" only while the query can run —
           with no bridge/graph it never will, and the empty state is honest. */}
       {enabled && hits === undefined ? (

--- a/apps/desktop/src/mobile/screens/all-notes.tsx
+++ b/apps/desktop/src/mobile/screens/all-notes.tsx
@@ -21,7 +21,7 @@ import {
   type AllNotesFilters,
 } from '@/mobile/search-filters/filter-state'
 import { NoteRowList } from '@/mobile/note-row-list'
-import { MobileSearchHeader } from '@/mobile/search-header'
+import { MobileSearchHeader, MobileSearchHeaderContent } from '@/mobile/search-header'
 import { SearchInput } from '@/mobile/search-input'
 import type { NoteRowModel } from '@/mobile/swipeable-note-row'
 import { useArrivalFocus } from '@/mobile/use-arrival-focus'
@@ -144,23 +144,8 @@ export function MobileAllNotes({
       style={{ paddingTop: 'env(safe-area-inset-top)' }}
     >
       <MobileSearchHeader
-        below={
-          pending !== null ? (
-            <TagSuggestions
-              facets={matchingTagFacets(facets ?? [], pending.partial)}
-              onPick={addPendingTag}
-            />
-          ) : (
-            <FilterBar
-              filters={filters}
-              onFiltersChange={onFiltersChange}
-              facets={facets ?? []}
-              routeTag={tag}
-              onClearRouteTag={() => navigate({ kind: 'allNotes', tag: null })}
-            />
-          )
-        }
       >
+        <MobileSearchHeaderContent>
         {tag !== null && (
           <Button
             variant="ghost"
@@ -178,7 +163,24 @@ export function MobileAllNotes({
           aria-label="Search notes"
           value={query}
           onValueChange={onQueryChange}
-        />
+          />
+        </MobileSearchHeaderContent>
+        <div className="pb-2">
+        pending !== null ? (
+          <TagSuggestions
+            facets={matchingTagFacets(facets ?? [], pending.partial)}
+            onPick={addPendingTag}
+          />
+        ) : (
+          <FilterBar
+            filters={filters}
+            onFiltersChange={onFiltersChange}
+            facets={facets ?? []}
+            routeTag={tag}
+            onClearRouteTag={() => navigate({ kind: 'allNotes', tag: null })}
+          />
+          )
+        </div>
       </MobileSearchHeader>
       {/* Undefined hits mean "still fetching" only while the query can run —
           with no bridge/graph it never will, and the empty state is honest. */}

--- a/apps/desktop/src/mobile/screens/all-notes.tsx
+++ b/apps/desktop/src/mobile/screens/all-notes.tsx
@@ -165,20 +165,20 @@ export function MobileAllNotes({
           />
         </MobileSearchHeaderContent>
         <div className="pb-2">
-          pending !== null ? (
-          <TagSuggestions
-            facets={matchingTagFacets(facets ?? [], pending.partial)}
-            onPick={addPendingTag}
-          />
+          {pending !== null ? (
+            <TagSuggestions
+              facets={matchingTagFacets(facets ?? [], pending.partial)}
+              onPick={addPendingTag}
+            />
           ) : (
-          <FilterBar
-            filters={filters}
-            onFiltersChange={onFiltersChange}
-            facets={facets ?? []}
-            routeTag={tag}
-            onClearRouteTag={() => navigate({ kind: 'allNotes', tag: null })}
-          />
-          )
+            <FilterBar
+              filters={filters}
+              onFiltersChange={onFiltersChange}
+              facets={facets ?? []}
+              routeTag={tag}
+              onClearRouteTag={() => navigate({ kind: 'allNotes', tag: null })}
+            />
+          )}
         </div>
       </MobileSearchHeader>
       {/* Undefined hits mean "still fetching" only while the query can run —

--- a/apps/desktop/src/mobile/screens/all-notes.tsx
+++ b/apps/desktop/src/mobile/screens/all-notes.tsx
@@ -143,35 +143,34 @@ export function MobileAllNotes({
       className="flex h-full w-screen flex-col"
       style={{ paddingTop: 'env(safe-area-inset-top)' }}
     >
-      <MobileSearchHeader
-      >
+      <MobileSearchHeader>
         <MobileSearchHeaderContent>
-        {tag !== null && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="-ml-2 size-10 shrink-0"
-            aria-label="Back"
-            onClick={back}
-          >
-            <ChevronLeft />
-          </Button>
-        )}
-        <SearchInput
-          ref={searchInputRef}
-          placeholder="Search anything…"
-          aria-label="Search notes"
-          value={query}
-          onValueChange={onQueryChange}
+          {tag !== null && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="-ml-2 size-10 shrink-0"
+              aria-label="Back"
+              onClick={back}
+            >
+              <ChevronLeft />
+            </Button>
+          )}
+          <SearchInput
+            ref={searchInputRef}
+            placeholder="Search anything…"
+            aria-label="Search notes"
+            value={query}
+            onValueChange={onQueryChange}
           />
         </MobileSearchHeaderContent>
         <div className="pb-2">
-        pending !== null ? (
+          pending !== null ? (
           <TagSuggestions
             facets={matchingTagFacets(facets ?? [], pending.partial)}
             onPick={addPendingTag}
           />
-        ) : (
+          ) : (
           <FilterBar
             filters={filters}
             onFiltersChange={onFiltersChange}

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -145,35 +145,35 @@ export function MobileTasks(): ReactElement {
     >
       <MobileSearchHeader>
         <MobileSearchHeaderContent>
-        <SearchInput
-          ref={searchInputRef}
-          placeholder="Search tasks…"
-          aria-label="Search tasks"
-          value={query}
-          onValueChange={setQuery}
-        />
-        {recentlyCompleted.length > 0 ? (
+          <SearchInput
+            ref={searchInputRef}
+            placeholder="Search tasks…"
+            aria-label="Search tasks"
+            value={query}
+            onValueChange={setQuery}
+          />
+          {recentlyCompleted.length > 0 ? (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-10 shrink-0"
+              aria-label={`Archive ${recentlyCompleted.length} completed`}
+              onClick={archiveCompleted}
+            >
+              <Archive />
+            </Button>
+          ) : null}
           <Button
             variant="ghost"
             size="icon"
             className="size-10 shrink-0"
-            aria-label={`Archive ${recentlyCompleted.length} completed`}
-            onClick={archiveCompleted}
+            aria-label="Task filters"
+            onClick={() => {
+              hapticImpactLight()
+              setFiltersOpen(true)
+            }}
           >
-            <Archive />
-          </Button>
-        ) : null}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-10 shrink-0"
-          aria-label="Task filters"
-          onClick={() => {
-            hapticImpactLight()
-            setFiltersOpen(true)
-          }}
-        >
-          <SlidersHorizontal />
+            <SlidersHorizontal />
           </Button>
         </MobileSearchHeaderContent>
       </MobileSearchHeader>

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -18,7 +18,7 @@ import {
 import { useTaskActions } from '@/lib/tasks/use-task-actions'
 import { useToday } from '@/lib/use-today'
 import { hapticImpactLight } from '@/mobile/haptics'
-import { MobileSearchHeader } from '@/mobile/search-header'
+import { MobileSearchHeader, MobileSearchHeaderContent } from '@/mobile/search-header'
 import { SearchInput } from '@/mobile/search-input'
 import { MobileTaskEditSheet } from '@/mobile/task-edit-sheet'
 import { TaskFiltersDrawer } from '@/mobile/task-filters-drawer'
@@ -144,6 +144,7 @@ export function MobileTasks(): ReactElement {
       style={{ paddingTop: 'env(safe-area-inset-top)' }}
     >
       <MobileSearchHeader>
+        <MobileSearchHeaderContent>
         <SearchInput
           ref={searchInputRef}
           placeholder="Search tasks…"
@@ -173,7 +174,8 @@ export function MobileTasks(): ReactElement {
           }}
         >
           <SlidersHorizontal />
-        </Button>
+          </Button>
+        </MobileSearchHeaderContent>
       </MobileSearchHeader>
       {isError ? (
         <p role="alert" className="px-4 py-6 text-sm text-text-muted">

--- a/apps/desktop/src/mobile/screens/tasks.tsx
+++ b/apps/desktop/src/mobile/screens/tasks.tsx
@@ -18,6 +18,7 @@ import {
 import { useTaskActions } from '@/lib/tasks/use-task-actions'
 import { useToday } from '@/lib/use-today'
 import { hapticImpactLight } from '@/mobile/haptics'
+import { MobileSearchHeader } from '@/mobile/search-header'
 import { SearchInput } from '@/mobile/search-input'
 import { MobileTaskEditSheet } from '@/mobile/task-edit-sheet'
 import { TaskFiltersDrawer } from '@/mobile/task-filters-drawer'
@@ -142,7 +143,7 @@ export function MobileTasks(): ReactElement {
       className="flex h-full w-screen flex-col"
       style={{ paddingTop: 'env(safe-area-inset-top)' }}
     >
-      <header className="flex shrink-0 items-center gap-1 border-b border-border px-4 pb-2 pt-1">
+      <MobileSearchHeader>
         <SearchInput
           ref={searchInputRef}
           placeholder="Search tasks…"
@@ -173,7 +174,7 @@ export function MobileTasks(): ReactElement {
         >
           <SlidersHorizontal />
         </Button>
-      </header>
+      </MobileSearchHeader>
       {isError ? (
         <p role="alert" className="px-4 py-6 text-sm text-text-muted">
           Couldn’t load tasks.

--- a/apps/desktop/src/mobile/search-header.tsx
+++ b/apps/desktop/src/mobile/search-header.tsx
@@ -1,17 +1,14 @@
 import type { ReactElement, ReactNode } from 'react'
 
-interface MobileSearchHeaderProps {
-  /** The search row: the field plus its leading and trailing controls. */
-  children: ReactNode
-  /** An optional second row under the field. */
-  below?: ReactNode
-}
 
-export function MobileSearchHeader({ children, below }: MobileSearchHeaderProps): ReactElement {
+export function MobileSearchHeader({ children }: { children: ReactNode }): ReactElement {
   return (
     <header className="shrink-0 border-b border-border px-4">
-      <div className="flex h-11 items-center gap-1">{children}</div>
-      {below ? <div className="pb-2">{below}</div> : null}
+      {children}
     </header>
   )
+}
+
+export function MobileSearchHeaderContent({ children }: { children: ReactNode }): ReactElement {
+  return <div className="flex h-11 items-center gap-1">{children}</div>
 }

--- a/apps/desktop/src/mobile/search-header.tsx
+++ b/apps/desktop/src/mobile/search-header.tsx
@@ -3,16 +3,10 @@ import type { ReactElement, ReactNode } from 'react'
 interface MobileSearchHeaderProps {
   /** The search row: the field plus its leading and trailing controls. */
   children: ReactNode
-  /** An optional second row under the field (the All tab's filter badges). */
+  /** An optional second row under the field. */
   below?: ReactNode
 }
 
-/**
- * The list tabs' header: a bar-height row holding the search field, over an
- * optional second row. The row matches the pushed screens' bar (`h-11`), and
- * both tabs render through this component, so the field keeps its place when
- * the tab bar switches between them.
- */
 export function MobileSearchHeader({ children, below }: MobileSearchHeaderProps): ReactElement {
   return (
     <header className="shrink-0 border-b border-border px-4">

--- a/apps/desktop/src/mobile/search-header.tsx
+++ b/apps/desktop/src/mobile/search-header.tsx
@@ -1,12 +1,7 @@
 import type { ReactElement, ReactNode } from 'react'
 
-
 export function MobileSearchHeader({ children }: { children: ReactNode }): ReactElement {
-  return (
-    <header className="shrink-0 border-b border-border px-4">
-      {children}
-    </header>
-  )
+  return <header className="shrink-0 border-b border-border px-4">{children}</header>
 }
 
 export function MobileSearchHeaderContent({ children }: { children: ReactNode }): ReactElement {

--- a/apps/desktop/src/mobile/search-header.tsx
+++ b/apps/desktop/src/mobile/search-header.tsx
@@ -1,0 +1,23 @@
+import type { ReactElement, ReactNode } from 'react'
+
+interface MobileSearchHeaderProps {
+  /** The search row: the field plus its leading and trailing controls. */
+  children: ReactNode
+  /** An optional second row under the field (the All tab's filter badges). */
+  below?: ReactNode
+}
+
+/**
+ * The list tabs' header: a bar-height row holding the search field, over an
+ * optional second row. The row matches the pushed screens' bar (`h-11`), and
+ * both tabs render through this component, so the field keeps its place when
+ * the tab bar switches between them.
+ */
+export function MobileSearchHeader({ children, below }: MobileSearchHeaderProps): ReactElement {
+  return (
+    <header className="shrink-0 border-b border-border px-4">
+      <div className="flex h-11 items-center gap-1">{children}</div>
+      {below ? <div className="pb-2">{below}</div> : null}
+    </header>
+  )
+}


### PR DESCRIPTION
The two tabs sized their search row from whatever control happened to be in it, so the field sat 4px lower on Tasks than on All; both now render through a shared 44px header row.

![Header close-up, before over after](https://github.com/user-attachments/assets/7074e134-7e28-4bfc-abb9-e8c6b6fb1789)

|  | before | after |
| --- | --- | --- |
| All | ![All tab before](https://github.com/user-attachments/assets/6f4bfdc5-e07d-4b73-99bf-d0dc938dffcc) | ![All tab after](https://github.com/user-attachments/assets/94588084-5fca-4876-bcaf-47e9076d6d92) |
| Tasks | ![Tasks tab before](https://github.com/user-attachments/assets/60eb9873-2b41-4fe5-b568-4f640add3457) | ![Tasks tab after](https://github.com/user-attachments/assets/7ad39302-13ed-45ef-9501-3e28701ef119) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the mobile All Notes and Tasks screens with a consistent search header layout.
  * Improved placement and sizing of search, back, filter, archive, and tag suggestion controls.
  * Existing search and filtering behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->