### PR TITLE
fix(mobile): avoid loading flashes on first tab switch

### DIFF
--- a/apps/desktop/src/mobile/mobile-screen.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.tsx
@@ -1,5 +1,4 @@
-import { lazy, Suspense, type ReactElement } from 'react'
-import { LoadingScreen } from '@/components/loading-screen'
+import { lazy, type ReactElement } from 'react'
 import { useToday } from '@/lib/use-today'
 import { MobileDaily } from '@/mobile/screens/daily'
 import { MobileNote } from '@/mobile/screens/note'
@@ -50,7 +49,7 @@ interface MobileScreenProps {
  * an app left open overnight rolls to the new day's note at midnight instead
  * of editing yesterday's.
  */
-function MobileScreenBody({
+export function MobileScreen({
   route,
   allQuery,
   onAllQueryChange,
@@ -102,10 +101,3 @@ function MobileScreenBody({
   }
 }
 
-export function MobileScreen(props: MobileScreenProps): ReactElement {
-  return (
-    <Suspense fallback={<LoadingScreen />}>
-      <MobileScreenBody {...props} />
-    </Suspense>
-  )
-}

--- a/apps/desktop/src/mobile/mobile-screen.tsx
+++ b/apps/desktop/src/mobile/mobile-screen.tsx
@@ -100,4 +100,3 @@ export function MobileScreen({
       return <MobileDaily key="daily" date={today} />
   }
 }
-

--- a/apps/desktop/src/mobile/mobile-shell.tsx
+++ b/apps/desktop/src/mobile/mobile-shell.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState, type ReactElement } from 'react'
+import { Suspense, useEffect, useRef, useState, type ReactElement } from 'react'
+import { LoadingScreen } from '@/components/loading-screen'
 import { useDoubleTap } from '@/hooks/use-double-tap'
 import { MobileFormattingToolbar } from '@/mobile/formatting-toolbar'
 import { MobileStack } from '@/mobile/mobile-stack'
@@ -101,12 +102,15 @@ export function MobileShell(): ReactElement {
       style={{ height: 'calc(100dvh - var(--keyboard-height, 0px))' }}
     >
       <div className="min-h-0 flex-1">
-        <MobileStack
-          allQuery={allQuery}
-          onAllQueryChange={setAllQuery}
-          allFilters={allFilters}
-          onAllFiltersChange={setAllFilters}
-        />
+        {/* A stable boundary lets route transitions retain the current screen while lazy code loads. */}
+        <Suspense fallback={<LoadingScreen />}>
+          <MobileStack
+            allQuery={allQuery}
+            onAllQueryChange={setAllQuery}
+            allFilters={allFilters}
+            onAllFiltersChange={setAllFilters}
+          />
+        </Suspense>
       </div>
       {/* V1 lets the keyboard cover the tab bar; with the root shrunk it
           would ride above the keyboard instead, so it hides while typing.


### PR DESCRIPTION
Switching to a mobile tab for the first time keeps the current screen visible until the lazy-loaded screen is ready, instead of flashing a loading page.

Move the Suspense boundary from each keyed screen to MobileShell around MobileStack so the existing router transitions can preserve the revealed content. Initial loading still has a fallback.

Validation: diff whitespace check passed. Local tests and lint were not run, following the requested CI-first workflow; CI validation is pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improved Mobile Loading**
  - Mobile users now see a loading screen while screens load, providing clearer feedback during navigation.
  - Mobile navigation and state behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->