### PR TITLE
fix: show preferences shortcut in graph menu

### DIFF
--- a/apps/desktop/src/components/sidebar/graph-footer.tsx
+++ b/apps/desktop/src/components/sidebar/graph-footer.tsx
@@ -160,6 +160,9 @@ export function GraphFooter({ graph, context }: GraphFooterProps): ReactElement 
           >
             <Settings aria-hidden strokeWidth={1.75} className="size-3.5 shrink-0" />
             <span className="min-w-0 flex-1 truncate">Preferences</span>
+            {SETTINGS_BINDING && (
+              <ShortcutKeys binding={SETTINGS_BINDING} className="text-[10px]" />
+            )}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => setAppsOpen(true)} className={MENU_ITEM_CLASS}>


### PR DESCRIPTION
The graph menu's Preferences item did not show its keyboard shortcut. Add a right-aligned shortcut hint (⌘, on Apple platforms), using the existing settings command binding and the same keycap styling as recent graph rows.

Verified with `pnpm check`, `pnpm build`, and all 24 sidebar browser tests in both Chromium and WebKit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Preferences menu now displays its configured keyboard shortcut when one is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->